### PR TITLE
Fixes bug caused by changes in PEP 420

### DIFF
--- a/cx_Freeze/finder.py
+++ b/cx_Freeze/finder.py
@@ -218,7 +218,7 @@ class ModuleFinder(object):
                 # Namespace package (?)
                 module = sys.modules[name]
                 info = ("", "", imp.PKG_DIRECTORY)
-                return None, module.__path__[0], info
+                return None, next(p for p in module.__path__), info
 
             # Check for modules in zip files.
             # If a path is a subdirectory within a zip file, we must have


### PR DESCRIPTION
(https://www.python.org/dev/peps/pep-0420/)

When including a package that doesn't exist in the 'includes' list of
build options, the code that prints the error message describing the
incorrect package causes an exception.

```<module>.__path__``` is now a ```_NamespacePath``` object that does not support
```getitem()```-style indexing. It does support iterable, so this change grabs
the first element like before.

This bug is extremely simple to reproduce, simply add a package to 'includes' that doesn't exist and run the cx_Freeze setup.py script. Here is an example traceback:

```Traceback (most recent call last):
  File "setup.py", line 42, in <module>
    Executable("main.py")
  File "C:\Program Files\Python36\lib\site-packages\cx_Freeze\dist.py", line 349, in setup
    distutils.core.setup(**attrs)
  File "C:\Program Files\Python36\lib\distutils\core.py", line 148, in setup
    dist.run_commands()
  File "C:\Program Files\Python36\lib\distutils\dist.py", line 955, in run_commands
    self.run_command(cmd)
  File "C:\Program Files\Python36\lib\distutils\dist.py", line 974, in run_command
    cmd_obj.run()
  File "C:\Program Files\Python36\lib\distutils\command\build.py", line 135, in run
    self.run_command(cmd_name)
  File "C:\Program Files\Python36\lib\distutils\cmd.py", line 313, in run_command
    self.distribution.run_command(command)
  File "C:\Program Files\Python36\lib\distutils\dist.py", line 974, in run_command
    cmd_obj.run()
  File "C:\Program Files\Python36\lib\site-packages\cx_Freeze\dist.py", line 219, in run
    freezer.Freeze()
  File "C:\Program Files\Python36\lib\site-packages\cx_Freeze\freezer.py", line 621, in Freeze
    self.finder = self._GetModuleFinder()
  File "C:\Program Files\Python36\lib\site-packages\cx_Freeze\freezer.py", line 335, in _GetModuleFinder
    package = finder.IncludeModule(name, namespace = True)
  File "C:\Program Files\Python36\lib\site-packages\cx_Freeze\finder.py", line 646, in IncludeModule
    namespace = namespace)
  File "C:\Program Files\Python36\lib\site-packages\cx_Freeze\finder.py", line 311, in _ImportModule
    deferredImports, namespace = namespace)
  File "C:\Program Files\Python36\lib\site-packages\cx_Freeze\finder.py", line 400, in _InternalImportModule
    fp, path, info = self._FindModule(searchName, path, namespace)
  File "C:\Program Files\Python36\lib\site-packages\cx_Freeze\finder.py", line 222, in _FindModule
    return None, module.__path__[0], info
TypeError: '_NamespacePath' object does not support indexing```