### PR TITLE
Add environment_variables option

### DIFF
--- a/cx_Freeze/windist.py
+++ b/cx_Freeze/windist.py
@@ -22,6 +22,7 @@ class bdist_msi(distutils.command.bdist_msi.bdist_msi):
         ('initial-target-dir=', None, 'initial target directory'),
         ('target-name=', None, 'name of the file to create'),
         ('directories=', None, 'list of 3-tuples of directories to create'),
+        ('environment-variables=', None, 'list of environment variables'),
         ('data=', None, 'dictionary of data indexed by table name'),
         ('product-code=', None, 'product code to use')
     ]
@@ -38,6 +39,8 @@ class bdist_msi(distutils.command.bdist_msi.bdist_msi):
                     [("E_PATH", "=-*Path", r"[~];[TARGETDIR]", "TARGETDIR")])
         if self.directories:
             msilib.add_data(self.db, "Directory", self.directories)
+        if self.environment_variables:
+            msilib.add_data(self.db, "Environment", self.environment_variables)
         msilib.add_data(self.db, 'CustomAction',
                 [("A_SET_TARGET_DIR", 256 + 51, "TARGETDIR",
                         self.initial_target_dir)])
@@ -347,6 +350,8 @@ class bdist_msi(distutils.command.bdist_msi.bdist_msi):
             self.target_name = os.path.join(self.dist_dir, self.target_name)
         if self.directories is None:
             self.directories = []
+        if self.environment_variables is None:
+            self.environment_variables = []
         if self.data is None:
             self.data = {}
 
@@ -358,6 +363,7 @@ class bdist_msi(distutils.command.bdist_msi.bdist_msi):
         self.initial_target_dir = None
         self.target_name = None
         self.directories = None
+        self.environment_variables = None
         self.data = None
 
     def run(self):

--- a/doc/distutils.rst
+++ b/doc/distutils.rst
@@ -234,6 +234,21 @@ command:
 |                       | packages created with the same upgrade code prior   |
 |                       | to the installation of this one                     |
 +-----------------------+-----------------------------------------------------+
+| environment-variable  | add any environment variables to MSI package;       |
+|                       | those variables will added to system environment    |
+|                       | variables at installation time                      |
+|                       |                                                     |
+|                       | example:                                            |
+|                       |                                                     |
+|                       | 'bdist_msi': {                                      |
+|                       |     'upgrade_code': upgrade_code,                   |
+|                       |     'add_to_path': True,                            |
+|                       |     'environment_variables': [                      |
+|                       |          ("E_MYAPP_VAR",                            |
+|                       |           "=-*MYAPP_VAR", f"1",                     |
+|                       |           "TARGETDIR"),                             |
+|                       |      ],                                             |
++-----------------------+-----------------------------------------------------+
 
 bdist_rpm
 `````````


### PR DESCRIPTION
I need some default environment variables with msi distribution. 
You can set default environment variables to msi:

```
 'bdist_msi': {
            'upgrade_code': upgrade_code,
            'add_to_path': True,
            'environment_variables': [
               ("E_MYAPP_VAR", "=-*MYAPP_VAR", f"1", "TARGETDIR"),
            ],
```