### PR TITLE
scipy.lib -> scipy._lib

### DIFF
--- a/cx_Freeze/hooks.py
+++ b/cx_Freeze/hooks.py
@@ -557,7 +557,7 @@ def load_scipy(finder, module):
     """the scipy module loads items within itself in a way that causes
        problems without the entire package and a number of other subpackages
        being present."""
-    finder.IncludePackage("scipy.lib")
+    finder.IncludePackage("scipy._lib")
     finder.IncludePackage("scipy.misc")
 
 


### PR DESCRIPTION
Addressing https://github.com/anthony-tuininga/cx_Freeze/issues/280 with the solution from https://stackoverflow.com/questions/32432887/cx-freeze-importerror-no-module-named-scipy . This fixed the scipy freeze under cygwin (python 3.4.3) for me.