### PR TITLE
Create list from module path iterator.

### DIFF
--- a/cx_Freeze/finder.py
+++ b/cx_Freeze/finder.py
@@ -202,7 +202,7 @@ class ModuleFinder(object):
                 # Namespace package (?)
                 module = sys.modules[name]
                 info = ("", "", imp.PKG_DIRECTORY)
-                return None, module.__path__[0], info
+                return None, list(module.__path__)[0], info
 
             # Check for modules in zip files.
             # If a path is a subdirectory within a zip file, we must have


### PR DESCRIPTION
Error seen when importing a dependency which is a namespace package.

Module's `__path__` attribute is an iterator, so create list before indexing.
