### PR TITLE
Fixing issue with @rpath causing file copy errors on bdist_mac and pyqt5

### DIFF
--- a/cx_Freeze/macdist.py
+++ b/cx_Freeze/macdist.py
@@ -179,7 +179,7 @@ class bdist_mac(Command):
                     try:
                         self.copy_file(referencedFile, os.path.join(self.binDir, name))
                     except DistutilsFileError as e:
-                        print(f"issue copying {referencedFile} to {os.path.join(self.binDir, name)} error {e} skipping")
+                        print("issue copying {} to {} error {} skipping".format(referencedFile, os.path.join(self.binDir, name), e))
                     else:
                         files.append(name)
 

--- a/doc/distutils.rst
+++ b/doc/distutils.rst
@@ -279,6 +279,9 @@ bundle (a .app directory).
 | codesign_resource_rules  | Plist file to be passed to codesign's            |
 |                          | --resource-rules option.                         |
 +--------------------------+--------------------------------------------------+
+| rpath_lib_folder         | replace @rpath with given folder for any files   |
+|                          |                                                  |
++--------------------------+--------------------------------------------------+
 
  .. versionadded:: 4.3
 


### PR DESCRIPTION
I ran into an issue with pyqt5 installed in an anaconda virtual env using python 3.6 
Somehow dylibs get pulled in with @rpath in their path.  After hardcoding the path in macdist I realized that I could just pass in a @rpath replacement from setup.py.

Couple caveats... this has been tested on my machine only in anaconda and python 3.6. I am very new to mac (normally just use linux) but the change seems rather harmless as copy_file will just fail when it gets a @rpath prefixed filename but I definitely do not know all the ramifications downstream.