### PR TITLE
Fixed setRelativeReferencePaths() from trying to relink files that were not Mach-O

### DIFF
--- a/cx_Freeze/macdist.py
+++ b/cx_Freeze/macdist.py
@@ -129,7 +129,6 @@ class bdist_mac(Command):
         """ Create a list of all the Mach-O binaries in Contents/MacOS.
             Then, check if they contain references to other files in
             that dir. If so, make those references relative. """
-
         files = []
         for root, dirs, dir_files in os.walk(self.binDir):
             for f in dir_files:


### PR DESCRIPTION
In macdist.py, the setRelativeReferencePaths() function would attempt to relink every single file in Contents/MacOS, including files that were not binaries, causing a huge amount of error spam. This adds a check to make sure a file is a Mach-O binary before adding it to the list of files it is checking the references of.

This will fix the error spam is #268