### PR TITLE
Add free automated flake8 testing of pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: python
+cache: pip
+python:
+    - 2.7
+    - 3.6
+    #- nightly
+    #- pypy
+    #- pypy3
+matrix:
+    allow_failures:
+        - python: nightly
+        - python: pypy
+        - python: pypy3
+install:
+    #- pip install -r requirements.txt
+    - pip install flake8  # pytest  # add another testing frameworks later
+before_script:
+    # stop the build if there are Python syntax errors or undefined names
+    - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+    # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+    - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+script:
+    - true  # pytest --capture=sys  # add other tests here
+notifications:
+    on_success: change
+    on_failure: change  # `always` will be the setting once code changes slow down

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,11 @@ install:
     #- pip install -r requirements.txt
     - pip install flake8  # pytest  # add another testing frameworks later
 before_script:
+    - EXCLUDE=./test/samples/invalid_syntax.py
     # stop the build if there are Python syntax errors or undefined names
-    - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+    - flake8 . --count --exclude=${EXCLUDE} --select=E901,E999,F821,F822,F823 --show-source --statistics
     # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
-    - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - flake8 . --count --exclude=${EXCLUDE} --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 script:
     - true  # pytest --capture=sys  # add other tests here
 notifications:


### PR DESCRIPTION
The Travis Continuous Integration service is free for all open source projects like this one.  This configuration will enable Travis CI to run tests on all pull requests before they are merged.  The owner of this repo would need to go to https://travis-ci.org/profile (log in via GitHub) and flip the repository switch __on__ to enable free, automated flake8 testing of each pull request.  Travis CI will run tests in parallel on both Python 2 and Python 3 but until the port can be completed, the Python 3 test should continue to be run in __allow_failures__ mode.