### PR TITLE
file() --> open() for Python 3

### DIFF
--- a/cx_Freeze/initscripts/SharedLibSource.py
+++ b/cx_Freeze/initscripts/SharedLibSource.py
@@ -18,8 +18,8 @@ __import__("site")
 # now locate the pth file to modify the path appropriately
 baseName, ext = os.path.splitext(FILE_NAME)
 pathFileName = baseName + ".pth"
-sys.path = [s.strip() for s in file(pathFileName).read().splitlines()] + \
-        sys.path
+with open(pathFileName) as in_file:
+    sys.path = [s.strip() for s in in_file.read().splitlines()] + sys.path
 
 
 def run():


### PR DESCRIPTION
__file()__ was removed from Python 3 in favor of __open()__.  Used __with open()__ to ensure that file handle is closed and deleted.