### PR TITLE
Always copy dependent files to root directory on darwin

### DIFF
--- a/cx_Freeze/freezer.py
+++ b/cx_Freeze/freezer.py
@@ -191,6 +191,10 @@ class Freezer(object):
         self.filesCopied[normalizedTarget] = None
         if copyDependentFiles \
                 and source not in self.finder.excludeDependentFiles:
+            # Always copy dependent files on root directory
+            # to allow to set relative reference
+            if sys.platform == 'darwin':
+                targetDir = self.targetDir
             for source in self._GetDependentFiles(source):
                 target = os.path.join(targetDir, os.path.basename(source))
                 self._CopyFile(source, target, copyDependentFiles)


### PR DESCRIPTION
cebdef5f65e260b3425755e356208b818806af97 changed this behavior but it is requires to build on macOS.