### PR TITLE
Add install_icon option

### DIFF
--- a/cx_Freeze/windist.py
+++ b/cx_Freeze/windist.py
@@ -23,7 +23,8 @@ class bdist_msi(distutils.command.bdist_msi.bdist_msi):
         ('target-name=', None, 'name of the file to create'),
         ('directories=', None, 'list of 3-tuples of directories to create'),
         ('data=', None, 'dictionary of data indexed by table name'),
-        ('product-code=', None, 'product code to use')
+        ('product-code=', None, 'product code to use'),
+        ('install-icon=', None, 'icon path to add/remove programs ')
     ]
     x = y = 50
     width = 370
@@ -244,7 +245,11 @@ class bdist_msi(distutils.command.bdist_msi.bdist_msi):
             props.append(("ARPURLINFOABOUT", metadata.url))
         if self.upgrade_code is not None:
             props.append(("UpgradeCode", self.upgrade_code))
+        if self.install_icon:
+            props.append(('ARPPRODUCTICON', 'InstallIcon'))
         msilib.add_data(self.db, 'Property', props)
+        if self.install_icon:
+            msilib.add_data(self.db, "Icon", [("InstallIcon", msilib.Binary(self.install_icon))])
 
     def add_select_directory_dialog(self):
         dialog = distutils.command.bdist_msi.PyDialog(self.db,
@@ -359,6 +364,7 @@ class bdist_msi(distutils.command.bdist_msi.bdist_msi):
         self.target_name = None
         self.directories = None
         self.data = None
+        self.install_icon = None
 
     def run(self):
         if not self.skip_build:


### PR DESCRIPTION
Added the possibility to use an icon on add/remove program window.
Just need to pass install-icon parameter on bdist_msi params.

Eg.: 
`
bdist_msi_options = {
    'target_name': 'app.msi',
    'initial_target_dir': r'[ProgramFilesFolder]\%s\%s' % (company_name, product_name),
    'upgrade_code': '{bdd2c283-d748-494f-84de-b13b618bbc59}',
    'add_to_path': True,
    'install-icon': '/full/path/app.ico'
}`