### PR TITLE
Include doc directory in sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,4 @@ include *.txt
 recursive-include cx_Freeze/initscripts *.py
 recursive-include cx_Freeze/samples *.py
 recursive-include source *.c *.rc *.txt
+recursive-include doc


### PR DESCRIPTION
This includes the license file, which the license itself requires be included, as well as useful things for downstream packagers and users like the changelog.  Also, lots of downstream packagers build the documentation when it is available.

The directory appears to only include text files, so it shouldn't increase the size of the sdists too much.

Fixes #376.