### PR TITLE
Compilation correct .pyc files for Python 3.7.0 64Bit, Windows 7, inlel core

### DIFF
--- a/cx_Freeze/freezer.py
+++ b/cx_Freeze/freezer.py
@@ -555,10 +555,16 @@ class Freezer(object):
             # the file is up to date so we can safely set this value to zero
             if module.code is not None:
                 if module.file is not None and os.path.exists(module.file):
-                    mtime = os.stat(module.file).st_mtime
+                    stat = os.stat(module.file)
+                    mtime = stat.st_mtime
+                    size = stat.st_size & 0xFFFFFFFF
                 else:
                     mtime = time.time()
-                header = magic + struct.pack("<ii", int(mtime), 0)
+                    size = 0
+                if sys.version_info[:2] == (3, 7):
+                    header = magic + struct.pack("<iii", 0, int(mtime), size)
+                else:
+                    header = magic + struct.pack("<ii", int(mtime), size)
                 data = header + marshal.dumps(module.code)
 
             # if the module should be written to the file system, do so


### PR DESCRIPTION
Faced fit this issue:
Fatal Python error: initfsencoding: unable to load the file system codec
zipimport.ZipImportError: can't find module 'encodings'

Current thread 0xXXXXXX (most recent call first):

Found that Python 37 has 12 system bits after Magic 4 - set as dummy, 4 - timestamp, 4 - original file size.
