### PR TITLE
Win exe's are looking in lib/ for clr dll

### DIFF
--- a/cx_Freeze/hooks.py
+++ b/cx_Freeze/hooks.py
@@ -798,7 +798,7 @@ def load_clr(finder, module):
     in runtime"""
     module_dir = os.path.dirname(module.file)
     dllname = 'Python.Runtime.dll'
-    finder.IncludeFiles(os.path.join(module_dir, dllname), dllname)
+    finder.IncludeFiles(os.path.join(module_dir, dllname), os.path.join("lib", dll_name))
     
     
 def load_sqlite3(finder, module):


### PR DESCRIPTION
Tested on Win10 and Windows2016.   The clr library (pythonnet) is being looked for in the lib/ folder.