### PR TITLE
Improvements

### DIFF
--- a/cx_Freeze/dist.py
+++ b/cx_Freeze/dist.py
@@ -252,16 +252,6 @@ class install(distutils.command.install.install):
         self.install_exe = None
 
     def finalize_options(self):
-        if self.prefix is None and sys.platform == "win32":
-            try:
-                import winreg
-            except:
-                import _winreg as winreg
-            key = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE,
-                    r"Software\Microsoft\Windows\CurrentVersion")
-            prefix = str(winreg.QueryValueEx(key, "ProgramFilesDir")[0])
-            metadata = self.distribution.metadata
-            self.prefix = "%s/%s" % (prefix, metadata.name)
         distutils.command.install.install.finalize_options(self)
         self.convert_paths('exe')
         if self.root is not None:

--- a/cx_Freeze/finder.py
+++ b/cx_Freeze/finder.py
@@ -528,7 +528,7 @@ class ModuleFinder(object):
                 continue
 
             # import statement: attempt to import module
-            elif op == IMPORT_NAME:
+            elif op == IMPORT_NAME or op == IMPORT_FROM:
                 name = co.co_names[opArg]
                 if len(arguments) >= 2:
                     relativeImportIndex, fromList = arguments[-2:]

--- a/cx_Freeze/freezer.py
+++ b/cx_Freeze/freezer.py
@@ -161,15 +161,20 @@ class Freezer(object):
             print(warning_msg)
             print("version must be specified")
             return
-        fileName = exe.targetName
-        versionInfo = VersionInfo(self.metadata.version,
-                comments = self.metadata.long_description,
-                description = self.metadata.description,
-                company = self.metadata.author,
-                product = self.metadata.name,
-                copyright = exe.copyright,
-                trademarks = exe.trademarks)
-        stamp(fileName, versionInfo)
+        try:
+            fileName = exe.targetName
+            versionInfo = VersionInfo(self.metadata.version,
+                    comments = self.metadata.long_description,
+                    description = self.metadata.description,
+                    company = self.metadata.author,
+                    product = self.metadata.name,
+                    copyright = exe.copyright,
+                    trademarks = exe.trademarks)
+            stamp(fileName, versionInfo)
+        except Exception as e:
+            print("*** WARNING *** unable to create version resource")
+            print("Error: %s" % e)
+            return
 
     def _CopyFile(self, source, target, copyDependentFiles,
             includeMode = False):

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,8 @@ class build_ext(distutils.command.build_ext.build_ext):
             compiler_type = self.compiler.compiler_type
             if compiler_type == "msvc":
                 extraArgs.append("/MANIFEST")
+                if "AsAdministrator" in ext.name:
+                    extraArgs.append("/MANIFESTUAC:level='requireAdministrator' uiAccess='false'")
             elif compiler_type == "mingw32" and "Win32GUI" in ext.name:
                 extraArgs.append("-mwindows")
         else:
@@ -156,9 +158,15 @@ extensions = [utilModule, console]
 if sys.platform == "win32":
     scripts.append("cxfreeze-postinstall")
     options["bdist_msi"] = dict(install_script = "cxfreeze-postinstall")
+    consoleAsAdministrator = Extension("cx_Freeze.bases.ConsoleAsAdministrator", ["source/bases/Console.c"],
+            depends = depends, libraries = libraries)
+    extensions.append(consoleAsAdministrator)
     gui = Extension("cx_Freeze.bases.Win32GUI", ["source/bases/Win32GUI.c"],
             depends = depends, libraries = libraries + ["user32"])
     extensions.append(gui)
+    guiAsAdministrator = Extension("cx_Freeze.bases.Win32GUIAsAdministrator", ["source/bases/Win32GUI.c"],
+            depends = depends, libraries = libraries + ["user32"])
+    extensions.append(guiAsAdministrator)
     moduleInfo = find_cx_Logging()
     if moduleInfo is not None:
         includeDir, libraryDir = moduleInfo


### PR DESCRIPTION
Remove prefix hack on Windows: Maybe not the good solution, but it's not working in virtualenv. Have to check if we are in virtualenv?

Don't fail on _AddVersionResource : If the project version is not digit.digit.digit.digit, it's blocking. Forcing to uninstall pywin32 or to use another version value

Support missing IMPORT_FROM: the from . import XXXX is not find by the Finder. This is easy to check, try to cxfreeze a project using pyreadline the "from . import release" inside "pyreadline/rlmain.py is not handled, then at execution this module is missing

Add Administrator executable versions : New base values: ConsoleAsAdministrator and Win32GUIAsAdministrator. This allows on Windows to have an UAC escalation when running the program