### PR TITLE
Added CFBundle Identifier (#426)

### DIFF
--- a/cx_Freeze/macdist.py
+++ b/cx_Freeze/macdist.py
@@ -116,6 +116,7 @@ class bdist_mac(Command):
             contents = {
                 'CFBundleIconFile': 'icon.icns',
                 'CFBundleDevelopmentRegion': 'English',
+                'CFBundleIdentifier': self.bundle_name,
             }
 
         # Ensure CFBundleExecutable is set correctly


### PR DESCRIPTION
Addressing issue https://github.com/anthony-tuininga/cx_Freeze/issues/426 by adding a bundle identifier in the default info.plist.