### PR TITLE
Make executable writable before adding icon. Fixes issue #368

### DIFF
--- a/cx_Freeze/freezer.py
+++ b/cx_Freeze/freezer.py
@@ -215,6 +215,10 @@ class Freezer(object):
 
         self._CopyFile(exe.base, exe.targetName, copyDependentFiles = True,
                 includeMode = True)
+        if not os.access(exe.targetName, os.W_OK):
+            mode = os.stat(exe.targetName).st_mode
+            os.chmod(exe.targetName, mode | stat.S_IWUSR)
+
         if self.includeMSVCR:
             self._IncludeMSVCR(exe)
 
@@ -229,9 +233,6 @@ class Freezer(object):
                 self._CopyFile(exe.icon, targetName,
                         copyDependentFiles = False)
 
-        if not os.access(exe.targetName, os.W_OK):
-            mode = os.stat(exe.targetName).st_mode
-            os.chmod(exe.targetName, mode | stat.S_IWUSR)
         if self.metadata is not None and sys.platform == "win32":
             self._AddVersionResource(exe)
 


### PR DESCRIPTION
Setting the application icon fails if the base executable is copied from a write-protected origin, see issue #368. I moved the code setting the write permission bit up a few lines to prevent this from happening.