### PR TITLE
print error when cx_Freeze.util.GetDependentFiles(path) produce cx_Freeze.util.BindError

### DIFF
--- a/cx_Freeze/freezer.py
+++ b/cx_Freeze/freezer.py
@@ -288,10 +288,14 @@ class Freezer(object):
                 import cx_Freeze.util
                 try:
                     dependentFiles = cx_Freeze.util.GetDependentFiles(path)
-                except cx_Freeze.util.BindError:
+                except cx_Freeze.util.BindError as exc:
                     # Sometimes this gets called when path is not actually a library
                     # See issue 88
                     dependentFiles = []
+                    sys.stderr.write(
+                        "error during GetDependentFiles of \"%s\": %s"
+                        % path, str(exc)
+                    )
                 os.environ["PATH"] = origPath
             else:
                 dependentFiles = []


### PR DESCRIPTION
Hello,

I had some issues on build process on client computer (Windows). It's user name was including a `é` character and `dependentFiles = cx_Freeze.util.GetDependentFiles(path)` was raising an `cx_Freeze.util.BindError` error.

I had to debug on computer client to find error because no log is produced in that case. So i suggest to add a log like in this PR.

Is that okay for you ?