### PR TITLE
Add base for Win32 GUI subsystem, with GPU enablement exports (v5.x branch)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,9 @@ class build_ext(distutils.command.build_ext.build_ext):
             compiler_type = self.compiler.compiler_type
             if compiler_type == "msvc":
                 extraArgs.append("/MANIFEST")
+                if ext.name == "cx_Freeze.bases.Win32GUI_GPU":
+                    implib = os.path.join(self.build_temp, ext.name)
+                    extraArgs.append("/IMPLIB:{}".format(implib))
             elif compiler_type == "mingw32" and "Win32GUI" in ext.name:
                 extraArgs.append("-mwindows")
         else:
@@ -155,6 +158,10 @@ if sys.platform == "win32":
     gui = Extension("cx_Freeze.bases.Win32GUI", ["source/bases/Win32GUI.c"],
             depends = depends, libraries = libraries + ["user32"])
     extensions.append(gui)
+    gpu = Extension("cx_Freeze.bases.Win32GUI_GPU",
+            ["source/bases/Win32GUI_GPU.c"], depends = depends,
+            libraries = libraries + ["user32"])
+    extensions.append(gpu)
     moduleInfo = find_cx_Logging()
     if moduleInfo is not None:
         includeDir, libraryDir = moduleInfo

--- a/source/bases/Win32GUI_GPU.c
+++ b/source/bases/Win32GUI_GPU.c
@@ -1,0 +1,18 @@
+//-----------------------------------------------------------------------------
+// Win32GUI.c
+//   Main routine for frozen GPU intensive programs for the Win32 GUI subsystem.
+//-----------------------------------------------------------------------------
+#include <windows.h>
+
+// This export will be picked up by nvidia drivers >= 302
+// https://docs.nvidia.com/gameworks/content/technologies/desktop/optimus.htm
+__declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001;
+
+
+// This export will be picked up by AMD drivers >= 13.35
+// https://gpuopen.com/amdpowerxpressrequesthighperformance/
+__declspec(dllexport) DWORD AmdPowerXpressRequestHighPerformance = 0x00000001;
+
+
+// We want the same program as the Win32GUI base, so let's just include that
+#include "Win32GUI.c"


### PR DESCRIPTION
This pull request adds a new base executable that is the same as the `Win32GUI` base executable, but with the addition of two exported symbols:

```cpp
__declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001;
__declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
```

These symbols will cause video drivers from Nvidia and AMD respectively to automatically select discrete high performance graphics if the machine has a integrated/discrete hardware combo.

I noticed there was an issue (anthony-tuininga/cx_Freeze#363) about this in your repo, so I'd thought I'd ask if there was any interest in upstreaming my solution to this problem. This is useful for a number of application categories, including games.

__Please note:__ This pull request is based on the v5.x branch (python 2.7) since that is what I needed. If this is something that the `cx_Freeze` would consider merging, I would be willing to create a pull request towards the master branch as well.