### PR TITLE
Update zmq hook to deal with missing libzmq library

### DIFF
--- a/cx_Freeze/hooks.py
+++ b/cx_Freeze/hooks.py
@@ -790,10 +790,14 @@ def load_zmq(finder, module):
     finder.IncludePackage("zmq.backend.cython")
     if sys.platform == "win32":
         # Not sure yet if this is cross platform
-        import zmq.libzmq
-        srcFileName = os.path.basename(zmq.libzmq.__file__)
-        finder.IncludeFiles(
-            os.path.join(module.path[0], srcFileName), srcFileName)
+        # Include the bundled libzmq library, if it exists
+        try:
+            import zmq.libzmq
+            srcFileName = os.path.basename(zmq.libzmq.__file__)
+            finder.IncludeFiles(
+                os.path.join(module.path[0], srcFileName), srcFileName)
+        except ImportError:
+            pass  # No bundled libzmq library
 
 
 def load_clr(finder, module):


### PR DESCRIPTION
Not all pyzmq installs on Windows have bundled libzmq libraries -- Anaconda in particular doesn't for recent versions. This check keeps cx_Freeze from failing with the cryptic (and incorrect) message "No module 'zmq' found" in cases where there is no bundled libzmq library.