### PR TITLE
Add -municode flag when building on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,8 +81,11 @@ class build_ext(distutils.command.build_ext.build_ext):
             compiler_type = self.compiler.compiler_type
             if compiler_type == "msvc":
                 extraArgs.append("/MANIFEST")
-            elif compiler_type == "mingw32" and "Win32GUI" in ext.name:
-                extraArgs.append("-mwindows")
+            elif compiler_type == "mingw32":
+                if "Win32GUI" in ext.name:
+                    extraArgs.append("-mwindows")
+                if sys.version_info[0] == 3:
+                    extraArgs.append("-municode")
         else:
             vars = distutils.sysconfig.get_config_vars()
             libraryDirs.append(vars["LIBPL"])


### PR DESCRIPTION
patch applied from https://github.com/msys2/MINGW-packages/blob/4c18633ba2331d980f00aff075f17135399c43c5/mingw-w64-python-cx_Freeze/0001-fix-build.patch

Credit for the patch goes to the msys2/MINGW-packages maintainers.
I only applied it so it could install the latest HEAD version of cx_freeze via pip.