### PR TITLE
Add hook to copy SSL DLLs in Python >= 3.7 on Windows.

### DIFF
--- a/cx_Freeze/hooks.py
+++ b/cx_Freeze/hooks.py
@@ -1,3 +1,4 @@
+import glob
 import os
 import sys
 
@@ -602,6 +603,16 @@ def load_site(finder, module):
        modules; ignore the error if these modules do not exist."""
     module.IgnoreName("sitecustomize")
     module.IgnoreName("usercustomize")
+
+
+def load_ssl(finder, module):
+    """In Windows, the SSL module in Python >= 3.7 requires additional dlls to
+       be present in the build directory."""
+    if sys.platform == "win32" and sys.version_info >= (3, 7):
+        for dll_search in ["libcrypto-*.dll", "libssl-*.dll"]:
+            for dll_path in glob.glob(os.path.join(sys.base_prefix, "DLLs", dll_search)):
+                dll_name = os.path.basename(dll_path)
+                finder.IncludeFiles(dll_path, os.path.join("lib", dll_name))
 
 
 def load_tkinter(finder, module):


### PR DESCRIPTION
This fixes my issue #437.