### PR TITLE
include module unicodedata

### DIFF
--- a/cx_Freeze/finder.py
+++ b/cx_Freeze/finder.py
@@ -150,6 +150,7 @@ class ModuleFinder(object):
            """
         self.IncludeModule("traceback")
         self.IncludeModule("warnings")
+        self.IncludeModule("unicodedata")
         self.IncludePackage("encodings")
         self.IncludeModule("io")
         self.IncludeModule("os")


### PR DESCRIPTION
_socket extension on python 3.7 (and possible previous versions) uses encondings.idna and that requires unicodedata
This resolves stranger crashes on sockets (windows and linux)
Initially I implemented a load__socket hook like the py2exe project, but I think that globally we can avoid bug in other modules.