### PR TITLE
_cffi_backend module requires libffi on a specific directory

### DIFF
--- a/cx_Freeze/hooks.py
+++ b/cx_Freeze/hooks.py
@@ -86,6 +86,19 @@ def load_ceODBC(finder, module):
     finder.IncludeModule("decimal")
 
 
+def load__cffi_backend(finder, module):
+    """_cffi_backend module requires libffi on a specific directory"""
+    if os.name == 'posix':
+        module_dir = os.path.dirname(module.file)
+        skip_count = len(module_dir)
+        for dirpath, _, filenames in os.walk(os.path.join(module_dir, ".libs_cffi_backend")):
+            for name in filenames:
+                source_path = os.path.join(dirpath, name)
+                target_path = os.path.join("lib", source_path[skip_count + 1:])
+                finder.IncludeFiles(source_path, target_path)
+        finder.ExcludeDependentFiles(module.file)
+
+
 def load_cx_Oracle(finder, module):
     """the cx_Oracle module implicitly imports datetime; make sure this
        happens."""

--- a/cx_Freeze/hooks.py
+++ b/cx_Freeze/hooks.py
@@ -71,6 +71,11 @@ def initialize(finder):
         finder.ExcludeModule("vms_lib")
     finder.ExcludeModule("new")
     finder.ExcludeModule("Tkinter")
+    #include the _cffi_backend (only if present in system or venv)
+    try:
+        finder.IncludeModule("_cffi_backend")
+    except ImportError:
+        pass
 
 
 def load_asyncio(finder, module):
@@ -89,19 +94,6 @@ def load_ceODBC(finder, module):
        sure this happens."""
     finder.IncludeModule("datetime")
     finder.IncludeModule("decimal")
-
-
-def load__cffi_backend(finder, module):
-    """_cffi_backend module requires libffi on a specific directory"""
-    if os.name == 'posix':
-        module_dir = os.path.dirname(module.file)
-        skip_count = len(module_dir)
-        for dirpath, _, filenames in os.walk(os.path.join(module_dir, ".libs_cffi_backend")):
-            for name in filenames:
-                source_path = os.path.join(dirpath, name)
-                target_path = os.path.join("lib", source_path[skip_count + 1:])
-                finder.IncludeFiles(source_path, target_path)
-        finder.ExcludeDependentFiles(module.file)
 
 
 def load_cx_Oracle(finder, module):

--- a/cx_Freeze/samples/cryptography/setup.py
+++ b/cx_Freeze/samples/cryptography/setup.py
@@ -1,4 +1,4 @@
-# A setup script to demonstrate the use of sqlite3
+# A setup script to demonstrate build using cffi (inside a cryptography pkg)
 #
 # Run the build process by running the command 'python setup.py build'
 #

--- a/cx_Freeze/samples/cryptography/setup.py
+++ b/cx_Freeze/samples/cryptography/setup.py
@@ -7,7 +7,7 @@
 
 from cx_Freeze import setup, Executable
 
-buildOptions = dict(zip_include_packages=["*"], zip_exclude_packages=[], includes='_cffi_backend')
+buildOptions = dict(zip_include_packages=["*"], zip_exclude_packages=[])
 executables = [Executable("test_crypt.py")]
 
 setup(name='test_crypt',

--- a/cx_Freeze/samples/distutils/setup.py
+++ b/cx_Freeze/samples/distutils/setup.py
@@ -1,4 +1,4 @@
-# A setup script to demonstrate the use of sqlite3
+# A setup script to demonstrate the use of distutils
 #
 # Run the build process by running the command 'python setup.py build'
 #

--- a/cx_Freeze/samples/pillow/setup.py
+++ b/cx_Freeze/samples/pillow/setup.py
@@ -1,4 +1,4 @@
-# A setup script to demonstrate the use of sqlite3
+# A setup script to demonstrate the use of pillow
 #
 # Run the build process by running the command 'python setup.py build'
 #


### PR DESCRIPTION
I am getting an ImportError when working with the cryptography packages.
Only on linux.
This patch has been rewritten and depends on #494