### PR TITLE
pytz module requires zoneinfo data included in library.zip.

### DIFF
--- a/cx_Freeze/finder.py
+++ b/cx_Freeze/finder.py
@@ -135,6 +135,7 @@ class ModuleFinder(object):
         self._builtinModules = dict.fromkeys(sys.builtin_module_names)
         self._badModules = {}
         self._zip_modules_cache = ZipModulesCache()
+        self.zipIncludes = []
         cx_Freeze.hooks.initialize(self)
         initialExcludedModules = self.excludes.copy()
         self._AddBaseModules()
@@ -644,6 +645,10 @@ class ModuleFinder(object):
             sys.stdout.write("This is not necessarily a problem - the modules "
                              "may not be needed on this platform.\n")
             sys.stdout.write("\n")
+
+    def ZipIncludeFiles(self, sourcePath, targetPath):
+        """Include the files in the given library.zip in the target build."""
+        self.zipIncludes.append((sourcePath, targetPath))
 
 
 class Module(object):

--- a/cx_Freeze/freezer.py
+++ b/cx_Freeze/freezer.py
@@ -619,6 +619,8 @@ class Freezer(object):
         # write any files to the zip file that were requested specially
         for sourceFileName, targetFileName in self.zipIncludes:
             outFile.write(sourceFileName, targetFileName)
+        for sourceFileName, targetFileName in self.finder.zipIncludes:
+            outFile.write(sourceFileName, targetFileName)
 
         outFile.close()
 

--- a/cx_Freeze/hooks.py
+++ b/cx_Freeze/hooks.py
@@ -559,6 +559,18 @@ def load_PyQt5_QtPrintSupport(finder, module):
     name, QtCore = _qt_implementation(module)
     copy_qt_plugins("printsupport", finder, QtCore)
 
+
+def load_pytz(finder, module):
+    """pytz module requires zoneinfo data included in library.zip."""
+    module_dir = os.path.dirname(module.file)
+    skip_count = len(os.path.dirname(module_dir))
+    for dirpath, _, filenames in os.walk(os.path.join(module_dir, "zoneinfo")):
+        for name in filenames:
+            source_path = os.path.join(dirpath, name)
+            target_path = source_path[skip_count + 1:].replace('\\', '/')
+            finder.ZipIncludeFiles(source_path, target_path)
+
+
 def load_reportlab(finder, module):
     """the reportlab module loads a submodule rl_settings via exec so force
        its inclusion here"""


### PR DESCRIPTION
I did several tests, it does not matter to include in the directory, have to put in the zip file.