### PR TITLE
replace the extension module loader using importlib machinery

### DIFF
--- a/cx_Freeze/finder.py
+++ b/cx_Freeze/finder.py
@@ -436,10 +436,6 @@ class ModuleFinder(object):
         
         elif type == imp.C_EXTENSION:
             logging.debug("Adding module [%s] [C_EXTENSION]", name)
-            if parent is None:
-                # Our extension loader (see the freezer module) uses imp to
-                # load compiled extensions.
-                self.IncludeModule("imp")
 
         # If there's a custom hook for this module, run it.
         self._RunHook("load", module.name, module)

--- a/cx_Freeze/initscripts/__startup__.py
+++ b/cx_Freeze/initscripts/__startup__.py
@@ -7,20 +7,27 @@
 import os
 import sys
 from importlib.machinery import ExtensionFileLoader, EXTENSION_SUFFIXES, PathFinder
-from importlib.util import spec_from_file_location
+from importlib.util import spec_from_loader
 
 
 class ExtensionFinder(PathFinder):
 
     @classmethod
     def find_spec(cls, fullname, path=None, target=None):
-        for path in sys.path:
+        """this finder is only for modules that are being searched in the
+        library.zip, however they are in the lib directory."""
+        if path is None:
+            return
+        #ignore the path (library.zip/PKG/_module) and search sys.path
+        path = sys.path
+        for entry in sys.path:
+            if '.zip' in entry:
+                continue
             for ext in EXTENSION_SUFFIXES:
-                location = os.path.join(path, fullname + ext)
+                location = os.path.join(entry, fullname + ext)
                 if os.path.isfile(location):
                     loader = ExtensionFileLoader(fullname, location)
-                    return spec_from_file_location(fullname, location,
-                                                   loader=loader)
+                    return spec_from_loader(fullname, loader)
 
 sys.meta_path.append(ExtensionFinder)
 

--- a/cx_Freeze/initscripts/__startup__.py
+++ b/cx_Freeze/initscripts/__startup__.py
@@ -6,6 +6,27 @@
 
 import os
 import sys
+from importlib.machinery import ExtensionFileLoader, EXTENSION_SUFFIXES, PathFinder
+from importlib.util import spec_from_file_location
+
+
+class ExtensionFinder(PathFinder):
+
+    @classmethod
+    def find_spec(cls, fullname, path=None, target=None):
+        print('ExtensionFinder.find_spec', fullname, path, target)
+        for path in sys.path:
+            for ext in EXTENSION_SUFFIXES:
+                location = os.path.join(path, fullname + ext)
+                if os.path.isfile(location):
+                    loader = ExtensionFileLoader(fullname, location)
+                    spec = spec_from_file_location(fullname, location,
+                                                   loader=loader)
+                    if spec:
+                        return spec
+
+sys.meta_path.append(ExtensionFinder)
+
 
 def run():
     baseName = os.path.normcase(os.path.basename(sys.executable))

--- a/cx_Freeze/initscripts/__startup__.py
+++ b/cx_Freeze/initscripts/__startup__.py
@@ -14,16 +14,13 @@ class ExtensionFinder(PathFinder):
 
     @classmethod
     def find_spec(cls, fullname, path=None, target=None):
-        print('ExtensionFinder.find_spec', fullname, path, target)
         for path in sys.path:
             for ext in EXTENSION_SUFFIXES:
                 location = os.path.join(path, fullname + ext)
                 if os.path.isfile(location):
                     loader = ExtensionFileLoader(fullname, location)
-                    spec = spec_from_file_location(fullname, location,
+                    return spec_from_file_location(fullname, location,
                                                    loader=loader)
-                    if spec:
-                        return spec
 
 sys.meta_path.append(ExtensionFinder)
 

--- a/cx_Freeze/samples/importlib_test/setup.py
+++ b/cx_Freeze/samples/importlib_test/setup.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from urllib.request import urlopen
+
+from cx_Freeze import setup, Executable
+
+buildOptions = dict(packages = ['gevent'], excludes = [], includes = [],
+		    zip_include_packages = ["*"], zip_exclude_packages = [],
+            build_exe='test_exe',)
+
+examples = [
+'https://raw.githubusercontent.com/aio-libs/aiohttp/master/examples/server_simple.py',
+'https://raw.githubusercontent.com/aio-libs/aiohttp/master/examples/web_srv.py',
+'https://raw.githubusercontent.com/gevent/gevent/master/examples/wsgiserver.py'
+]
+
+executables = []
+for ex in examples:
+	local = ex.split('/')[-1]
+	with urlopen(ex) as fp1, open(local, 'w+b') as fp2:
+		fp2.write(fp1.read())
+	executables.append(Executable(local))
+
+setup(name='test_exe',
+      version = '1.0',
+      description = 'test_exe',
+      options = dict(build_exe = buildOptions),
+      executables = executables)


### PR DESCRIPTION
replace the extension module loader using importlib machinery

In py37 extension modules that load other modules causes errors like
SystemError: <method 'load_module' of 'zipimport.zipimporter' objects> returned NULL without setting an error
In some cases I see ImportError too...
Using importlib machinery instead of deprecated imp modernizes the code and possibly will be compatible with py38
Tested using py36 and py37 on windows and with py37 on linux
