### PR TITLE
force extension .exe on windows

### DIFF
--- a/cx_Freeze/freezer.py
+++ b/cx_Freeze/freezer.py
@@ -708,10 +708,12 @@ class Executable(object):
         self._GetInitScriptFileName()
         self._GetBaseFileName()
         if self.targetName is None:
-            name, ext = os.path.splitext(os.path.basename(self.script))
+            name, _ = os.path.splitext(os.path.basename(self.script))
             baseName, ext = os.path.splitext(self.base)
             self.targetName = name + ext
         name, ext = os.path.splitext(self.targetName)
+        if ext == "" and sys.platform == "win32":
+            self.targetName += ".exe"
         self.moduleName = "%s__main__" % os.path.normcase(name)
         self.initModuleName = "%s__init__" % os.path.normcase(name)
         self.targetName = os.path.join(freezer.targetDir, self.targetName)

--- a/doc/src/distutils.rst
+++ b/doc/src/distutils.rst
@@ -371,6 +371,7 @@ constructor are as follows:
      - the name of the target executable; the default value is the name of the
        script with the extension exchanged with the extension for the base
        executable
+     - if specified without extension, one will be added (Windows only).
    * - icon
      - name of icon which should be included in the executable itself on
        Windows or placed in the target directory for other platforms


### PR DESCRIPTION
if we use the same setup script on windows and linux can specify targetName without extension