### PR TITLE
copy dependent files relative to source module file

### DIFF
--- a/cx_Freeze/freezer.py
+++ b/cx_Freeze/freezer.py
@@ -168,7 +168,7 @@ class Freezer(object):
                 targetDir = self.targetDir
             sourceDir = os.path.dirname(source)
             for source in self._GetDependentFiles(source):
-                if relativeSource and\
+                if relativeSource and os.path.isabs(source) and\
                         os.path.commonpath((source, sourceDir)) == sourceDir:
                     relative = os.path.relpath(source, sourceDir)
                     target = os.path.join(targetDir, relative)

--- a/cx_Freeze/freezer.py
+++ b/cx_Freeze/freezer.py
@@ -172,7 +172,7 @@ class Freezer(object):
         stamp(fileName, versionInfo)
 
     def _CopyFile(self, source, target, copyDependentFiles,
-            includeMode = False):
+            includeMode = False, relativeSource = False):
         normalizedSource = os.path.normcase(os.path.normpath(source))
         normalizedTarget = os.path.normcase(os.path.normpath(target))
         if normalizedTarget in self.filesCopied:
@@ -195,9 +195,16 @@ class Freezer(object):
             # to allow to set relative reference
             if sys.platform == 'darwin':
                 targetDir = self.targetDir
+            sourceDir = os.path.dirname(source)
             for source in self._GetDependentFiles(source):
-                target = os.path.join(targetDir, os.path.basename(source))
-                self._CopyFile(source, target, copyDependentFiles)
+                if relativeSource and\
+                        os.path.commonpath((source, sourceDir)) == sourceDir:
+                    relative = os.path.relpath(source, sourceDir)
+                    target = os.path.join(targetDir, relative)
+                else:
+                    target = os.path.join(targetDir, os.path.basename(source))
+                self._CopyFile(source, target, copyDependentFiles,
+                               relativeSource=relativeSource)
 
     def _CreateDirectory(self, path):
         if not os.path.isdir(path):
@@ -628,7 +635,8 @@ class Freezer(object):
                 if module.parent is not None:
                     path = os.pathsep.join([origPath] + module.parent.path)
                     os.environ["PATH"] = path
-                self._CopyFile(module.file, target, copyDependentFiles = True)
+                self._CopyFile(module.file, target, copyDependentFiles = True,
+                               relativeSource = True)
             finally:
                 os.environ["PATH"] = origPath
 

--- a/cx_Freeze/freezer.py
+++ b/cx_Freeze/freezer.py
@@ -605,8 +605,8 @@ class Freezer(object):
                 if module.parent is not None:
                     path = os.pathsep.join([origPath] + module.parent.path)
                     os.environ["PATH"] = path
-                self._CopyFile(module.file, target, copyDependentFiles = True,
-                               relativeSource = True)
+                self._CopyFile(module.file, target, copyDependentFiles=True,
+                               relativeSource=(sys.platform == "linux"))
             finally:
                 os.environ["PATH"] = origPath
 


### PR DESCRIPTION
I was trying to fix errors in modules that use _cffi_backend like PIL, cryptography and bcrypt. _cffi_backend needs a libffi*.so.* file in a specific subfolder, and PIL needs it either in libs/PIL/.libs or lib/.libs when zip_include_packages = ["*"]
With this patch it was possible to reduce the hooks for PIL and cffi.
I ended up making a little fuss about submitting the patches on cffi and PIL.
For PIL, it had already closed patch #480 and sent a new #491
For cffi I will fix #479