### PR TITLE
Tests to replicate errors to justify PR #479 and #494

### DIFF
--- a/cx_Freeze/samples/cryptography/requirements.txt
+++ b/cx_Freeze/samples/cryptography/requirements.txt
@@ -1,0 +1,3 @@
+cx-freeze
+cryptography
+

--- a/cx_Freeze/samples/cryptography/setup.py
+++ b/cx_Freeze/samples/cryptography/setup.py
@@ -1,0 +1,17 @@
+# A setup script to demonstrate the use of sqlite3
+#
+# Run the build process by running the command 'python setup.py build'
+#
+# If everything works well you should find a subdirectory in the build
+# subdirectory that contains the files needed to run the script without Python
+
+from cx_Freeze import setup, Executable
+
+buildOptions = dict(zip_include_packages=["*"], zip_exclude_packages=[], includes='_cffi_backend')
+executables = [Executable("test_crypt.py")]
+
+setup(name='test_crypt',
+      version='0.1',
+      description='cx_Freeze script to test cryptography',
+      executables=executables,
+      options=dict(build_exe=buildOptions))

--- a/cx_Freeze/samples/cryptography/test_crypt.py
+++ b/cx_Freeze/samples/cryptography/test_crypt.py
@@ -1,0 +1,3 @@
+from cryptography.fernet import Fernet
+
+print('Hello cryptography', Fernet)

--- a/cx_Freeze/samples/distutils/setup.py
+++ b/cx_Freeze/samples/distutils/setup.py
@@ -1,0 +1,17 @@
+# A setup script to demonstrate the use of sqlite3
+#
+# Run the build process by running the command 'python setup.py build'
+#
+# If everything works well you should find a subdirectory in the build
+# subdirectory that contains the files needed to run the script without Python
+
+from cx_Freeze import setup, Executable
+
+buildOptions = dict(zip_include_packages=["*"], zip_exclude_packages=[])
+executables = [Executable("test_dist.py")]
+
+setup(name='test_dist',
+      version='0.1',
+      description='cx_Freeze script to test distutils',
+      executables=executables,
+      options=dict(build_exe=buildOptions))

--- a/cx_Freeze/samples/distutils/test_dist.py
+++ b/cx_Freeze/samples/distutils/test_dist.py
@@ -1,0 +1,5 @@
+from distutils import dist, sysconfig
+
+print('Hello distutils')
+print(dist)
+print(sysconfig)

--- a/cx_Freeze/samples/pillow/requirements.txt
+++ b/cx_Freeze/samples/pillow/requirements.txt
@@ -1,0 +1,3 @@
+cx-freeze
+pillow
+

--- a/cx_Freeze/samples/pillow/setup.py
+++ b/cx_Freeze/samples/pillow/setup.py
@@ -1,0 +1,17 @@
+# A setup script to demonstrate the use of sqlite3
+#
+# Run the build process by running the command 'python setup.py build'
+#
+# If everything works well you should find a subdirectory in the build
+# subdirectory that contains the files needed to run the script without Python
+
+from cx_Freeze import setup, Executable
+
+buildOptions = dict(zip_include_packages=["*"], zip_exclude_packages=[])
+executables = [Executable("test_pillow.py")]
+
+setup(name='test_pillow',
+      version='0.1',
+      description='cx_Freeze script to test pillow (PIL)',
+      executables=executables,
+      options=dict(build_exe=buildOptions))

--- a/cx_Freeze/samples/pillow/test_pillow.py
+++ b/cx_Freeze/samples/pillow/test_pillow.py
@@ -1,0 +1,10 @@
+from io import BytesIO
+from urllib.request import urlopen
+from PIL import Image
+
+print('Opening image with PIL')
+filename = 'https://avatars3.githubusercontent.com/u/12752334?s=400&u=3ba7ed4b03221b76af248ff57b5f619d77b6021f&v=4'
+fp = BytesIO(urlopen(filename).read())
+with Image.open(fp) as im, open('test_pillow.pdf', 'w+b') as fp2:
+	im.save(fp2, format='PDF')
+print('OK')

--- a/cx_Freeze/samples/sqlite/setup.py
+++ b/cx_Freeze/samples/sqlite/setup.py
@@ -1,0 +1,17 @@
+# A setup script to demonstrate the use of sqlite3
+#
+# Run the build process by running the command 'python setup.py build'
+#
+# If everything works well you should find a subdirectory in the build
+# subdirectory that contains the files needed to run the script without Python
+
+from cx_Freeze import setup, Executable
+
+buildOptions = {}#dict(zip_include_packages=["*"], zip_exclude_packages=[])
+executables = [Executable("test_sqlite3.py")]
+
+setup(name='test_sqlite3',
+      version='0.1',
+      description='cx_Freeze script to test sqlite3',
+      executables=executables,
+      options=dict(build_exe=buildOptions))

--- a/cx_Freeze/samples/sqlite/test_sqlite3.py
+++ b/cx_Freeze/samples/sqlite/test_sqlite3.py
@@ -1,0 +1,32 @@
+import sqlite3
+
+#examples from python documentation
+
+con = sqlite3.connect(":memory:")
+cur = con.cursor()
+cur.executescript("""
+    create table person(
+        firstname,
+        lastname,
+        age
+    );
+
+    create table book(
+        title,
+        author,
+        published
+    );
+
+    insert into book(title, author, published)
+    values (
+        'Dirk Gently''s Holistic Detective Agency',
+        'Douglas Adams',
+        1987
+    );
+    """)
+with open('dump.sql', 'w') as f:
+    for line in con.iterdump():
+        f.write('%s\n' % line)
+
+print('dump.sql created')
+con.close()


### PR DESCRIPTION
Tested on linux py37-64, windows py37-32

1. cryptography
only on linux:
ModuleNotFoundError: No module named '_cffi_backend'
after adding includes='_cffi_backend' new error arises
ImportError: libffi-d78936b1.so.6.0.4: cannot open shared object file: No such file or directory
issue #313 and others
PR #479 and #494 resolves this issues

2. pillow
only on linux:
ImportError: libjpeg-3b10b538.so.9.3.0: cannot open shared object file: No such file or directory
PR #494 resolves this issue

3. sqlite
linux and windows: ModuleNotFoundError: No module named 'sqlite3.dump'
issue #454

4. distutils
example to check only that it is ok on linux and windows