### PR TITLE
pytz hook using the new infrastructure

### DIFF
--- a/cx_Freeze/hooks.py
+++ b/cx_Freeze/hooks.py
@@ -458,7 +458,7 @@ def load_pytz(finder, module):
     if not os.path.isdir(dataPath):
         # Fedora (and possibly other systems) use a separate location to
         # store timezone data so look for that here as well
-        dataPath = "/usr/share/zoneinfo"
+        dataPath = os.getenv('PYTZ_TZDATADIR') or "/usr/share/zoneinfo"
         if os.path.isdir(dataPath) and module.WillBeStoredInFileSystem():
             targetPath = os.path.join("lib", "pytz", "zoneinfo")
             finder.IncludeFiles(dataPath, targetPath, copyDependentFiles=False)

--- a/cx_Freeze/hooks.py
+++ b/cx_Freeze/hooks.py
@@ -459,6 +459,8 @@ def load_pytz(finder, module):
         # Fedora (and possibly other systems) use a separate location to
         # store timezone data so look for that here as well
         dataPath = os.getenv('PYTZ_TZDATADIR') or "/usr/share/zoneinfo"
+        if dataPath.endswith(os.sep):
+            dataPath = dataPath[:-1]
         if os.path.isdir(dataPath) and module.WillBeStoredInFileSystem():
             targetPath = os.path.join("lib", "pytz", "zoneinfo")
             finder.IncludeFiles(dataPath, targetPath, copyDependentFiles=False)

--- a/cx_Freeze/hooks.py
+++ b/cx_Freeze/hooks.py
@@ -452,22 +452,15 @@ def load_pythoncom(finder, module):
 
 def load_pytz(finder, module):
     """the pytz module requires timezone data to be found in a known directory
-       pointed to by an environment variable if the package is not being
-       written to the file system"""
+       or in the zip file where the package is written"""
     import pytz
-    includeFiles = False
     dataPath = os.path.join(os.path.dirname(pytz.__file__), "zoneinfo")
-    if os.path.isdir(dataPath):
-        includeFiles = not module.WillBeStoredInFileSystem()
-    else:
+    if not os.path.isdir(dataPath):
         # Fedora (and possibly other systems) use a separate location to
         # store timezone data so look for that here as well
         dataPath = "/usr/share/zoneinfo"
-        if os.path.isdir(dataPath):
-            includeFiles = True
-    if includeFiles:
-        finder.AddConstant("HAS_PYTZ", 1)
-        finder.IncludeFiles(dataPath, "pytz-data", copyDependentFiles=False)
+    if os.path.isdir(dataPath) and not module.WillBeStoredInFileSystem():
+        finder.ZipIncludeFiles(dataPath, "pytz/zoneinfo")
 
 
 def load_pywintypes(finder, module):

--- a/cx_Freeze/hooks.py
+++ b/cx_Freeze/hooks.py
@@ -458,12 +458,16 @@ def load_pytz(finder, module):
     if not os.path.isdir(dataPath):
         # Fedora (and possibly other systems) use a separate location to
         # store timezone data so look for that here as well
-        dataPath = os.getenv('PYTZ_TZDATADIR') or "/usr/share/zoneinfo"
+        if hasattr(pytz, '_tzinfo_dir'):
+            dataPath = pytz._tzinfo_dir
+        else:
+            dataPath = os.getenv('PYTZ_TZDATADIR') or "/usr/share/zoneinfo"
         if dataPath.endswith(os.sep):
             dataPath = dataPath[:-1]
-        if os.path.isdir(dataPath) and module.WillBeStoredInFileSystem():
+        if os.path.isdir(dataPath):
             targetPath = os.path.join("lib", "pytz", "zoneinfo")
             finder.IncludeFiles(dataPath, targetPath, copyDependentFiles=False)
+            finder.AddConstant("PYTZ_TZDATADIR", targetPath)
             return
     if os.path.isdir(dataPath) and not module.WillBeStoredInFileSystem():
         finder.ZipIncludeFiles(dataPath, "pytz/zoneinfo")

--- a/cx_Freeze/hooks.py
+++ b/cx_Freeze/hooks.py
@@ -459,6 +459,10 @@ def load_pytz(finder, module):
         # Fedora (and possibly other systems) use a separate location to
         # store timezone data so look for that here as well
         dataPath = "/usr/share/zoneinfo"
+        if os.path.isdir(dataPath) and module.WillBeStoredInFileSystem():
+            targetPath = os.path.join("lib", "pytz", "zoneinfo")
+            finder.IncludeFiles(dataPath, targetPath, copyDependentFiles=False)
+            return
     if os.path.isdir(dataPath) and not module.WillBeStoredInFileSystem():
         finder.ZipIncludeFiles(dataPath, "pytz/zoneinfo")
 

--- a/cx_Freeze/initscripts/Console.py
+++ b/cx_Freeze/initscripts/Console.py
@@ -21,6 +21,10 @@ if hasattr(BUILD_CONSTANTS, "HAS_TKINTER"):
 if hasattr(BUILD_CONSTANTS, "HAS_MATPLOTLIB"):
     os.environ["MATPLOTLIBDATA"] = os.path.join(DIR_NAME, "mpl-data")
 
+if hasattr(BUILD_CONSTANTS, "PYTZ_TZDATADIR"):
+    os.environ["PYTZ_TZDATADIR"] = os.path.join(DIR_NAME,
+                                                BUILD_CONSTANTS.PYTZ_TZDATADIR)
+
 def run():
     name, ext = os.path.splitext(os.path.basename(os.path.normcase(FILE_NAME)))
     moduleName = "%s__main__" % name

--- a/cx_Freeze/initscripts/Console.py
+++ b/cx_Freeze/initscripts/Console.py
@@ -21,9 +21,6 @@ if hasattr(BUILD_CONSTANTS, "HAS_TKINTER"):
 if hasattr(BUILD_CONSTANTS, "HAS_MATPLOTLIB"):
     os.environ["MATPLOTLIBDATA"] = os.path.join(DIR_NAME, "mpl-data")
 
-if hasattr(BUILD_CONSTANTS, "HAS_PYTZ"):
-    os.environ["PYTZ_TZDATADIR"] = os.path.join(DIR_NAME, "pytz-data")
-
 def run():
     name, ext = os.path.splitext(os.path.basename(os.path.normcase(FILE_NAME)))
     moduleName = "%s__main__" % name

--- a/cx_Freeze/initscripts/ConsoleSetLibPath.py
+++ b/cx_Freeze/initscripts/ConsoleSetLibPath.py
@@ -33,9 +33,6 @@ if hasattr(BUILD_CONSTANTS, "HAS_TKINTER"):
 if hasattr(BUILD_CONSTANTS, "HAS_MATPLOTLIB"):
     os.environ["MATPLOTLIBDATA"] = os.path.join(DIR_NAME, "mpl-data")
 
-if hasattr(BUILD_CONSTANTS, "HAS_PYTZ"):
-    os.environ["PYTZ_TZDATADIR"] = os.path.join(DIR_NAME, "pytz-data")
-
 def run():
     name, ext = os.path.splitext(os.path.basename(os.path.normcase(FILE_NAME)))
     moduleName = "%s__main__" % name

--- a/cx_Freeze/initscripts/ConsoleSetLibPath.py
+++ b/cx_Freeze/initscripts/ConsoleSetLibPath.py
@@ -33,6 +33,9 @@ if hasattr(BUILD_CONSTANTS, "HAS_TKINTER"):
 if hasattr(BUILD_CONSTANTS, "HAS_MATPLOTLIB"):
     os.environ["MATPLOTLIBDATA"] = os.path.join(DIR_NAME, "mpl-data")
 
+if hasattr(BUILD_CONSTANTS, "PYTZ_TZDATADIR"):
+    os.environ["PYTZ_TZDATADIR"] = os.path.join(DIR_NAME,
+                                                BUILD_CONSTANTS.PYTZ_TZDATADIR)
 def run():
     name, ext = os.path.splitext(os.path.basename(os.path.normcase(FILE_NAME)))
     moduleName = "%s__main__" % name


### PR DESCRIPTION
In this patch I'm taking account the desire of user/developer. If he defines zip_include_packages all, he wants the modules/packages in library.zip, and pytz accepts this method.
If user/developer want the packages in file system, cx-freeze copies the package and its data as is. To this occurs, define zip_excludes_packages with all or zip_exclude_packages with 'pytz'.
If the data is on pytz/zoneinfo in the library.zip or in the file system at build dir (lib/pytz/zoneinfo), pytz detects and use.
On fedora, this is not possible, then the PYTZ_TZDATADIR environment variable is used.
Tested with Windows, Ubuntu and Fedora (I have installed Fedora31 in a VM and tested this PR with the new pytz sample, the next PR).