### PR TITLE
pytz sample using only pytz

### DIFF
--- a/cx_Freeze/samples/pytz/requirements.txt
+++ b/cx_Freeze/samples/pytz/requirements.txt
@@ -1,4 +1,3 @@
 cx-freeze
 pytz
-tzlocal
 

--- a/cx_Freeze/samples/pytz/setup2.py
+++ b/cx_Freeze/samples/pytz/setup2.py
@@ -1,5 +1,5 @@
 '''A setup script to demonstrate build using pytz
-   This version requires the zoneinfo in the zip file
+   This version requires the zoneinfo in the file system
 '''
 #
 # Run the build process by running the command 'python setup.py build'
@@ -7,13 +7,22 @@
 # If everything works well you should find a subdirectory in the build
 # subdirectory that contains the files needed to run the script without Python
 
+import distutils
+import sys
+import os
+
 from cx_Freeze import setup, Executable
 
-setup(name='test_pytz_zip',
+dir_name = "exe.%s-%s.2" % \
+        (distutils.util.get_platform(), sys.version[0:3])
+build_exe = os.path.join('build', dir_name)
+
+setup(name='test_pytz',
       version='0.2',
       description='cx_Freeze script to test pytz',
       executables=[Executable("test_pytz.py")],
       options={
           'build_exe': {'zip_include_packages': ["*"],
-                        'zip_exclude_packages': []}
+                        'zip_exclude_packages': ["pytz"],
+                        'build_exe': build_exe}
           })

--- a/cx_Freeze/samples/pytz/test_pytz.py
+++ b/cx_Freeze/samples/pytz/test_pytz.py
@@ -1,16 +1,16 @@
 '''sample to show the datetime in RFC1123 (timezone is required)'''
-from datetime import datetime
+import datetime
 import pytz
-import tzlocal
 
 RFC1123 = '%a, %d %b %Y %H:%M:%S %z'
 
-try:
-    tz = tzlocal.get_localzone()
-    print('Using your local timezone:', tz.zone)
-except pytz.exceptions.UnknownTimeZoneError as exc:
-    print('Detected your local timezone:', exc.args[0])
-    print("WARNING: fail to load pytz timezones, fallback to UTC")
-    tz = pytz.utc
-finally:
-    print(datetime.now(tz).strftime(RFC1123))
+utc_time = datetime.datetime.utcnow()
+print('UTC time:', utc_time.strftime(RFC1123))
+
+tz1 = pytz.timezone('America/Sao_Paulo')
+brz_time = tz1.fromutc(utc_time)
+print('Brazil time:', brz_time.strftime(RFC1123))
+
+tz2 = pytz.timezone('US/Eastern')
+eas_time = tz2.fromutc(utc_time)
+print('US Eastern time:', eas_time.strftime(RFC1123))


### PR DESCRIPTION
I modified these samples to just use pytz. I believe that by using tzlocal earlier, I led you to assume other things about the patch.
Note that there are two setups (setup.py and setup2.py) that generate in different directories within the build and so we can build the executable with all modules inside the zip (setup.py) and if you want you can generate pytz in the systems.
It is worth noting that the second version works on 6.0, ie it did not need environment variable.