### PR TITLE
add ctypes hook in Python 3.8 for windows

### DIFF
--- a/cx_Freeze/hooks.py
+++ b/cx_Freeze/hooks.py
@@ -91,8 +91,17 @@ def load_ceODBC(finder, module):
 
 
 def load_cryptography_hazmat_bindings__padding(finder, module):
-    """the cryptography module requires the cffi package (loaded implicitly)"""
+    """the cryptography module requires the _cffi_backend module (loaded implicitly)"""
     finder.IncludeModule('_cffi_backend')
+
+
+def load__ctypes(finder, module):
+    """In Windows, the _ctypes module in Python >= 3.8 requires an additional dll
+       libffi-7.dll to be present in the build directory."""
+    if sys.platform == "win32" and sys.version_info >= (3, 8):
+        dll_name = "libffi-7.dll"
+        dll_path = os.path.join(sys.base_prefix, "DLLs", dll_name)
+        finder.IncludeFiles(dll_path, os.path.join("lib", dll_name))
 
 
 def load_cx_Oracle(finder, module):


### PR DESCRIPTION
With this patch, py38 can definitely be declared as supported.
Issue #523 
Sample #546 