### PR TITLE
tkinter support complete now; cleanup

### DIFF
--- a/cx_Freeze/hooks.py
+++ b/cx_Freeze/hooks.py
@@ -69,7 +69,6 @@ def initialize(finder):
     if sys.platform[:4] != "OpenVMS":
         finder.ExcludeModule("vms_lib")
     finder.ExcludeModule("new")
-    finder.ExcludeModule("Tkinter")
 
 
 def load_asyncio(finder, module):
@@ -108,10 +107,7 @@ def load_cx_Oracle(finder, module):
     """the cx_Oracle module implicitly imports datetime; make sure this
        happens."""
     finder.IncludeModule("datetime")
-    try:
-        finder.IncludeModule("decimal")
-    except ImportError:
-        pass
+    finder.IncludeModule("decimal")
 
 
 def load_datetime(finder, module):
@@ -434,12 +430,14 @@ def load_pty(finder, module):
     """The sgi module is not needed for this module to function."""
     module.IgnoreName("sgi")
 
+
 def load_pycparser(finder, module):
     """ These files are missing which causes
         permission denied issues on windows when they are regenerated.
     """
     finder.IncludeModule("pycparser.lextab")
     finder.IncludeModule("pycparser.yacctab")
+
 
 def load_pydoc(finder, module):
     """The pydoc module will work without the Tkinter module so ignore the
@@ -694,7 +692,6 @@ def load_tkinter(finder, module):
        runtime."""
     if sys.platform == "win32":
         import tkinter
-        import _tkinter
         root_names = "tcl", "tk"
         environ_names = "TCL_LIBRARY", "TK_LIBRARY"
         version_vars = tkinter.TclVersion, tkinter.TkVersion
@@ -706,30 +703,10 @@ def load_tkinter(finder, module):
                 lib_texts = os.path.join(sys.base_prefix, "tcl",
                         mod_name + str(ver_var))
             finder.IncludeFiles(lib_texts, mod_name)
-        for ver_var, mod_name in zip(version_vars, root_names):
             dll_name = mod_name + str(ver_var).replace(".", "") + "t.dll"
-            dll_path = os.path.join(sys.base_prefix, "Dlls", dll_name)
+            dll_path = os.path.join(sys.base_prefix, "DLLS", dll_name)
             finder.IncludeFiles(dll_path, os.path.join("lib", dll_name))
-
-
-def load_Tkinter(finder, module):
-    """the Tkinter module has data files that are required to be loaded so
-       ensure that they are copied into the directory that is expected at
-       runtime."""
-    import Tkinter
-    import _tkinter
-    tk = _tkinter.create()
-    tclDir = os.path.dirname(tk.call("info", "library"))
-    # on OS X, Tcl and Tk are organized in frameworks, different layout
-    if sys.platform == 'darwin' and tk.call('tk', 'windowingsystem') == 'aqua':
-        tclSourceDir=os.path.join(os.path.split(tclDir)[0], 'Tcl')
-        tkSourceDir = tclSourceDir.replace('Tcl', 'Tk')
-    else:
-        tclSourceDir = os.path.join(tclDir, "tcl%s" % _tkinter.TCL_VERSION)
-        tkSourceDir = os.path.join(tclDir, "tk%s" % _tkinter.TK_VERSION)
-    finder.AddConstant("HAS_TKINTER", 1)
-    finder.IncludeFiles(tclSourceDir, "tcl")
-    finder.IncludeFiles(tkSourceDir, "tk")
+        finder.AddConstant("HAS_TKINTER", 1)
 
 
 def load_tempfile(finder, module):

--- a/cx_Freeze/hooks.py
+++ b/cx_Freeze/hooks.py
@@ -268,10 +268,11 @@ def load_idna(finder, module):
 def load_matplotlib(finder, module):
     """the matplotlib module requires data to be found in mpl-data in the
        same directory as the frozen executable so oblige it"""
-    finder.AddConstant("HAS_MATPLOTLIB", 1)
     import matplotlib
     dataPath = matplotlib.get_data_path()
-    finder.IncludeFiles(dataPath, "mpl-data", copyDependentFiles=False)
+    targetPath = os.path.join("lib", "matplotlib", "mpl-data")
+    finder.AddConstant("MATPLOTLIBDATA", targetPath)
+    finder.IncludeFiles(dataPath, targetPath, copyDependentFiles=False)
 
 
 def load_numpy(finder, module):
@@ -702,11 +703,12 @@ def load_tkinter(finder, module):
             except KeyError:
                 lib_texts = os.path.join(sys.base_prefix, "tcl",
                         mod_name + str(ver_var))
-            finder.IncludeFiles(lib_texts, mod_name)
+            targetPath = os.path.join("lib", "tkinter", mod_name)
+            finder.AddConstant(env_name, targetPath)
+            finder.IncludeFiles(lib_texts, targetPath)
             dll_name = mod_name + str(ver_var).replace(".", "") + "t.dll"
-            dll_path = os.path.join(sys.base_prefix, "DLLS", dll_name)
+            dll_path = os.path.join(sys.base_prefix, "DLLs", dll_name)
             finder.IncludeFiles(dll_path, os.path.join("lib", dll_name))
-        finder.AddConstant("HAS_TKINTER", 1)
 
 
 def load_tempfile(finder, module):

--- a/cx_Freeze/initscripts/Console.py
+++ b/cx_Freeze/initscripts/Console.py
@@ -14,9 +14,11 @@ sys.frozen = True
 FILE_NAME = sys.executable
 DIR_NAME = os.path.dirname(sys.executable)
 
-if hasattr(BUILD_CONSTANTS, "TK_LIBRARY"):
+if hasattr(BUILD_CONSTANTS, "TCL_LIBRARY"):
     os.environ["TCL_LIBRARY"] = os.path.join(DIR_NAME,
                                              BUILD_CONSTANTS.TCL_LIBRARY)
+
+if hasattr(BUILD_CONSTANTS, "TK_LIBRARY"):
     os.environ["TK_LIBRARY"] = os.path.join(DIR_NAME,
                                              BUILD_CONSTANTS.TK_LIBRARY)
 

--- a/cx_Freeze/initscripts/Console.py
+++ b/cx_Freeze/initscripts/Console.py
@@ -14,12 +14,15 @@ sys.frozen = True
 FILE_NAME = sys.executable
 DIR_NAME = os.path.dirname(sys.executable)
 
-if hasattr(BUILD_CONSTANTS, "HAS_TKINTER"):
-    os.environ["TCL_LIBRARY"] = os.path.join(DIR_NAME, "tcl")
-    os.environ["TK_LIBRARY"] = os.path.join(DIR_NAME, "tk")
+if hasattr(BUILD_CONSTANTS, "TK_LIBRARY"):
+    os.environ["TCL_LIBRARY"] = os.path.join(DIR_NAME,
+                                             BUILD_CONSTANTS.TCL_LIBRARY)
+    os.environ["TK_LIBRARY"] = os.path.join(DIR_NAME,
+                                             BUILD_CONSTANTS.TK_LIBRARY)
 
-if hasattr(BUILD_CONSTANTS, "HAS_MATPLOTLIB"):
-    os.environ["MATPLOTLIBDATA"] = os.path.join(DIR_NAME, "mpl-data")
+if hasattr(BUILD_CONSTANTS, "MATPLOTLIBDATA"):
+    os.environ["MATPLOTLIBDATA"] = os.path.join(DIR_NAME,
+                                             BUILD_CONSTANTS.MATPLOTLIBDATA)
 
 if hasattr(BUILD_CONSTANTS, "PYTZ_TZDATADIR"):
     os.environ["PYTZ_TZDATADIR"] = os.path.join(DIR_NAME,

--- a/cx_Freeze/initscripts/ConsoleSetLibPath.py
+++ b/cx_Freeze/initscripts/ConsoleSetLibPath.py
@@ -26,16 +26,22 @@ if DIR_NAME not in paths:
 sys.frozen = True
 sys.path = sys.path[:4]
 
-if hasattr(BUILD_CONSTANTS, "HAS_TKINTER"):
-    os.environ["TCL_LIBRARY"] = os.path.join(DIR_NAME, "tcl")
-    os.environ["TK_LIBRARY"] = os.path.join(DIR_NAME, "tk")
+if hasattr(BUILD_CONSTANTS, "TCL_LIBRARY"):
+    os.environ["TCL_LIBRARY"] = os.path.join(DIR_NAME,
+                                             BUILD_CONSTANTS.TCL_LIBRARY)
 
-if hasattr(BUILD_CONSTANTS, "HAS_MATPLOTLIB"):
-    os.environ["MATPLOTLIBDATA"] = os.path.join(DIR_NAME, "mpl-data")
+if hasattr(BUILD_CONSTANTS, "TK_LIBRARY"):
+    os.environ["TK_LIBRARY"] = os.path.join(DIR_NAME,
+                                             BUILD_CONSTANTS.TK_LIBRARY)
+
+if hasattr(BUILD_CONSTANTS, "MATPLOTLIBDATA"):
+    os.environ["MATPLOTLIBDATA"] = os.path.join(DIR_NAME,
+                                             BUILD_CONSTANTS.MATPLOTLIBDATA)
 
 if hasattr(BUILD_CONSTANTS, "PYTZ_TZDATADIR"):
     os.environ["PYTZ_TZDATADIR"] = os.path.join(DIR_NAME,
                                                 BUILD_CONSTANTS.PYTZ_TZDATADIR)
+
 def run():
     name, ext = os.path.splitext(os.path.basename(os.path.normcase(FILE_NAME)))
     moduleName = "%s__main__" % name

--- a/cx_Freeze/samples/Tkinter/SimpleTkApp.py
+++ b/cx_Freeze/samples/Tkinter/SimpleTkApp.py
@@ -1,10 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
-try:
-    from tkinter import Tk, Label, Button, BOTTOM
-except ImportError:
-    from Tkinter import Tk, Label, Button, BOTTOM
+from tkinter import Tk, Label, Button, BOTTOM
 
 root = Tk()
 root.title('Button')


### PR DESCRIPTION
Support for tkinter was broke in py3, and remove unused code (py3 renamed Tkinter to tkinter).
Move location of data files.
Some cleanup.

Tested the tk sample with py368 and py381 on Windows, and py375 on Linux.