### PR TITLE
get rid of MATPLOTLIBDATA environment variable (it was deprecated)

### DIFF
--- a/cx_Freeze/finder.py
+++ b/cx_Freeze/finder.py
@@ -502,10 +502,18 @@ class ModuleFinder(object):
         for i, value in enumerate(constants):
             if isinstance(value, type(co)):
                 constants[i] = self._ReplacePathsInCode(topLevelModule, value)
+        
+        # Build the new code object.
+        params = [co.co_argcount, co.co_kwonlyargcount,
+                  co.co_nlocals, co.co_stacksize, co.co_flags, co.co_code,
+                  tuple(constants), co.co_names, co.co_varnames, newFileName,
+                  co.co_name, co.co_firstlineno, co.co_lnotab, co.co_freevars,
+                  co.co_cellvars]
+        if hasattr(co, "co_posonlyargcount"):
+            #PEP570 added "positional only arguments" in Python 3.8
+            params.insert(1, co.co_posonlyargcount)
+        return types.CodeType(*params)
 
-        return self.BuildNewCodeObject(co, constants=constants,
-                                        filename=newFileName)
-    
     def _RunHook(self, hookName, moduleName, *args):
         """Run hook for the given module if one is present."""
         name = "%s_%s" % (hookName, moduleName.replace(".", "_"))
@@ -590,21 +598,6 @@ class ModuleFinder(object):
 
     def AddConstant(self, name, value):
         self.constants_module.values[name] = value
-
-    def BuildNewCodeObject(self, co, code=None, constants=None, filename=None):
-        """Build the new code object."""
-        code = code or co.co_code
-        constants = tuple(constants or co.co_consts)
-        filename = filename or co.co_filename
-        params = [co.co_argcount, co.co_kwonlyargcount,
-                  co.co_nlocals, co.co_stacksize, co.co_flags, code,
-                  constants, co.co_names, co.co_varnames, filename,
-                  co.co_name, co.co_firstlineno, co.co_lnotab, co.co_freevars,
-                  co.co_cellvars]
-        if hasattr(co, "co_posonlyargcount"):
-            # PEP570 added "positional only arguments" in Python 3.8
-            params.insert(1, co.co_posonlyargcount)
-        return types.CodeType(*params)
 
     def ExcludeDependentFiles(self, fileName):
         self.exclude_dependent_files[fileName] = None

--- a/cx_Freeze/hooks.py
+++ b/cx_Freeze/hooks.py
@@ -298,7 +298,7 @@ def _get_data_path():
         constants = list(co.co_consts)
         for i, value in enumerate(constants):
             if isinstance(value, type(co)) and value.co_name == co_func.co_name:
-                constants[i] = finder.BuildNewCodeObject(co_func)
+                constants[i] = rebuild_code_object(co_func)
                 break
         module.code = rebuild_code_object(co, constants=constants)
 

--- a/cx_Freeze/hooks.py
+++ b/cx_Freeze/hooks.py
@@ -2,6 +2,8 @@ import glob
 import os
 import sys
 
+from cx_Freeze.common import rebuild_code_object
+
 def initialize(finder):
     """upon initialization of the finder, this routine is called to set up some
        automatic exclusions for various platforms."""
@@ -298,7 +300,7 @@ def _get_data_path():
             if isinstance(value, type(co)) and value.co_name == co_func.co_name:
                 constants[i] = finder.BuildNewCodeObject(co_func)
                 break
-        module.code = finder.BuildNewCodeObject(co, constants=constants)
+        module.code = rebuild_code_object(co, constants=constants)
 
 
 def load_numpy(finder, module):

--- a/cx_Freeze/hooks.py
+++ b/cx_Freeze/hooks.py
@@ -265,14 +265,13 @@ def load_idna(finder, module):
     finder.IncludeModule("idna.idnadata")
 
 
-MATPLOTLIB_CODE_STR = """
-def _get_data_path():
-    return os.path.join(os.path.dirname(sys.executable), '{}')
-"""
-
 def load_matplotlib(finder, module):
     """the matplotlib package requires mpl-data in a subdirectory of the
     package."""
+    MATPLOTLIB_CODE_STR = """
+def _get_data_path():
+    return os.path.join(os.path.dirname(sys.executable), '{}')
+"""
     import matplotlib
     data_path = matplotlib.get_data_path()
     target_path = os.path.join("lib", module.name, "mpl-data")

--- a/cx_Freeze/initscripts/Console.py
+++ b/cx_Freeze/initscripts/Console.py
@@ -22,10 +22,6 @@ if hasattr(BUILD_CONSTANTS, "TK_LIBRARY"):
     os.environ["TK_LIBRARY"] = os.path.join(DIR_NAME,
                                              BUILD_CONSTANTS.TK_LIBRARY)
 
-if hasattr(BUILD_CONSTANTS, "MATPLOTLIBDATA"):
-    os.environ["MATPLOTLIBDATA"] = os.path.join(DIR_NAME,
-                                             BUILD_CONSTANTS.MATPLOTLIBDATA)
-
 if hasattr(BUILD_CONSTANTS, "PYTZ_TZDATADIR"):
     os.environ["PYTZ_TZDATADIR"] = os.path.join(DIR_NAME,
                                                 BUILD_CONSTANTS.PYTZ_TZDATADIR)

--- a/cx_Freeze/initscripts/ConsoleSetLibPath.py
+++ b/cx_Freeze/initscripts/ConsoleSetLibPath.py
@@ -34,10 +34,6 @@ if hasattr(BUILD_CONSTANTS, "TK_LIBRARY"):
     os.environ["TK_LIBRARY"] = os.path.join(DIR_NAME,
                                              BUILD_CONSTANTS.TK_LIBRARY)
 
-if hasattr(BUILD_CONSTANTS, "MATPLOTLIBDATA"):
-    os.environ["MATPLOTLIBDATA"] = os.path.join(DIR_NAME,
-                                             BUILD_CONSTANTS.MATPLOTLIBDATA)
-
 if hasattr(BUILD_CONSTANTS, "PYTZ_TZDATADIR"):
     os.environ["PYTZ_TZDATADIR"] = os.path.join(DIR_NAME,
                                                 BUILD_CONSTANTS.PYTZ_TZDATADIR)

--- a/cx_Freeze/samples/matplotlib/matplotlib_afm.py
+++ b/cx_Freeze/samples/matplotlib/matplotlib_afm.py
@@ -1,0 +1,16 @@
+"""A simple script to show some values of a font in matplotlib."""
+
+from pathlib import Path
+import matplotlib as mpl
+from matplotlib.afm import AFM
+
+print('matplotlib datapath:', mpl.get_data_path())
+afm_path = Path(mpl.get_data_path(), 'fonts', 'afm', 'ptmr8a.afm')
+with afm_path.open('rb') as fh:
+    afm = AFM(fh)
+print("compare the results with:", "https://github.com/matplotlib/matplotlib/blob/master/lib/matplotlib/afm.py")
+print(afm.string_width_height('What the heck?'))
+print(afm.get_fontname())
+print(afm.get_kern_dist('A', 'f'))
+print(afm.get_kern_dist('A', 'y'))
+print(afm.get_bbox_char('!'))

--- a/cx_Freeze/samples/matplotlib/matplotlib_eg.py
+++ b/cx_Freeze/samples/matplotlib/matplotlib_eg.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+"""A simple script to demonstrate matplotlib."""
 
 from numpy import arange, sin, pi
 import matplotlib
@@ -7,7 +6,6 @@ matplotlib.use('WXAgg')
 from matplotlib.backends.backend_wxagg import FigureCanvasWxAgg as FigureCanvas
 from matplotlib.backends.backend_wx import NavigationToolbar2Wx
 from matplotlib.figure import Figure
-import sys
 import wx
 
 

--- a/cx_Freeze/samples/matplotlib/requirements.txt
+++ b/cx_Freeze/samples/matplotlib/requirements.txt
@@ -1,0 +1,2 @@
+matplotlib
+wxpython

--- a/cx_Freeze/samples/matplotlib/setup_zip.py
+++ b/cx_Freeze/samples/matplotlib/setup_zip.py
@@ -1,4 +1,5 @@
-"""A simple setup script to create two executables using matplotlib."""
+"""A simple setup script to create two executables using matplotlib
+   This version requires the mpl-data in the zip file."""
 
 # matplotlib_eg.py is a very simple matplotlib application that demonstrates
 # its use.
@@ -11,6 +12,8 @@
 # If everything works well you should find a subdirectory in the build
 # subdirectory that contains the files needed to run the application
 
+import distutils
+import os
 import sys
 from cx_Freeze import setup, Executable
 
@@ -18,12 +21,19 @@ base = 'Console'
 if sys.platform == 'win32':
     base = 'Win32GUI'
 
+dir_name = "zip.%s-%s" % \
+        (distutils.util.get_platform(), sys.version[0:3])
+build_exe_dir = os.path.join('build', dir_name)
+
 options = {
     'build_exe': {
 
         # Sometimes a little fine-tuning is needed
         # exclude all backends except wx
-        'excludes': ['gtk', 'PyQt4', 'PyQt5', 'Tkinter']
+        'excludes': ['gtk', 'PyQt4', 'PyQt5', 'Tkinter'],
+        'zip_include_packages': ["*"],
+        'zip_exclude_packages': [],
+        'build_exe': build_exe_dir
     }
 }
 


### PR DESCRIPTION
- The MATPLOTLIBDATA environment variable was deprecated (issue #569), so I implemented it in a way that can be compatible with previous versions (2.2.4 LTS, 3.0.0) and the current one (3.1.2).
- Support use of zip_include_packages = ["*"]  (the change at load_numpy is necessary too)
- Added setup_zip to show the use of zip_include_packages in matplotlib sample.
- A tiny sample to load matplotlib afm (and compare results).

Edit:
depends on PR #629