### PR TITLE
exclude Tkinter from loaded modules

### DIFF
--- a/cx_Freeze/hooks.py
+++ b/cx_Freeze/hooks.py
@@ -6,6 +6,7 @@ def initialize(finder):
     """upon initialization of the finder, this routine is called to set up some
        automatic exclusions for various platforms."""
     finder.ExcludeModule("FCNTL")
+    finder.ExcludeModule("Tkinter")
     finder.ExcludeModule("os.path")
     finder.ExcludeModule("multiprocessing.Process")
     if os.name == "nt":


### PR DESCRIPTION
Issue #567 
My comment: https://github.com/anthony-tuininga/cx_Freeze/issues/567#issuecomment-580369241
