### PR TITLE
Update hook for pkg_resources for setuptools 45.0.0.

### DIFF
--- a/cx_Freeze/hooks.py
+++ b/cx_Freeze/hooks.py
@@ -423,8 +423,13 @@ def load_PIL(finder, module):
 
 
 def load_pkg_resources(finder, module):
-    """pkg_resources dynamic load modules in a subpackage."""
+    """pkg_resources dynamic load modules in a subpackage
+       and, since setuptools 45.0.0, imports a warning-emitting module using __import__('pkg_resources.py2_warn')."""
     finder.IncludePackage("pkg_resources._vendor")
+    try:
+        finder.IncludeModule("pkg_resources.py2_warn")
+    except ImportError:
+       pass
 
 
 def load_postgresql_lib(finder, module):


### PR DESCRIPTION
- Fixes ModuleNotFoundError: No module named 'pkg_resources.py2_warn' with setuptools 45.0.0 (#579), see also https://github.com/pypa/setuptools/issues/1963
- Tested with setuptools 45.0.0 and 44.0.0 (backward compatibility) 