### PR TITLE
the pkg_resources must be loaded as a package; dynamically loaded mod…

### DIFF
--- a/cx_Freeze/hooks.py
+++ b/cx_Freeze/hooks.py
@@ -423,8 +423,9 @@ def load_PIL(finder, module):
 
 
 def load_pkg_resources(finder, module):
-    """pkg_resources dynamic load modules in a subpackage."""
-    finder.IncludePackage("pkg_resources._vendor")
+    """the pkg_resources must be loaded as a package;
+       dynamically loaded modules in subpackages is growing."""
+    finder.IncludePackage("pkg_resources")
 
 
 def load_postgresql_lib(finder, module):


### PR DESCRIPTION
…ules in subpackages is growing.
I noticed issue #579 and PR #580 and #565 

But I take a different approach and I believe that including the whole package is better and will not impact the size of the executable, since they are small modules.