### PR TITLE
support metadata to use by pkg_resources

### DIFF
--- a/cx_Freeze/finder.py
+++ b/cx_Freeze/finder.py
@@ -3,6 +3,7 @@ Base class for finding modules.
 """
 
 import dis
+import glob
 import imp
 import importlib.machinery
 import importlib.util
@@ -677,6 +678,25 @@ class Module(object):
         self.source_is_zip_file = False
         self.in_import = True
         self.store_in_file_system = True
+        self.dist_files = None
+        if file_name is not None:
+            dir_name = os.path.dirname(file_name)
+            search_path = os.path.join(dir_name, name+"-*.dist-info")
+        elif path:
+            search_path = path[0]+"-*.dist-info"
+        else:
+            search_path = None
+        if search_path:
+            pathnames = glob.glob(search_path)
+            if pathnames:
+                dist_path = pathnames[0]
+                arc_path = os.path.basename(dist_path)
+                # cache file names to use in write modules
+                dist_files = []
+                for fname in os.listdir(dist_path):
+                    dist_files.append((os.path.join(dist_path, fname),
+                                       os.path.join(arc_path, fname)))
+                self.dist_files = dist_files
 
     def __repr__(self):
         parts = ["name=%s" % repr(self.name)]

--- a/cx_Freeze/freezer.py
+++ b/cx_Freeze/freezer.py
@@ -560,7 +560,11 @@ class Freezer(object):
                         parts.append("__init__")
                     targetName = os.path.join(targetDir, *parts) + ".pyc"
                     open(targetName, "wb").write(data)
-
+                if module.dist_files:
+                    for filepath, arcname in module.dist_files:
+                        self._CopyFile(filepath,
+                                       os.path.join(targetDir, arcname),
+                                       copyDependentFiles=False)
 
             # otherwise, write to the zip file
             elif module.code is not None:
@@ -572,6 +576,9 @@ class Freezer(object):
                 if self.compress:
                     zinfo.compress_type = zipfile.ZIP_DEFLATED
                 outFile.writestr(zinfo, data)
+                if module.dist_files:
+                    for filepath, arcname in module.dist_files:
+                        outFile.write(filepath, arcname.replace("\\", "/"))
 
         # write any files to the zip file that were requested specially
         for sourceFileName, targetFileName in finder.zip_includes:

--- a/cx_Freeze/hooks.py
+++ b/cx_Freeze/hooks.py
@@ -678,6 +678,13 @@ def load_scipy_special__cephes(finder, module):
     module.AddGlobalName("gammaln")
 
 
+def load_setuptools(finder, module):
+    """the setuptools must be loaded as a package;
+       to prevent it to break in the future."""
+    finder.IncludePackage("setuptools")
+    finder.ExcludePackage("setuptools.extern")
+
+
 def load_setuptools_extension(finder, module):
     """the setuptools.extension module optionally loads
        Pyrex.Distutils.build_ext but its absence is not considered an error."""

--- a/cx_Freeze/hooks.py
+++ b/cx_Freeze/hooks.py
@@ -682,7 +682,6 @@ def load_setuptools(finder, module):
     """the setuptools must be loaded as a package;
        to prevent it to break in the future."""
     finder.IncludePackage("setuptools")
-    finder.ExcludePackage("setuptools.extern")
 
 
 def load_setuptools_extension(finder, module):


### PR DESCRIPTION
While freezing an application using pikepdf I found the need to add the dist-info directories (I decided not to use pkg_resources to determine them, and get them directly from the file system).

Edit:
This fixes #112, #216 and #586 
Edit2:
dependency removed, can be merged as is
Edit3:
Tested by a user in closed issue: https://github.com/anthony-tuininga/cx_Freeze/issues/438#issuecomment-621252979
