### PR TITLE
Add hook to importlib_metadata load.

### DIFF
--- a/cx_Freeze/hooks.py
+++ b/cx_Freeze/hooks.py
@@ -906,3 +906,15 @@ def load_sqlite3(finder, module):
         dll_path = os.path.join(sys.base_prefix, "DLLs", dll_name)
         finder.IncludeFiles(dll_path, os.path.join("lib", dll_name))
     finder.IncludePackage('sqlite3')
+
+def load_importlib_metadata(finder, module):
+    """importlib_metadata tries to extact its own metadata from dist-info on
+    import. Include dist-info in the package."""
+    importlib_metadata = __import__('importlib_metadata')
+    dist = importlib_metadata.distribution('importlib_metadata')
+    src_path = dist._path
+    dst_name = "importlib_metadata-{}.dist-info".format(dist.version)
+
+    assert src_path.is_dir()
+
+    finder.IncludeFiles(str(src_path), os.path.join('lib', dst_name))


### PR DESCRIPTION
importlib_metadata is a library which provides an API for accessing an
installed package’s metadata (see PEP 566), such as its entry points or
its top-level name. It works by finding *.egg or *.dist-info files from
installed packages. Because cx_freeze discards *.egg and *.dist-info
files on freezing, it breaks importlib_metadata.

Even worse, on import the package tries to extract its own metadata and
fails. Which makes it unloadable.

As a workaround, include .dist-info file of the package itself, allowing
it to be loaded. It won't function properly anyway because it can't find
any other package.