### PR TITLE
solving multiprocessing pickling errors (WINDOWS)

### DIFF
--- a/cx_Freeze/initscripts/Console.py
+++ b/cx_Freeze/initscripts/Console.py
@@ -11,7 +11,6 @@ import BUILD_CONSTANTS
 
 sys.frozen = True
 
-FILE_NAME = sys.executable
 DIR_NAME = os.path.dirname(sys.executable)
 
 if hasattr(BUILD_CONSTANTS, "TCL_LIBRARY"):
@@ -20,7 +19,7 @@ if hasattr(BUILD_CONSTANTS, "TCL_LIBRARY"):
 
 if hasattr(BUILD_CONSTANTS, "TK_LIBRARY"):
     os.environ["TK_LIBRARY"] = os.path.join(DIR_NAME,
-                                             BUILD_CONSTANTS.TK_LIBRARY)
+                                            BUILD_CONSTANTS.TK_LIBRARY)
 
 if hasattr(BUILD_CONSTANTS, "MATPLOTLIBDATA"):
     os.environ["MATPLOTLIBDATA"] = os.path.join(DIR_NAME,
@@ -31,7 +30,8 @@ if hasattr(BUILD_CONSTANTS, "PYTZ_TZDATADIR"):
                                                 BUILD_CONSTANTS.PYTZ_TZDATADIR)
 
 def run():
-    name, ext = os.path.splitext(os.path.basename(os.path.normcase(FILE_NAME)))
-    moduleName = "%s__main__" % name
-    code = __loader__.get_code(moduleName)
-    exec(code, {'__name__': '__main__'})
+    name = "%s__main__" % __name__[:-8]
+    code = __loader__.get_code(name)
+    m = __import__('__main__')
+    m.__dict__['__file__'] = code.co_filename
+    exec(code,  m.__dict__)

--- a/cx_Freeze/initscripts/Console.py
+++ b/cx_Freeze/initscripts/Console.py
@@ -30,7 +30,7 @@ if hasattr(BUILD_CONSTANTS, "PYTZ_TZDATADIR"):
                                                 BUILD_CONSTANTS.PYTZ_TZDATADIR)
 
 def run():
-    name = "%s__main__" % __name__[:-8]
+    name = __name__.rpartition("__init__")[0] + "__main__"
     code = __loader__.get_code(name)
     m = __import__('__main__')
     m.__dict__['__file__'] = code.co_filename

--- a/cx_Freeze/initscripts/ConsoleSetLibPath.py
+++ b/cx_Freeze/initscripts/ConsoleSetLibPath.py
@@ -13,7 +13,6 @@ import sys
 
 import BUILD_CONSTANTS
 
-FILE_NAME = sys.executable
 DIR_NAME = os.path.dirname(sys.executable)
 
 paths = os.environ.get("LD_LIBRARY_PATH", "").split(os.pathsep)
@@ -32,7 +31,7 @@ if hasattr(BUILD_CONSTANTS, "TCL_LIBRARY"):
 
 if hasattr(BUILD_CONSTANTS, "TK_LIBRARY"):
     os.environ["TK_LIBRARY"] = os.path.join(DIR_NAME,
-                                             BUILD_CONSTANTS.TK_LIBRARY)
+                                            BUILD_CONSTANTS.TK_LIBRARY)
 
 if hasattr(BUILD_CONSTANTS, "MATPLOTLIBDATA"):
     os.environ["MATPLOTLIBDATA"] = os.path.join(DIR_NAME,
@@ -43,7 +42,8 @@ if hasattr(BUILD_CONSTANTS, "PYTZ_TZDATADIR"):
                                                 BUILD_CONSTANTS.PYTZ_TZDATADIR)
 
 def run():
-    name, ext = os.path.splitext(os.path.basename(os.path.normcase(FILE_NAME)))
-    moduleName = "%s__main__" % name
-    code = __loader__.get_code(moduleName)
-    exec(code, {'__name__': '__main__'})
+    name = "%s__main__" % __name__[:-8]
+    code = __loader__.get_code(name)
+    m = __import__('__main__')
+    m.__dict__['__file__'] = code.co_filename
+    exec(code,  m.__dict__)

--- a/cx_Freeze/initscripts/ConsoleSetLibPath.py
+++ b/cx_Freeze/initscripts/ConsoleSetLibPath.py
@@ -42,7 +42,7 @@ if hasattr(BUILD_CONSTANTS, "PYTZ_TZDATADIR"):
                                                 BUILD_CONSTANTS.PYTZ_TZDATADIR)
 
 def run():
-    name = "%s__main__" % __name__[:-8]
+    name = __name__.rpartition("__init__")[0] + "__main__"
     code = __loader__.get_code(name)
     m = __import__('__main__')
     m.__dict__['__file__'] = code.co_filename


### PR DESCRIPTION
This fixes issues #539, #402, #403, #231, #536 
Tested with samples in the issues and with examples from python docs.
Here are two samples to test:

#sample1.py
```
'''test of mp'''
__version__ = '0.1'
import multiprocessing

def foo(q):
    q.put('hello')

if __name__ == '__main__':
    print(locals())
    multiprocessing.freeze_support()
    multiprocessing.set_start_method('spawn')
    q = multiprocessing.SimpleQueue()
    p = multiprocessing.Process(target=foo, args=(q,))
    p.start()
    print(q.get())
    p.join()
```
#sample2.py
```
if __name__ ==  "__main__":
    import multiprocessing
    multiprocessing.freeze_support()
    mgr = multiprocessing.Manager()
    var = [1] * 10000000 #main process will use more memory (easier to find in device mgr)
    print("before creating dict")
    mgr_dict = mgr.dict(
        {
            'test': 1
        }
    )

    print("after creating dict")
    input("...")
```
