### PR TITLE
no module named 'multiprocessing.pool'

### DIFF
--- a/cx_Freeze/hooks.py
+++ b/cx_Freeze/hooks.py
@@ -9,6 +9,7 @@ def initialize(finder):
     finder.ExcludeModule("Tkinter")
     finder.ExcludeModule("os.path")
     finder.ExcludeModule("multiprocessing.Process")
+    finder.ExcludeModule("multiprocessing.Pool")
     if os.name == "nt":
         finder.ExcludeModule("fcntl")
         finder.ExcludeModule("grp")


### PR DESCRIPTION
fix #353