### PR TITLE
Check for Mach-O using byte strings to allow case of non unicode chars

### DIFF
--- a/cx_Freeze/macdist.py
+++ b/cx_Freeze/macdist.py
@@ -177,7 +177,7 @@ class bdist_mac(Command):
         for root, dirs, dir_files in os.walk(self.binDir):
             for f in dir_files:
                 p = subprocess.Popen(("file", os.path.join(root, f)), stdout=subprocess.PIPE)
-                if "Mach-O" in p.stdout.readline().decode():
+                if b"Mach-O" in p.stdout.readline():
                     files.append(os.path.join(root, f).replace(self.binDir + "/", ""))
 
         for fileName in files:


### PR DESCRIPTION
The recent change of not encoding byte strings in bdist_mac is breaking the build. Methods using bytes should not be mixed with str. This patch unifies the relevant code to use all bytes.

NOTE: There is one step where I choose to `decode`

```python
else:
                        files.append(name.decode())
```

This is because 
```python 
filePath = os.path.join(self.binDir, fileName)
```

The `fileName` is generated from type `str` (from `os.walk`) but when we add extra files in the loop they were added as type bytes.

Currently I decode back to string then append to the list, but alternatively it may be better to encode the results of `os.walk` so that it is all bytes throughout.