### PR TITLE
fix optimize option in python 3.8

### DIFF
--- a/cx_Freeze/finder.py
+++ b/cx_Freeze/finder.py
@@ -653,6 +653,9 @@ class ModuleFinder(object):
     def SetOptimizeFlag(self, optimizeFlag):
         """Set a new value of optimize flag and returns the previous value."""
         previous = self.optimizeFlag
+        # The value of optimizeFlag is propagated according to the user's
+        # choice and checked in dist.py or main,py. This value is unlikely
+        # to be wrong, yet we check and ignore any divergent value.
         if -1 <= optimizeFlag <= 2:
             self.optimizeFlag = optimizeFlag
         return previous

--- a/cx_Freeze/finder.py
+++ b/cx_Freeze/finder.py
@@ -607,7 +607,7 @@ class ModuleFinder(object):
             moduleName = name
         info = (ext, "r", imp.PY_SOURCE)
         deferredImports = []
-        module = self._LoadModule(moduleName, 0, path, info, deferredImports)
+        module = self._LoadModule(moduleName, None, path, info, deferredImports)
         self._ImportDeferredImports(deferredImports)
         return module
 

--- a/cx_Freeze/finder.py
+++ b/cx_Freeze/finder.py
@@ -125,6 +125,7 @@ class ModuleFinder(object):
             constants_module=None, zip_includes=None):
         self.include_files = include_files or []
         self.excludes = dict.fromkeys(excludes or [])
+        self.optimizeFlag = 0
         self.path = path or sys.path
         self.replace_paths = replace_paths or []
         self.zip_include_all_packages = zip_include_all_packages
@@ -424,7 +425,8 @@ class ModuleFinder(object):
             if codeString and codeString[-1] != "\n":
                 codeString = codeString + "\n"
             try:
-                module.code = compile(codeString, path, "exec")
+                module.code = compile(codeString, path, "exec",
+                                      optimize=self.optimizeFlag)
             except SyntaxError:
                 raise ImportError("Invalid syntax in %s" % path)
         
@@ -605,8 +607,7 @@ class ModuleFinder(object):
             moduleName = name
         info = (ext, "r", imp.PY_SOURCE)
         deferredImports = []
-        module = self._LoadModule(moduleName, open(path, "U"), path, info,
-                deferredImports)
+        module = self._LoadModule(moduleName, 0, path, info, deferredImports)
         self._ImportDeferredImports(deferredImports)
         return module
 
@@ -648,6 +649,13 @@ class ModuleFinder(object):
             sys.stdout.write("This is not necessarily a problem - the modules "
                              "may not be needed on this platform.\n")
             sys.stdout.write("\n")
+
+    def SetOptimizeFlag(self, optimizeFlag):
+        """Set a new value of optimize flag and returns the previous value."""
+        previous = self.optimizeFlag
+        if -1 <= optimizeFlag <= 2:
+            self.optimizeFlag = optimizeFlag
+        return previous
 
     def ZipIncludeFiles(self, sourcePath, targetPath):
         """Include the file(s) in the library.zip"""

--- a/cx_Freeze/freezer.py
+++ b/cx_Freeze/freezer.py
@@ -349,6 +349,7 @@ class Freezer(object):
                 self.path, self.replacePaths, self.zipIncludeAllPackages,
                 self.zipExcludePackages, self.zipIncludePackages,
                 self.constantsModule, self.zipIncludes)
+        finder.SetOptimizeFlag(self.optimizeFlag)
         for name in self.namespacePackages:
             package = finder.IncludeModule(name, namespace = True)
             package.ExtendPath()
@@ -356,7 +357,6 @@ class Freezer(object):
             finder.IncludeModule(name)
         for name in self.packages:
             finder.IncludePackage(name)
-        finder.SetOptimizeFlag(self.optimizeFlag)
         return finder
 
     def _IncludeMSVCR(self, exe):

--- a/cx_Freeze/freezer.py
+++ b/cx_Freeze/freezer.py
@@ -356,6 +356,7 @@ class Freezer(object):
             finder.IncludeModule(name)
         for name in self.packages:
             finder.IncludePackage(name)
+        finder.SetOptimizeFlag(self.optimizeFlag)
         return finder
 
     def _IncludeMSVCR(self, exe):
@@ -606,8 +607,6 @@ class Freezer(object):
         self.filesCopied = {}
         self.linkerWarnings = {}
         self.msvcRuntimeDir = None
-        import cx_Freeze.util
-        cx_Freeze.util.SetOptimizeFlag(self.optimizeFlag)
 
         self.finder = self._GetModuleFinder()
         for executable in self.executables:

--- a/setup.py
+++ b/setup.py
@@ -102,34 +102,34 @@ def find_cx_Logging():
 
 commandClasses = dict(build_ext=build_ext)
 
-# build utility module
+# build base executables
 if sys.platform == "win32":
     libraries = ["imagehlp", "Shlwapi"]
 else:
     libraries = []
-utilModule = Extension("cx_Freeze.util", ["source/util.c"],
-        libraries = libraries)
-
-# build base executables
-docFiles = "README.txt"
 options = dict(install=dict(optimize=1))
 depends = ["source/bases/Common.c"]
 console = Extension("cx_Freeze.bases.Console", ["source/bases/Console.c"],
-        depends = depends, libraries = libraries)
-extensions = [utilModule, console]
+                    depends=depends, libraries=libraries)
+extensions = [console]
 if sys.platform == "win32":
     gui = Extension("cx_Freeze.bases.Win32GUI", ["source/bases/Win32GUI.c"],
-            depends = depends, libraries = libraries + ["user32"])
+                    depends=depends, libraries=libraries + ["user32"])
     extensions.append(gui)
     moduleInfo = find_cx_Logging()
     if moduleInfo is not None:
         includeDir, libraryDir = moduleInfo
         service = Extension("cx_Freeze.bases.Win32Service",
-                ["source/bases/Win32Service.c"], depends = depends,
-                library_dirs = [libraryDir],
-                libraries = libraries + ["advapi32", "cx_Logging"],
-                include_dirs = [includeDir])
+                            ["source/bases/Win32Service.c"],
+                            depends=depends,
+                            library_dirs=[libraryDir],
+                            libraries=libraries + ["advapi32", "cx_Logging"],
+                            include_dirs=[includeDir])
         extensions.append(service)
+    # build utility module
+    utilModule = Extension("cx_Freeze.util", ["source/util.c"],
+                           libraries=libraries)
+    extensions.append(utilModule)
 
 # define package data
 packageData = []

--- a/source/util.c
+++ b/source/util.c
@@ -393,25 +393,9 @@ static PyObject *ExtGetWindowsDir(
 
 
 //-----------------------------------------------------------------------------
-// ExtSetOptimizeFlag()
-//   Set the optimize flag as needed.
-//-----------------------------------------------------------------------------
-static PyObject *ExtSetOptimizeFlag(
-    PyObject *self,                     // passthrough argument
-    PyObject *args)                     // arguments
-{
-    if (!PyArg_ParseTuple(args, "i", &Py_OptimizeFlag))
-        return NULL;
-    Py_INCREF(Py_None);
-    return Py_None;
-}
-
-
-//-----------------------------------------------------------------------------
 // Methods
 //-----------------------------------------------------------------------------
 static PyMethodDef g_ModuleMethods[] = {
-    { "SetOptimizeFlag", ExtSetOptimizeFlag, METH_VARARGS },
 #ifdef MS_WINDOWS
     { "BeginUpdateResource", ExtBeginUpdateResource, METH_VARARGS },
     { "UpdateResource", ExtUpdateResource, METH_VARARGS },
@@ -461,4 +445,3 @@ PyMODINIT_FUNC PyInit_util(void)
 #endif
     return module;
 }
-


### PR DESCRIPTION
fix #639
I looked for something in the python documentation, indicating the change but I couldn't find it. I did some tests and saw that in py38 just passing the parameter -O or -OO globally set the optimize flag (it didn't work with the method that existed or using os.environ ['PYTHONOPTIMIZE']). So I decided to propagate the variable to the finder method and it is even easy to see.
So, only on win32 will we need 'cx_Freeze.util'.
Success: https://github.com/anthony-tuininga/cx_Freeze/issues/639#issuecomment-620165863