### PR TITLE
pass command line arguments in current locale - linux

### DIFF
--- a/cx_Freeze/initscripts/__startup__.py
+++ b/cx_Freeze/initscripts/__startup__.py
@@ -34,6 +34,7 @@ class ExtensionFinder(importlib.machinery.PathFinder):
 sys.meta_path.append(ExtensionFinder)
 
 def run():
+    sys.executable = os.fsencode(sys.executable).decode()
     baseName = os.path.normcase(os.path.basename(sys.executable))
     name, ext = os.path.splitext(baseName)
     module = __import__(name + "__init__")

--- a/cx_Freeze/initscripts/__startup__.py
+++ b/cx_Freeze/initscripts/__startup__.py
@@ -34,7 +34,6 @@ class ExtensionFinder(importlib.machinery.PathFinder):
 sys.meta_path.append(ExtensionFinder)
 
 def run():
-    sys.executable = os.fsencode(sys.executable).decode()
     baseName = os.path.normcase(os.path.basename(sys.executable))
     name, ext = os.path.splitext(baseName)
     module = __import__(name + "__init__")

--- a/source/bases/Console.c
+++ b/source/bases/Console.c
@@ -3,6 +3,7 @@
 //   Main routine for frozen programs which run in a console.
 //-----------------------------------------------------------------------------
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include <locale.h>
 #ifdef MS_WINDOWS
@@ -66,4 +67,3 @@ int main(int argc, char **argv)
     Py_Finalize();
     return status;
 }
-


### PR DESCRIPTION
fix #611 and fix the path and the executable. The fix is needed because currently, in Linux, sys.argv, sys.executable, and sys.path path are in utf8 with surrogate escape. (In windows, this does not happen).
Also, I changed to use PyMem_RawMalloc as recommended in the documentation for py3 (Py_DecodeLocale uses PyMem_RawMalloc too).