### PR TITLE
when building from sources, get cx_Logging to build Win32Service.exe

### DIFF
--- a/cx_Freeze/samples/service/Config.py
+++ b/cx_Freeze/samples/service/Config.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #------------------------------------------------------------------------------
 # Config.py
 #   This file defines information about the service. The first four

--- a/cx_Freeze/samples/service/ServiceHandler.py
+++ b/cx_Freeze/samples/service/ServiceHandler.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 """
 Implements a simple service using cx_Freeze.
 

--- a/cx_Freeze/samples/service/setup.py
+++ b/cx_Freeze/samples/service/setup.py
@@ -1,31 +1,31 @@
-# -*- coding: utf-8 -*-
+"""A simple setup script for creating a Windows service.
+   See the comments in the Config.py and ServiceHandler.py files for
+   more information on how to set this up.
 
-# A simple setup script for creating a Windows service. See the comments in the
-# Config.py and ServiceHandler.py files for more information on how to set this
-# up.
-#
-# Installing the service is done with the option --install <Name> and
-# uninstalling the service is done with the option --uninstall <Name>. The
-# value for <Name> is intended to differentiate between different invocations
-# of the same service code -- for example for accessing different databases or
-# using different configuration files.
+   Installing the service is done with the option --install <Name> and
+   uninstalling the service is done with the option --uninstall <Name>. The
+   value for <Name> is intended to differentiate between different invocations
+   of the same service code -- for example for accessing different databases or
+   using different configuration files.
+"""
 
 from cx_Freeze import setup, Executable
 
 options = {
-    'build_exe': {
-        'includes': ['ServiceHandler', 'cx_Logging']
+    "build_exe": {
+        "includes": ["ServiceHandler", "cx_Logging"],
+        "excludes": ["tkinter"]
     }
 }
 
 executables = [
-    Executable('Config.py', base='Win32Service',
-               targetName='cx_FreezeSampleService.exe')
+    Executable("Config.py", base="Win32Service",
+               targetName="cx_FreezeSampleService.exe")
 ]
 
-setup(name='cx_FreezeSampleService',
-      version='0.1',
-      description='Sample cx_Freeze Windows serice',
+setup(name="cx_FreezeSampleService",
+      version="0.1",
+      description="Sample cx_Freeze Windows serice",
       executables=executables,
       options=options
       )

--- a/cx_Freeze/samples/service/setup.py
+++ b/cx_Freeze/samples/service/setup.py
@@ -1,12 +1,13 @@
-"""A simple setup script for creating a Windows service.
-   See the comments in the Config.py and ServiceHandler.py files for
-   more information on how to set this up.
+"""
+A simple setup script for creating a Windows service.
+See the comments in the Config.py and ServiceHandler.py files for more
+information on how to set this up.
 
-   Installing the service is done with the option --install <Name> and
-   uninstalling the service is done with the option --uninstall <Name>. The
-   value for <Name> is intended to differentiate between different invocations
-   of the same service code -- for example for accessing different databases or
-   using different configuration files.
+Installing the service is done with the option --install <Name> and
+uninstalling the service is done with the option --uninstall <Name>. The
+value for <Name> is intended to differentiate between different invocations
+of the same service code -- for example for accessing different databases or
+using different configuration files.
 """
 
 from cx_Freeze import setup, Executable

--- a/setup.py
+++ b/setup.py
@@ -88,13 +88,27 @@ class build_ext(distutils.command.build_ext.build_ext):
 
 
 def find_cx_Logging():
-    dirName = os.path.dirname(os.getcwd())
+    import subprocess
+    dirName = os.path.dirname(os.path.dirname(os.path.os.path.abspath(__file__)))
     loggingDir = os.path.join(dirName, "cx_Logging")
+    if not os.path.exists(loggingDir):
+        try:
+            subprocess.run(["git", "clone",
+                            "https://github.com/anthony-tuininga/cx_Logging.git",
+                            loggingDir])
+        except (FileNotFoundError, subprocess.SubprocessError):
+            pass
     if not os.path.exists(loggingDir):
         return
     subDir = "implib.%s-%s" % (distutils.util.get_platform(), sys.version[:3])
     importLibraryDir = os.path.join(loggingDir, "build", subDir)
     includeDir = os.path.join(loggingDir, "src")
+    if not os.path.exists(importLibraryDir):
+        try:
+            subprocess.run([sys.executable, "setup.py", "install"],
+                           cwd=loggingDir)
+        except (FileNotFoundError, subprocess.SubprocessError):
+            pass
     if not os.path.exists(importLibraryDir):
         return
     return includeDir, importLibraryDir


### PR DESCRIPTION
fix #519 
If the source cannot be obtained, it silently fails, as it currently does.
Also:
- Win32Service - replace deprecated functions that will be removed in py4
- cleanup samples