### PR TITLE
remove dead code for namespace packages

### DIFF
--- a/cx_Freeze/finder.py
+++ b/cx_Freeze/finder.py
@@ -11,7 +11,6 @@ import logging
 import marshal
 import opcode
 import os
-import pkgutil
 import sys
 import tokenize
 import zipfile
@@ -384,8 +383,6 @@ class ModuleFinder(object):
                             namespace = namespace)
             if parentModule is None:
                 return None
-            if namespace:
-                parentModule.ExtendPath()
             path = parentModule.path
             searchName = name[pos + 1:]
 
@@ -726,11 +723,6 @@ class Module(object):
 
     def ExcludeName(self, name):
         self.exclude_names[name] = None
-
-    def ExtendPath(self):
-        self.path = pkgutil.extend_path(self.path, self.name)
-        if self.parent is not None:
-            self.parent.ExtendPath()
 
     def IgnoreName(self, name):
         self.ignore_names[name] = None

--- a/cx_Freeze/freezer.py
+++ b/cx_Freeze/freezer.py
@@ -372,8 +372,7 @@ class Freezer(object):
                 self.constantsModule, self.zipIncludes)
         finder.SetOptimizeFlag(self.optimizeFlag)
         for name in self.namespacePackages:
-            package = finder.IncludeModule(name, namespace = True)
-            package.ExtendPath()
+            finder.IncludeModule(name, namespace = True)
         for name in self.includes:
             finder.IncludeModule(name)
         for name in self.packages:

--- a/cx_Freeze/hooks.py
+++ b/cx_Freeze/hooks.py
@@ -1052,12 +1052,6 @@ def load_xmlrpclib(finder, module):
     module.IgnoreName("sgmlop")
 
 
-def load_zope(finder, module):
-    """the zope package is distributed in multiple packages and they need to be
-       stitched back together again."""
-    module.ExtendPath()
-
-
 def load_zope_component(finder, module):
     """the zope.component package requires the presence of the pkg_resources
        module but it uses a dynamic, not static import to do its work."""

--- a/cx_Freeze/samples/zope/setup.py
+++ b/cx_Freeze/samples/zope/setup.py
@@ -10,6 +10,7 @@
 # If everything works well you should find a subdirectory in the build
 # subdirectory that contains the files needed to run the application
 
+import sys
 from cx_Freeze import setup, Executable
 
 options = {

--- a/cx_Freeze/samples/zope/setup.py
+++ b/cx_Freeze/samples/zope/setup.py
@@ -10,7 +10,6 @@
 # If everything works well you should find a subdirectory in the build
 # subdirectory that contains the files needed to run the application
 
-import sys
 from cx_Freeze import setup, Executable
 
 options = {


### PR DESCRIPTION
This is cleanup for the next patch.
Currently, namespace packages should be defined by option.
ExtendPath is unnecessary in py3 (see PEP 451)
To test, run the zope sample, its build, and runs after this patch.