### PR TITLE
detect namespace packages

### DIFF
--- a/cx_Freeze/finder.py
+++ b/cx_Freeze/finder.py
@@ -398,9 +398,10 @@ class ModuleFinder(object):
         # detect namespace packages
         try:
             spec = importlib.util.find_spec(name)
-        except (AttributeError, ValueError):
+        except (AttributeError, ModuleNotFoundError, ValueError):
             spec = None
-        if spec and spec.origin is None and spec.submodule_search_locations:
+        if spec and spec.origin in (None, 'namespace') and \
+                spec.submodule_search_locations:
             path = list(spec.submodule_search_locations)[0]
             return self._LoadNamespacePackage(name, path, parentModule)
         # other modules or packages

--- a/cx_Freeze/finder.py
+++ b/cx_Freeze/finder.py
@@ -398,11 +398,11 @@ class ModuleFinder(object):
         # detect namespace packages
         try:
             spec = importlib.util.find_spec(name)
-        except ValueError:
+        except (AttributeError, ValueError):
             spec = None
         if spec and spec.origin is None and spec.submodule_search_locations:
-            return self._LoadNamespacePackage(name,
-                            spec.submodule_search_locations[0], parentModule)
+            path = list(spec.submodule_search_locations)[0]
+            return self._LoadNamespacePackage(name, path, parentModule)
         # other modules or packages
         try:
             fp, path, info = self._FindModule(searchName, path, namespace)

--- a/cx_Freeze/samples/zope/requirements.txt
+++ b/cx_Freeze/samples/zope/requirements.txt
@@ -1,0 +1,3 @@
+cx_Freeze
+twisted
+

--- a/cx_Freeze/samples/zope/setup.py
+++ b/cx_Freeze/samples/zope/setup.py
@@ -1,31 +1,23 @@
-# -*- coding: utf-8 -*-
+"""
+A simple setup script to create an executable using Zope which demonstrates
+the use of namespace packages.
 
-# A simple setup script to create an executable using Zope which demonstrates
-# the use of namespace packages.
-#
-# qotd.py is a very simple type of Zope application
-#
-# Run the build process by running the command 'python setup.py build'
-#
-# If everything works well you should find a subdirectory in the build
-# subdirectory that contains the files needed to run the application
+qotd.py is a very simple type of Zope application
 
-import sys
+Run the build process by running the command 'python setup.py build'
+
+If everything works well you should find a subdirectory in the build
+subdirectory that contains the files needed to run the application
+"""
+
 from cx_Freeze import setup, Executable
-
-options = {
-    'build_exe': {
-        'namespace_packages': ['zope']
-    }
-}
 
 executables = [
     Executable('qotd.py')
 ]
 
 setup(name='QOTD sample',
-      version='1.0',
+      version='1.1',
       description='QOTD sample for demonstrating use of namespace packages',
-      options=options,
       executables=executables
       )

--- a/cx_Freeze/samples/zope/setup.py
+++ b/cx_Freeze/samples/zope/setup.py
@@ -12,12 +12,19 @@ subdirectory that contains the files needed to run the application
 
 from cx_Freeze import setup, Executable
 
+options = {
+    "build_exe": {
+        "excludes": ["tkinter"],
+    }
+}
+
 executables = [
-    Executable('qotd.py')
+    Executable("qotd.py")
 ]
 
-setup(name='QOTD sample',
-      version='1.1',
-      description='QOTD sample for demonstrating use of namespace packages',
+setup(name="QOTD sample",
+      version="1.1",
+      description="QOTD sample for demonstrating use of namespace packages",
+      options=options,
       executables=executables
       )


### PR DESCRIPTION
With this patch, namespace packages are automatically detected.
The sample with zope is updated to reflect and test the patch.
I've tested it with a older project that use the following namespace packages:
namespace_packages = ["tgext", "paste", "zope", "repoze", "repoze.who", "repoze.who.plugins",]

Now, this is gone.

(tested in python 3.5 to 3.7 in windows and 3.8 on linux)