### PR TITLE
remove warning 'Distutils was imported before Setuptools'

### DIFF
--- a/cx_Freeze/__init__.py
+++ b/cx_Freeze/__init__.py
@@ -1,3 +1,4 @@
+import setuptools
 import sys
 from cx_Freeze.dist import bdist_rpm, build, build_exe, install, install_exe,\
     setup

--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,13 @@
 Distutils script for cx_Freeze.
 """
 
+from setuptools import setup, Extension
 import distutils.command.build_ext
 import distutils.command.install
 import distutils.command.install_data
 import distutils.sysconfig
 import os
 import sys
-
-from setuptools import setup, Extension
 
 
 if sys.version_info < (3, 5, 2):


### PR DESCRIPTION
fix #693