### PR TITLE
Code to fix issues with PyQt5-related hooks. 

### DIFF
--- a/cx_Freeze/hooks.py
+++ b/cx_Freeze/hooks.py
@@ -744,6 +744,9 @@ def _qt_implementation(module):
               "Some incorrect files may be copied.")
     return name, _qtcore
 
+def _qt_in_file_system(module):
+    return module.WillBeStoredInFileSystem()
+
 def copy_qt_plugins(plugins, finder, QtCore):
     """Helper function to find and copy Qt plugins."""
 
@@ -759,17 +762,31 @@ def copy_qt_plugins(plugins, finder, QtCore):
 def load_PyQt4_phonon(finder, module):
     """In Windows, phonon4.dll requires an additional dll phonon_ds94.dll to
        be present in the build directory inside a folder phonon_backend."""
+    if _qt_in_file_system(module): return
     name, QtCore = _qt_implementation(module)
     if WIN32:
         copy_qt_plugins("phonon_backend", finder, QtCore)
 
 load_PySide_phonon = load_PyQt5_phonon = load_PyQt4_phonon
 
+def sip_module_name(QtCore) -> str:
+    """Returns the name of the sip module to import.  (As of 5.11, the distributed wheels no longer provided for the
+    sip module outside of the PyQt5 namespace)."""
+    versionString = QtCore.PYQT_VERSION_STR
+    try:
+        pyqtVersionInts = tuple(int(c) for c in versionString.split("."))
+        if pyqtVersionInts >= (5,11):
+            return "PyQt5.sip"
+    except Exception:
+        pass
+    return "sip"
+
 def load_PyQt4_QtCore(finder, module):
     """the PyQt4.QtCore module implicitly imports the sip module and,
        depending on configuration, the PyQt4._qt module."""
+    if _qt_in_file_system(module): return
     name, QtCore = _qt_implementation(module)
-    finder.IncludeModule("sip")
+    finder.IncludeModule(sip_module_name(QtCore=QtCore))
     try:
         finder.IncludeModule("%s._qt" % name)
     except ImportError:
@@ -787,6 +804,7 @@ def load_PyQt4_Qt(finder, module):
        foolish way of doing things but perhaps there is some hidden advantage
        to this technique over pure Python; ignore the absence of some of
        the modules since not every installation includes all of them."""
+    if _qt_in_file_system(module): return
     name, QtCore = _qt_implementation(module)
     finder.IncludeModule("%s.QtCore" % name)
     finder.IncludeModule("%s.QtGui" % name)
@@ -803,6 +821,7 @@ def load_PyQt4_uic(finder, module):
     """The uic module makes use of "plugins" that need to be read directly and
        cannot be frozen; the PyQt4.QtWebKit and PyQt4.QtNetwork modules are
        also implicity loaded."""
+    if _qt_in_file_system(module): return
     name, QtCore = _qt_implementation(module)
     dir = os.path.join(module.path[0], "widget-plugins")
     finder.IncludeFiles(dir, "%s.uic.widget-plugins" % name)
@@ -827,6 +846,7 @@ def load_PyQt4_QtGui(finder, module):
     """There is a chance that GUI will use some image formats
     add the image format plugins
     """
+    if _qt_in_file_system(module): return
     name, QtCore = _qt_implementation(module)
     _QtGui(finder, module, QtCore.QT_VERSION_STR)
 
@@ -841,9 +861,11 @@ def load_PySide_QtGui(finder, module):
     _QtGui(finder, module, QtCore.__version__)
 
 def load_PyQt5_QtWidgets(finder, module):
+    if _qt_in_file_system(module): return
     finder.IncludeModule('PyQt5.QtGui')
 
 def load_PyQt4_QtWebKit(finder, module):
+    if _qt_in_file_system(module): return
     name, QtCore = _qt_implementation(module)
     finder.IncludeModule("%s.QtNetwork" % name)
     finder.IncludeModule("%s.QtGui" % name)
@@ -851,12 +873,14 @@ def load_PyQt4_QtWebKit(finder, module):
 load_PyQt5_QtWebKit = load_PySide_QtWebKit = load_PyQt4_QtWebKit
 
 def load_PyQt5_QtMultimedia(finder, module):
+    if _qt_in_file_system(module): return
     name, QtCore = _qt_implementation(module)
     finder.IncludeModule("%s.QtCore" % name)
     finder.IncludeModule("%s.QtMultimediaWidgets" % name)
     copy_qt_plugins("mediaservice", finder, QtCore)
 
 def load_PyQt5_QtPrintSupport(finder, module):
+    if _qt_in_file_system(module): return
     name, QtCore = _qt_implementation(module)
     copy_qt_plugins("printsupport", finder, QtCore)
 


### PR DESCRIPTION
Code changes to let cx_Freeze locate sip on PyQt5.11 and later.

Also disabled certain hooks that are not required if the whole PyQt package directory is being copied into the package (rather than PyQ being included in the zip file).

This can be tested with the sample in PyQt5_zip (PR: #717).  This change is only helpful if/when the changes to finding OSX binary dependencies are accepted (PR: #590) (since without that, PyQt does not work from the zip file anyway).