### PR TITLE
Small fix to handle a build constant that includes a "=" symbol.

### DIFF
--- a/cx_Freeze/freezer.py
+++ b/cx_Freeze/freezer.py
@@ -7,6 +7,7 @@ from __future__ import print_function
 import datetime
 import distutils.sysconfig
 from importlib.util import MAGIC_NUMBER
+from keyword import iskeyword
 import marshal
 import os
 import shutil
@@ -729,6 +730,12 @@ class Executable(object):
             raise ConfigError("no initscript named %s", name)
 
 
+def _isValidVariableName(name: str) -> bool:
+    """Returns True if name is a valid variable name."""
+    if not name.isidentifier(): return False
+    if iskeyword(name): return False
+    return True
+
 class ConstantsModule(object):
 
     def __init__(self, releaseString = None, copyright = None,
@@ -747,6 +754,9 @@ class ConstantsModule(object):
             else:
                 name, stringValue = parts
                 value = eval(stringValue)
+            if not _isValidVariableName(name):
+                raise Exception("Invalid constant name in ConstantsModule (\"{}\")".format(name))
+
             self.values[name] = value
 
     def Create(self, finder):

--- a/cx_Freeze/freezer.py
+++ b/cx_Freeze/freezer.py
@@ -740,7 +740,7 @@ class ConstantsModule(object):
         self.values["BUILD_RELEASE_STRING"] = releaseString
         self.values["BUILD_COPYRIGHT"] = copyright
         for constant in constants:
-            parts = constant.split("=")
+            parts = constant.split("=", maxsplit=1)
             if len(parts) == 1:
                 name = constant
                 value = None

--- a/cx_Freeze/freezer.py
+++ b/cx_Freeze/freezer.py
@@ -730,12 +730,6 @@ class Executable(object):
             raise ConfigError("no initscript named %s", name)
 
 
-def _isValidVariableName(name: str) -> bool:
-    """Returns True if name is a valid variable name."""
-    if not name.isidentifier(): return False
-    if iskeyword(name): return False
-    return True
-
 class ConstantsModule(object):
 
     def __init__(self, releaseString = None, copyright = None,
@@ -754,9 +748,8 @@ class ConstantsModule(object):
             else:
                 name, stringValue = parts
                 value = eval(stringValue)
-            if not _isValidVariableName(name):
-                raise Exception("Invalid constant name in ConstantsModule (\"{}\")".format(name))
-
+            if (not name.isidentifier()) or iskeyword(name):
+                raise ConfigError("Invalid constant name in ConstantsModule (\"{}\")".format(name))
             self.values[name] = value
 
     def Create(self, finder):


### PR DESCRIPTION
Small fix to deal with the case where a build constant includes an equal sign. For example:

```
var="abc=xyz"
```