### PR TITLE
remove 'import distutils.command.install'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,6 @@ Distutils script for cx_Freeze.
 
 from setuptools import setup, Extension
 import distutils.command.build_ext
-import distutils.command.install
-import distutils.command.install_data
 import distutils.sysconfig
 import os
 import sys


### PR DESCRIPTION
In py38 'import distutils.command.install' causes python setup.py install work different from previous versions, installing importlib-metadata as egg, not wheels