### PR TITLE
Improve Windows GUID documentation

### DIFF
--- a/doc/src/distutils.rst
+++ b/doc/src/distutils.rst
@@ -267,7 +267,7 @@ For example:
   .. code-block:: python
 
     'bdist_msi': {
-        'upgrade_code': upgrade_code,
+        'upgrade_code': "{XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}",
         'add_to_path': True,
         'environment_variables': [
             ("E_MYAPP_VAR", "=-*MYAPP_VAR", "1", "TARGETDIR")

--- a/doc/src/distutils.rst
+++ b/doc/src/distutils.rst
@@ -260,7 +260,7 @@ command:
      - define the GUID of the upgrade code for the package that is created;
        this is used to force removal of any packages created with the same
        upgrade code prior to the installation of this one; the valid format for
-       a GUID is {XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX} where X is a hex digit.
+       a GUID is {XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX} where X is a hex digit. Refer to `Windows GUID <https://docs.microsoft.com/en-us/windows/win32/api/guiddef/ns-guiddef-guid>`_.
 
 For example:
 


### PR DESCRIPTION
I recommend the changes to the GUID documentation to make the GUID feature clearer for new users of cx_Freeze. New users can easily forget to wrap the GUID in quotes and can get stuck as to why the auto-update doesn't work. I also added the Microsoft documentation link for GUID reference because I found it useful when trying to get my GUID to work. cx_Freeze is a great tool and I hope this helps the documentation.