### PR TITLE
set python initialization flags prior to Py_SetPath call to avoid warnings

### DIFF
--- a/source/bases/Common.c
+++ b/source/bases/Common.c
@@ -165,13 +165,16 @@ static int InitializePython(int argc, char **argv)
         PyMem_RawFree(path);
         return FatalError("Unable to convert path to string!");
     }
+
+    // set initialization flags prior Py_SetPath
+    Py_NoSiteFlag = 1;
+    Py_FrozenFlag = 1;
+    Py_IgnoreEnvironmentFlag = 1;
+
     Py_SetPath(wpath);
     PyMem_RawFree(wpath);
 
     // initialize Python
-    Py_NoSiteFlag = 1;
-    Py_FrozenFlag = 1;
-    Py_IgnoreEnvironmentFlag = 1;
     Py_Initialize();
 
     // set sys.executable


### PR DESCRIPTION
Related to https://github.com/marcelotduarte/cx_Freeze/issues/748 issue. 
After I build from master sources I was able to run binary, but I faced with next warnings on start:

Could not find platform independent libraries <prefix>
Could not find platform dependent libraries <exec_prefix>
Consider setting $PYTHONHOME to <prefix>[:<exec_prefix>]

This happens due to Python configuration read two times - in  Py_SetPath and Py_Initialize. 
According to this - Python Flags (Py_NoSiteFlag) must be set before both of them