### PR TITLE
Cause MSI file to be released at the end of bdist_msi command.

### DIFF
--- a/cx_Freeze/windist.py
+++ b/cx_Freeze/windist.py
@@ -455,6 +455,10 @@ class bdist_msi(distutils.command.bdist_msi.bdist_msi):
             distutils.dir_util.remove_tree(self.bdist_dir,
                     dry_run = self.dry_run)
 
+        # Cause the MSI file to be released.  Without this, then if bdist_msi is run programmatically
+        # from within a larger script, subsequent editting of the MSI is blocked.
+        self.db = None
+
 
 def is_valid_GUID(code):
     pattern = re.compile(r"^\{[0-9A-F]{8}-([0-9A-F]{4}-){3}[0-9A-F]{12}\}$",


### PR DESCRIPTION
When the bdist_msi command is run from within a larger script, then the .db member was not being released at the end of the command.  As a result the .msi remained locked blocking changes by other programs. This change corrects this.

(In my particular case, I have a script that runs the bdist_msi command (via distutils.core.run_setup) and then uses signtool.exe to sign the resulting msi.  Signtools.exe was failing because the file was still open.)