### PR TITLE
Update version in __init__.py

### DIFF
--- a/cx_Freeze/__init__.py
+++ b/cx_Freeze/__init__.py
@@ -16,5 +16,5 @@ elif sys.platform == "darwin":
 from cx_Freeze.finder import Module, ModuleFinder
 from cx_Freeze.freezer import ConfigError, ConstantsModule, Executable, Freezer
 
-__version__ = "6.2"
+__version__ = "6.4"
 version = __version__


### PR DESCRIPTION
I noticed that both 6.3 and 6.4 release packages report their version as 6.2, still — the `__version__` in `init.py` isn't being updated. Seems like either a release procedure or script is missing a step to bump that.

Perhaps I should be bumping it to 6.5 here, in fact. Regardless, the point of this PR isn't really to bump the version. It's primarily to call attention to the fact that it's not getting incremented for each release.