### PR TITLE
pin importlib_metadata version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ keywords =
 [options]
 python_requires = >=3.6
 install_requires =
-    importlib_metadata >= 1.6.1
+    importlib_metadata >= 3.1.1
 # https://setuptools.readthedocs.io/en/latest/setuptools.html#setting-the-zip-safe-flag
 zip_safe = False
 


### PR DESCRIPTION
pin importlib_metadata to >=3.1.1, as there was error in https://github.com/python/importlib_metadata/issues/261