### PR TITLE
Removed rpath-lib-folder option from bdist_mac

### DIFF
--- a/cx_Freeze/macdist.py
+++ b/cx_Freeze/macdist.py
@@ -2,6 +2,7 @@ from distutils.core import Command
 import os
 import plistlib
 import subprocess
+import warnings
 
 from cx_Freeze.common import normalize_to_list
 
@@ -157,7 +158,7 @@ class bdist_mac(Command):
         (
             "rpath-lib-folder",
             None,
-            "replace @rpath with given folder for any files",
+            "[DEPRECIATED]",
         ),
     ]
 
@@ -177,6 +178,11 @@ class bdist_mac(Command):
 
     def finalize_options(self):
         self.include_frameworks = normalize_to_list(self.include_frameworks)
+        if self.rpath_lib_folder is not None:
+            warnings.warn(
+                "rpath-lib-folder is obsolete and will be removed in the next version"
+            )
+
 
     def create_plist(self):
         """Create the Contents/Info.plist file"""

--- a/cx_Freeze/macdist.py
+++ b/cx_Freeze/macdist.py
@@ -158,7 +158,7 @@ class bdist_mac(Command):
         (
             "rpath-lib-folder",
             None,
-            "[DEPRECIATED]",
+            "DEPRECATED.  Will be removed in next version.",
         ),
     ]
 

--- a/doc/src/distutils.rst
+++ b/doc/src/distutils.rst
@@ -332,7 +332,7 @@ bundle (a .app directory).
    * - absolute_reference_path
      - Path to use for all referenced libraries instead of @executable_path
    * - rpath_lib_folder
-     - **[DEPRECIATED]** Will be removed in next version. (Formerly replaced @rpath with given folder for any files.)
+     - **DEPRECATED**. Will be removed in next version. (Formerly replaced @rpath with given folder for any files.)
 
 .. versionadded:: 4.3
 

--- a/doc/src/distutils.rst
+++ b/doc/src/distutils.rst
@@ -332,7 +332,7 @@ bundle (a .app directory).
    * - absolute_reference_path
      - Path to use for all referenced libraries instead of @executable_path
    * - rpath_lib_folder
-     - replace @rpath with given folder for any files
+     - **[DEPRECIATED]** Will be removed in next version. (Formerly replaced @rpath with given folder for any files.)
 
 .. versionadded:: 4.3
 


### PR DESCRIPTION
This pull would remove the rpath-lib-folder option, which no longer does anything (the option is literally never used in the code) after the recent changes that added the darwintools module.  Previously, that option would determine the value of rpath used when determining dependencies on OSX.  Now, rpath is determined by looking at the values specified in the linking binaries.

The other alternative I can see are:
1. Mark the option as depreciated, and print a warning when a setup script is run that uses the option.  That way old setup scripts will continue to run, but the user will at least be warned that the rpath-lib-folder is no longer doing what it used to do.

2. Allow the option, if set, to override the determination of the rpath in the darwintools module. I suppose in theory someone might have a script that actually depended on the older behaviour, and that was not fixed by the darwintools changes.