### PR TITLE
Suppress additional output if --silent has been set.

### DIFF
--- a/cx_Freeze/dist.py
+++ b/cx_Freeze/dist.py
@@ -140,8 +140,6 @@ class build_exe(distutils.core.Command):
             "[default: *]",
         ),
         ("silent", "s", "suppress all output except warnings"),
-        ("no-missing-warnings", "n", "suppress warnings concerning missing modules"),
-
     ]
     boolean_options = ["no-compress", "include_msvcr", "silent"]
 
@@ -212,7 +210,6 @@ class build_exe(distutils.core.Command):
         self.path = None
         self.include_msvcr = None
         self.silent = None
-        self.no_missing_warnings = None
 
     def finalize_options(self):
         self.set_undefined_options("build", ("build_exe", "build_exe"))
@@ -220,9 +217,6 @@ class build_exe(distutils.core.Command):
 
         if self.silent is None:
             self.silent = False
-
-        if self.no_missing_warnings is None:
-            self.no_missing_warnings = False
 
         # Make sure all options of multiple values are lists
         for option in self.list_options:
@@ -254,7 +248,6 @@ class build_exe(distutils.core.Command):
             binExcludes=self.bin_excludes,
             zipIncludes=self.zip_includes,
             silent=self.silent,
-            noMissingWarnings=self.no_missing_warnings,
             binPathIncludes=self.bin_path_includes,
             binPathExcludes=self.bin_path_excludes,
             metadata=metadata,

--- a/cx_Freeze/dist.py
+++ b/cx_Freeze/dist.py
@@ -140,6 +140,8 @@ class build_exe(distutils.core.Command):
             "[default: *]",
         ),
         ("silent", "s", "suppress all output except warnings"),
+        ("no-missing-warnings", "n", "suppress warnings concerning missing modules"),
+
     ]
     boolean_options = ["no-compress", "include_msvcr", "silent"]
 
@@ -210,6 +212,7 @@ class build_exe(distutils.core.Command):
         self.path = None
         self.include_msvcr = None
         self.silent = None
+        self.no_missing_warnings = None
 
     def finalize_options(self):
         self.set_undefined_options("build", ("build_exe", "build_exe"))
@@ -217,6 +220,9 @@ class build_exe(distutils.core.Command):
 
         if self.silent is None:
             self.silent = False
+
+        if self.no_missing_warnings is None:
+            self.no_missing_warnings = False
 
         # Make sure all options of multiple values are lists
         for option in self.list_options:
@@ -248,6 +254,7 @@ class build_exe(distutils.core.Command):
             binExcludes=self.bin_excludes,
             zipIncludes=self.zip_includes,
             silent=self.silent,
+            noMissingWarnings=self.no_missing_warnings,
             binPathIncludes=self.bin_path_includes,
             binPathExcludes=self.bin_path_excludes,
             metadata=metadata,

--- a/cx_Freeze/freezer.py
+++ b/cx_Freeze/freezer.py
@@ -56,7 +56,6 @@ class Freezer:
         includeFiles: Optional[List] = None,
         zipIncludes: Optional[List] = None,
         silent: bool = False,
-        noMissingWarnings: bool = False,
         metadata: Optional[DistributionMetadata] = None,
         includeMSVCR: bool = False,
         zipIncludePackages: Optional[List[str]] = None,
@@ -86,7 +85,6 @@ class Freezer:
         self.includeFiles = process_path_specs(includeFiles)
         self.zipIncludes = process_path_specs(zipIncludes)
         self.silent = silent
-        self.noMissingWarnings = noMissingWarnings
         self.metadata = metadata
         self.zipIncludePackages = list(zipIncludePackages or [])
         self.zipExcludePackages = list(zipExcludePackages or [])
@@ -594,8 +592,7 @@ class Freezer:
 
         if not self.silent:
             self._PrintReport(fileName, modules)
-        if not self.noMissingWarnings:
-            finder.ReportMissingModules()
+        finder.ReportMissingModules()
 
         targetDir = os.path.dirname(fileName)
         self._CreateDirectory(targetDir)

--- a/cx_Freeze/freezer.py
+++ b/cx_Freeze/freezer.py
@@ -56,6 +56,7 @@ class Freezer:
         includeFiles: Optional[List] = None,
         zipIncludes: Optional[List] = None,
         silent: bool = False,
+        noMissingWarnings: bool = False,
         metadata: Optional[DistributionMetadata] = None,
         includeMSVCR: bool = False,
         zipIncludePackages: Optional[List[str]] = None,
@@ -85,6 +86,7 @@ class Freezer:
         self.includeFiles = process_path_specs(includeFiles)
         self.zipIncludes = process_path_specs(zipIncludes)
         self.silent = silent
+        self.noMissingWarnings = noMissingWarnings
         self.metadata = metadata
         self.zipIncludePackages = list(zipIncludePackages or [])
         self.zipExcludePackages = list(zipExcludePackages or [])
@@ -592,7 +594,8 @@ class Freezer:
 
         if not self.silent:
             self._PrintReport(fileName, modules)
-        finder.ReportMissingModules()
+        if not self.noMissingWarnings:
+            finder.ReportMissingModules()
 
         targetDir = os.path.dirname(fileName)
         self._CreateDirectory(targetDir)
@@ -631,7 +634,8 @@ class Freezer:
                 targetPackageDir = os.path.join(targetDir, *parts)
                 sourcePackageDir = os.path.dirname(module.file)
                 if not os.path.exists(targetPackageDir):
-                    print("Copying data from package", module.name + "...")
+                    if not self.silent:
+                        print("Copying data from package", module.name + "...")
                     shutil.copytree(
                         sourcePackageDir,
                         targetPackageDir,

--- a/cx_Freeze/macdist.py
+++ b/cx_Freeze/macdist.py
@@ -29,14 +29,17 @@ class bdist_dmg(Command):
             "Boolean for whether to include "
             "shortcut to Applications in the DMG disk image",
         ),
+        ("silent", "s", "suppress all output except warnings")
     ]
 
     def initialize_options(self):
         self.volume_label = self.distribution.get_fullname()
         self.applications_shortcut = False
+        self.silent = None
 
     def finalize_options(self):
-        pass
+        if self.silent is None:
+            self.silent = False
 
     def buildDMG(self):
         # Remove DMG if it already exists
@@ -46,6 +49,10 @@ class bdist_dmg(Command):
         createargs = [
             "hdiutil",
             "create",
+        ]
+        if self.silent:
+            createargs += [ "-quiet" ]
+        createargs += [
             "-fs",
             "HFSX",
             "-format",

--- a/doc/src/distutils.rst
+++ b/doc/src/distutils.rst
@@ -176,8 +176,6 @@ It can be further customized:
        zip file (the default)
    * - silent (-s)
      - suppress all output except warnings
-   * - no_missing_warnings (-n)
-     - suppress warnings concerning missing modules
 
 
 install
@@ -381,8 +379,6 @@ installation.
    * - applications_shortcut
      - Boolean for whether to include shortcut to Applications in the DMG disk
        image
-   * - silent (-s)
-     - suppress all output except warnings
 
 .. versionadded:: 4.3
 

--- a/doc/src/distutils.rst
+++ b/doc/src/distutils.rst
@@ -379,6 +379,8 @@ installation.
    * - applications_shortcut
      - Boolean for whether to include shortcut to Applications in the DMG disk
        image
+   * - silent (-s)
+     - suppress all output except warnings
 
 .. versionadded:: 4.3
 

--- a/doc/src/distutils.rst
+++ b/doc/src/distutils.rst
@@ -176,6 +176,8 @@ It can be further customized:
        zip file (the default)
    * - silent (-s)
      - suppress all output except warnings
+   * - no_missing_warnings (-n)
+     - suppress warnings concerning missing modules
 
 
 install
@@ -379,6 +381,8 @@ installation.
    * - applications_shortcut
      - Boolean for whether to include shortcut to Applications in the DMG disk
        image
+   * - silent (-s)
+     - suppress all output except warnings
 
 .. versionadded:: 4.3
 


### PR DESCRIPTION
This makes the script a bit closer to silent when "silent" operation has been specified.