### PR TITLE
Correct test failures when initializing ModuleFinder

### DIFF
--- a/cx_Freeze/finder.py
+++ b/cx_Freeze/finder.py
@@ -57,7 +57,7 @@ class ModuleFinder:
         self.aliases = {}
         self.exclude_dependent_files = {}
         self._modules = dict.fromkeys(
-            excludes
+            excludes or []
         )  # type: Dict[str, Optional[Module]]
         self._builtin_modules = dict.fromkeys(sys.builtin_module_names)
         self._bad_modules = {}


### PR DESCRIPTION
Fixes errors like the following one:

```
======================================================================
ERROR: test_finder.test_ScanCode
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3.9/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/build/python-cx_freeze/src/cx_Freeze-6.4/test/test_finder.py", line 13, in test_ScanCode
    mf = ModuleFinder()
  File "/build/python-cx_freeze/src/cx_Freeze-6.4/cx_Freeze/finder.py", line 164, in __init__
    self._modules = dict.fromkeys(
TypeError: 'NoneType' object is not iterable
```