### PR TITLE
Standardize InitializePython on all platforms.

### DIFF
--- a/source/bases/Console.c
+++ b/source/bases/Console.c
@@ -4,6 +4,7 @@
 //-----------------------------------------------------------------------------
 
 #define PY_SSIZE_T_CLEAN
+
 #include <Python.h>
 #include <locale.h>
 #ifdef MS_WINDOWS
@@ -50,9 +51,6 @@ static int FatalScriptError(void)
 //-----------------------------------------------------------------------------
 #if defined(MS_WINDOWS)
 int wmain(int argc, wchar_t **argv)
-#else
-int main(int argc, char **argv)
-#endif
 {
     size_t status = 0;
 
@@ -63,6 +61,42 @@ int main(int argc, char **argv)
     // do the work
     if (status == 0 && ExecuteScript() < 0)
         status = 1;
+
     Py_Finalize();
     return status;
 }
+#else
+int main(int argc, char **argv)
+{
+    size_t status = 0;
+    wchar_t **wargv;
+    int i;
+
+    // convert arguments to wide characters, using the system default locale
+    setlocale(LC_ALL, "");
+    wargv = PyMem_RawMalloc(sizeof(wchar_t*) * argc);
+    if (!wargv)
+        return FatalError("Out of memory converting arguments!");
+    for (i = 0; i < argc; i++) {
+        wargv[i] = Py_DecodeLocale(argv[i], NULL);
+        if (!wargv[i])
+            return FatalError("Unable to convert argument to string!");
+    }
+
+    // initialize Python
+    if (InitializePython(argc, wargv) < 0)
+        status = 1;
+
+    // do the work
+    if (status == 0 && ExecuteScript() < 0)
+        status = 1;
+
+    // free the memory
+    for (i = 0; i < argc; i++)
+        PyMem_RawFree(wargv[i]);
+    PyMem_RawFree(wargv);
+
+    Py_Finalize();
+    return status;
+}
+#endif


### PR DESCRIPTION
* the internal API for POSIX platforms is the same as windows
* affected functions: InitializePython, SetExecutableName
* convert arguments to wide characters, using the system default locale
