### PR TITLE
Avoid the __main__ module from pip wheel

### DIFF
--- a/cx_Freeze/hooks.py
+++ b/cx_Freeze/hooks.py
@@ -38,6 +38,7 @@ def initialize(finder: ModuleFinder) -> None:
     ):
         finder.ExcludeModule("email." + name)
     finder.ExcludeModule("__builtin__")
+    finder.ExcludeModule("__main__")
     finder.ExcludeModule("_winreg")
     finder.ExcludeModule("audiodev")
     finder.ExcludeModule("anydbm")


### PR DESCRIPTION
When the user has a recent pip and recent wheel installed, the cxfreeze command line is installed as one executable file - cxfreeze.exe - with the main module inside it. Previously, a second file - cxfreeze-script.py - was used. Now, the can be detected by the finder and causes error described in #891.