### PR TITLE
Update hooks for pyzmq 22

### DIFF
--- a/cx_Freeze/hooks.py
+++ b/cx_Freeze/hooks.py
@@ -1328,7 +1328,13 @@ def load_zmq(finder: ModuleFinder, module: Module) -> None:
                 os.path.join(module.path[0], filename), filename
             )
         except (ImportError, AttributeError):
-            pass  # No bundled libzmq library
+            # For pyzmq 22 the libzmq dependencies are located in site-packages/pyzmq.libs
+            libzmq_folder = "pyzmq.libs"
+            libs_path = os.path.abspath(os.path.join(module.path[0], os.pardir, libzmq_folder))
+            if os.path.exists(libs_path):
+                finder.IncludeFiles(libs_path, os.path.join('lib', libzmq_folder))
+            else:
+                pass  # No bundled libzmq library
 
 
 def load_zoneinfo(finder: ModuleFinder, module: Module) -> None:

--- a/cx_Freeze/samples/pyzmq/pyzmq_client.py
+++ b/cx_Freeze/samples/pyzmq/pyzmq_client.py
@@ -1,0 +1,26 @@
+import sys
+import zmq
+
+if len(sys.argv) > 1:
+    port = int(sys.argv[1])
+else:
+    port = 5556
+
+url = f"tcp://localhost:{port}"
+request = "Ping"
+
+context = zmq.Context()
+socket = context.socket(zmq.REQ)
+
+try:
+    print(f"Client connecting to {url}")
+    with socket.connect(url):
+        while True:
+            print(f"Client sending: {request}")
+            socket.send_string(request)
+            reply = socket.recv_string()
+            print(f"Client received: {reply}")
+except KeyboardInterrupt:
+    sys.exit(0)
+
+

--- a/cx_Freeze/samples/pyzmq/pyzmq_server.py
+++ b/cx_Freeze/samples/pyzmq/pyzmq_server.py
@@ -1,0 +1,28 @@
+import time
+import sys
+import zmq
+
+if len(sys.argv) > 1:
+    port = int(sys.argv[1])
+else:
+    port = 5556
+
+url = f"tcp://*:{port}"
+reply = "Pong"
+
+context = zmq.Context()
+socket = context.socket(zmq.REP)
+socket.bind(url)
+
+
+try:
+    print(f"Server listening at {url}")
+    while True:
+        message = socket.recv_string()
+        print(f"Server received: {message}")
+        time.sleep(1)
+        print(f"Server sending: {reply}")
+        socket.send_string(reply)
+except KeyboardInterrupt:
+    sys.exit(0)
+

--- a/cx_Freeze/samples/pyzmq/setup.py
+++ b/cx_Freeze/samples/pyzmq/setup.py
@@ -1,0 +1,17 @@
+# A setup script to demonstrate the use of pyzmq
+#
+# Run the build process by running the command 'python setup.py build'
+#
+# If everything works well you should find a subdirectory in the build
+# subdirectory that contains the files needed to run the script without Python
+
+from cx_Freeze import setup, Executable
+
+setup(
+    name="test_pyzmq",
+    version="0.1",
+    description="cx_Freeze script to test pyzmq server and client",
+    executables=[Executable("pyzmq_server.py"), Executable("pyzmq_client.py")],
+    options={
+        "build_exe": {"excludes": ["tkinter"]},}
+)


### PR DESCRIPTION
import zmq.libzmq fails for pyzmq 22 on windows and therefore the libzmq dependencies are not included when freezing. The libzmq
dependencies are found in %ZMQ_MODULE_PATH%/../pyzmq.libs for pyzmq 22

Not sure if this is a permanent change in pyzmq or if the behavior will change again in the future, but i assume my changes won't break anything on the cx_Freeze side if that happens

fixes #950