### PR TITLE
Update hooks for pyzmq 22

### DIFF
--- a/cx_Freeze/hooks.py
+++ b/cx_Freeze/hooks.py
@@ -1328,7 +1328,13 @@ def load_zmq(finder: ModuleFinder, module: Module) -> None:
                 os.path.join(module.path[0], filename), filename
             )
         except (ImportError, AttributeError):
-            pass  # No bundled libzmq library
+            # For pyzmq 22 the libzmq dependencies are located in site-packages/pyzmq.libs
+            libzmq_folder = "pyzmq.libs"
+            libs_path = os.path.abspath(os.path.join(module.path[0], os.pardir, libzmq_folder))
+            if os.path.exists(libs_path):
+                finder.IncludeFiles(libs_path, os.path.join('lib', libzmq_folder))
+            else:
+                pass  # No bundled libzmq library
 
 
 def load_zoneinfo(finder: ModuleFinder, module: Module) -> None:

--- a/cx_Freeze/hooks.py
+++ b/cx_Freeze/hooks.py
@@ -1330,11 +1330,10 @@ def load_zmq(finder: ModuleFinder, module: Module) -> None:
         except (ImportError, AttributeError):
             # For pyzmq 22 the libzmq dependencies are located in site-packages/pyzmq.libs
             libzmq_folder = "pyzmq.libs"
-            libs_path = os.path.abspath(os.path.join(module.path[0], os.pardir, libzmq_folder))
+            libs_path = os.path.join(os.path.dirname(module.path[0]), libzmq_folder)
+            # if the pyzmq.libs folder does not exists, assume libzmq is not bundled
             if os.path.exists(libs_path):
-                finder.IncludeFiles(libs_path, os.path.join('lib', libzmq_folder))
-            else:
-                pass  # No bundled libzmq library
+                finder.IncludeFiles(libs_path, os.path.join("lib", libzmq_folder))
 
 
 def load_zoneinfo(finder: ModuleFinder, module: Module) -> None:


### PR DESCRIPTION
import zmq.libzmq fails for pyzmq 22 on windows. The libzmq
dependencies are found in %ZMQ_MODULE_PATH%/../pyzmq.libs

Resolves #950 