### PR TITLE
Store a copy of cached dist-info

### DIFF
--- a/cx_Freeze/finder.py
+++ b/cx_Freeze/finder.py
@@ -8,6 +8,7 @@ import importlib.machinery
 import logging
 import os
 import sys
+from tempfile import TemporaryDirectory
 from types import CodeType
 from typing import Dict, List, Optional, Tuple, Union
 import opcode
@@ -65,6 +66,7 @@ class ModuleFinder:
         self._bad_modules = {}
         self._hooks = __import__("cx_Freeze", fromlist=["hooks"]).hooks
         self._hooks.initialize(self)
+        self.dist_cachedir = TemporaryDirectory(prefix="cxfreeze")
         self._add_base_modules()
 
     def _add_base_modules(self) -> None:
@@ -102,7 +104,9 @@ class ModuleFinder:
         """
         module = self._modules.get(name)
         if module is None:
-            module = Module(name, path, file_name, parent)
+            module = Module(
+                name, path, file_name, parent, dist_cachedir=self.dist_cachedir
+            )
             self._modules[name] = module
             self.modules.append(module)
             if name in self._bad_modules:

--- a/cx_Freeze/freezer.py
+++ b/cx_Freeze/freezer.py
@@ -715,11 +715,12 @@ class Freezer:
                 zinfo.compress_type = compress_type
                 outFile.writestr(zinfo, data)
 
-            # put the distribution files metadata in the zip file
-            if module.dist_files:
-                for filepath, arcname in module.dist_files:
-                    if arcname not in outFile.namelist():
-                        outFile.write(filepath, arcname)
+        # put the distribution files metadata in the zip file
+        dist_cachedir = finder.dist_cachedir.name
+        for dirpath, _, filenames in os.walk(dist_cachedir):
+            basedir = dirpath[len(dist_cachedir) + 1 :].replace("\\", "/")
+            for name in filenames:
+                outFile.write(os.path.join(dirpath, name), f"{basedir}/{name}")
 
         # write any files to the zip file that were requested specially
         for sourceFileName, targetFileName in finder.zip_includes:


### PR DESCRIPTION
* The dist-info files can be modified on hooks, using the cached file.
* On freezer an optimization happens because the slow ZipFile.namelist is not more necessary.
