### PR TITLE
Add hook for pandas and fix a waning in the sample

### DIFF
--- a/cx_Freeze/hooks.py
+++ b/cx_Freeze/hooks.py
@@ -733,6 +733,12 @@ def load_Numeric(finder: ModuleFinder, module: Module) -> None:
     module.IgnoreName("dotblas")
 
 
+def load_pandas(finder: ModuleFinder, module: Module) -> None:
+    """The pandas has dynamic imports."""
+    finder.IncludePackage("pandas._libs")
+    finder.ExcludeModule("pandas.tests")
+
+
 def load_pikepdf(finder: ModuleFinder, module: Module) -> None:
     """The pikepdf must be loaded as a package."""
     finder.IncludePackage("pikepdf")

--- a/cx_Freeze/samples/pandas/test_pandas.py
+++ b/cx_Freeze/samples/pandas/test_pandas.py
@@ -5,5 +5,5 @@ print("pandas version", pd.__version__)
 
 df = pd.DataFrame(np.random.random(size=(100, 5)))
 corr_mat = df.corr()
-mask = np.tril(np.ones_like(corr_mat, dtype=np.bool), k=-1)
+mask = np.tril(np.ones_like(corr_mat, dtype=bool), k=-1)
 print(corr_mat.where(mask))


### PR DESCRIPTION
The hook is necessary when using zip_include_packages
The warning is related to numpy 1.20