### PR TITLE
Only copy a file if should copy a file

### DIFF
--- a/cx_Freeze/freezer.py
+++ b/cx_Freeze/freezer.py
@@ -116,6 +116,9 @@ class Freezer:
         includeMode=False,
         machOReference: Optional[MachOReference] = None,
     ):
+        if not self._ShouldCopyFile(source):
+            return
+
         normalizedSource = os.path.normcase(os.path.normpath(source))
         normalizedTarget = os.path.normcase(os.path.normpath(target))
         norm_target_name = os.path.basename(normalizedTarget)
@@ -447,12 +450,6 @@ class Freezer:
                         dependentFile = dependentFile[:pos].strip()
                     if dependentFile:
                         dependentFiles.append(dependentFile)
-
-            dependentFiles = [
-                os.path.normcase(f)
-                for f in dependentFiles
-                if self._ShouldCopyFile(f)
-            ]
             self.dependentFiles[path] = dependentFiles
         return dependentFiles
 
@@ -565,11 +562,12 @@ class Freezer:
         self.binExcludes = [os.path.normcase(name) for name in filenames]
 
         paths = list(self.binPathIncludes or [])
+        paths += [path for path in self.path if os.path.isdir(path)]
         self.binPathIncludes = [os.path.normcase(name) for name in paths]
 
         paths = list(self.binPathExcludes or [])
         paths += self._GetDefaultBinPathExcludes()
-        self.binPathExcludes = [os.path.normcase(n) for n in paths]
+        self.binPathExcludes = [os.path.normcase(name) for name in paths]
 
         # control runtime files
         self.runtime_files = set()


### PR DESCRIPTION
Files marked in the exclusion list were being copied. Files were only excluded when they were detected as a dependency, however, when the entire folder was copied, unnecessary files were copied. Packages like pyqt5 and pyside2 have many duplicate files and were copied and generated a list of dependencies in another directory again.
Now, that is over, and I hope it does not cause regressions (at least it did not in my tests and my projects).