### PR TITLE
Use the delay load to compile Win32Service

### DIFF
--- a/cx_Freeze/freezer.py
+++ b/cx_Freeze/freezer.py
@@ -341,7 +341,7 @@ class Freezer:
         because they are part of a package which requires independent
         installation anyway."""
         if sys.platform == "win32":
-            return ["comctl32.dll", "oci.dll", "cx_Logging.pyd"]
+            return ["comctl32.dll", "oci.dll"]
         return ["libclntsh.so", "libwtc9.so", "ldd"]
 
     def _GetDefaultBinIncludes(self):

--- a/setup.py
+++ b/setup.py
@@ -185,7 +185,8 @@ if __name__ == "__main__":
             ["source/bases/Win32Service.c"],
             depends=depends,
             include_dirs=[get_cx_logging_h_dir()],
-            libraries=libraries + ["advapi32", "cx_Logging"],
+            extra_link_args=["/DELAYLOAD:cx_Logging"],
+            libraries=libraries + ["advapi32"],
         )
         extensions.append(service)
         # build utility module


### PR DESCRIPTION
With the recent changes needed to correct the location of DLLs and avoid copying excess od DLLs, it ended up breaking a load of cx_Logging C interface (yes, it has a dual interface), but with the delay load, this is resolved.