### PR TITLE
Add extension registration on Windows

### DIFF
--- a/cx_Freeze/samples/msi_extensions/README.md
+++ b/cx_Freeze/samples/msi_extensions/README.md
@@ -1,0 +1,31 @@
+This sample shows how to register a program as handling some file types on windows, using msi features, with minimal supplement of direct registry modifications.
+
+There’s a single option to modify, with a list of dicts, one per file-type association, each comprised of:
+1. a file type (extension without leading .)
+2. an executable
+3. a verb, e.g. “open”
+4. optionally arguments, e.g. `"%1"` for proper quoting, but any other program arguments can be passed (see sample),
+5. optionally a context menu display name for the association, defaults to `{program name} {verb}`
+6. optionally a mime type associated with the extension
+
+Building & installing the sample from this directory modifies the context menu for the specified extensions / file types `.log` and `.txt`:
+- it primarily adds an entry the « Open With » submenu for these files,
+- when the program is selected as default handler for the file type, it also modifies the top options of the context menu (one per verb for the extension)
+
+The executable + argument are called with the file when an action is selected. 
+
+This works for all-users (`all_users=True` in bdist_msi options) as well as current-user installs.
+
+
+---
+
+Under the hood, cx_Freeze populates MSI tables: extension, verb, mime, progid, and slightly modifies components.
+
+**Component**: Executables are bundled into separate `Component`s (with the executable as its `keyfile`), meaning 1 per directory + 1 per executable. There is a tiny risk of Component id clashes (if there are directories named `_cx_executable{N}_{executable base name}`). 
+
+**ProgId**: The `progId` are generated and as close as possible to [recommendations](https://docs.microsoft.com/en-us/windows/win32/shell/fa-progids), which are `[Vendor or Application].[Component].[Version]`.
+
+Additionally, 2 types of registry keys are added, which are needed:
+- `FriendlyAppName`: to set a display name other than the executable’s file name (`Hello Program` instead of `hello.exe` in the Open With submenu)
+- `ApplicationCompany`: to have the application show directly in the « Open With » submenu rather than only in the « Choose another program » dialog from the « Open With » submenu.
+ 

--- a/cx_Freeze/samples/msi_extensions/hello.py
+++ b/cx_Freeze/samples/msi_extensions/hello.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+
+from datetime import datetime
+import sys
+
+print("Hello from cx_Freeze")
+print(
+    "The current date is {}\n".format(
+        datetime.today().strftime("%B %d, %Y %H:%M:%S")
+    )
+)
+
+print(f"Executable: {sys.executable}")
+print(f"Prefix: {sys.prefix}")
+print(f"Default encoding: {sys.getdefaultencoding()}")
+print(f"File system encoding: {sys.getfilesystemencoding()}\n")
+
+print("ARGUMENTS:")
+for a in sys.argv:
+    print(f"{a}")
+print("")
+
+print("PATH:")
+for p in sys.path:
+    print(f"{p}")
+print()
+
+input("Press Enter to continue...")

--- a/cx_Freeze/samples/msi_extensions/setup.py
+++ b/cx_Freeze/samples/msi_extensions/setup.py
@@ -1,0 +1,39 @@
+# A very simple setup script to test adding extension handling to an MSI file.
+#
+# This script defines three ways for the hello.py executable to handle text files,
+# that are registered in the operating system.
+#
+# hello.py is a very simple 'Hello, world' type script which also displays the
+# environment in which the script runs
+#
+# Run the build process by running the command 'python setup.py bdist_msi'
+
+
+from cx_Freeze import setup, Executable
+
+executables = [Executable('hello.py')]
+
+bdist_msi_options = {
+    'extensions': [
+        # open / print / view text files
+        {'extension': 'txt', 'verb': 'open', 'executable': 'hello.exe', 'context': 'Edit with hello.py'},
+        {'extension': 'txt', 'verb': 'print', 'executable': 'hello.exe', 'context': 'Print with hello.py', 'argument': '--print "%1"'},
+        {'extension': 'txt', 'verb': 'view', 'executable': 'hello.exe', 'context': 'View with hello.py', 'argument': '--read-only "%1"'},
+        # open / print / view log files
+        {'extension': 'log', 'verb': 'open', 'executable': 'hello.exe', 'context': 'Edit with hello.py'},
+        {'extension': 'log', 'verb': 'print', 'executable': 'hello.exe', 'context': 'Print with hello.py', 'argument': '--print "%1"'},
+        {'extension': 'log', 'verb': 'view', 'executable': 'hello.exe', 'context': 'View with hello.py', 'argument': '--read-only "%1"'},
+    ],
+}
+
+setup(
+    name='Hello Program',
+    version='0.1',
+    author='cx_Freeze',
+    description='Sample cx_Freeze script to test MSI extension registration',
+    executables=executables,
+    options={
+        'build_exe': {'excludes': ['tkinter']},
+        'bdist_msi': bdist_msi_options,
+    },
+)

--- a/cx_Freeze/windist.py
+++ b/cx_Freeze/windist.py
@@ -40,6 +40,7 @@ class bdist_msi(distutils.command.bdist_msi.bdist_msi):
         ("product-code=", None, "product code to use"),
         ("install-icon=", None, "icon path to add/remove programs "),
         ("all-users=", None, "installation for all users (or just me)"),
+        ('extensions=', None, 'Extensions for which to register Verbs'),
     ]
     x = y = 50
     width = 370
@@ -296,7 +297,21 @@ class bdist_msi(distutils.command.bdist_msi.bdist_msi):
         while todo:
             dir = todo.pop()
             for file in os.listdir(dir.absolute):
-                if os.path.isdir(os.path.join(dir.absolute, file)):
+                sep_comp = self.separate_components.get(os.path.relpath(
+                    os.path.join(dir.absolute, file),
+                    self.bdist_dir,
+                ))
+                if sep_comp is not None:
+                    restore_component = dir.component
+                    dir.start_component(
+                        component=sep_comp,
+                        flags=0,
+                        feature=f,
+                        keyfile=file,
+                    )
+                    dir.add_file(file)
+                    dir.component = restore_component
+                elif os.path.isdir(os.path.join(dir.absolute, file)):
                     newDir = msilib.Directory(
                         db,
                         cab,
@@ -746,6 +761,12 @@ class bdist_msi(distutils.command.bdist_msi.bdist_msi):
         )
         button.event("EndDialog", "Exit")
 
+    def _append_to_data(self, table, *line):
+        rows = self.data.setdefault(table, [])
+        line = tuple(line)
+        if line not in rows:
+            rows.append(line)
+
     def finalize_options(self):
         distutils.command.bdist_msi.bdist_msi.finalize_options(self)
         name = self.distribution.get_name()
@@ -773,6 +794,94 @@ class bdist_msi(distutils.command.bdist_msi.bdist_msi):
             self.data = {}
         if not isinstance(self.summary_data, dict):
             self.summary_data = {}
+        self.separate_components = {}
+        for n, executable in enumerate(self.distribution.executables):
+            base_name = os.path.basename(executable.target_name)
+            # Trying to make these names unique from any directory name
+            self.separate_components[base_name] = msilib.make_id(
+                '_cx_executable{}_{}'.format(n, executable)
+            )
+        if self.extensions is None:
+            self.extensions = []
+        for extension in self.extensions:
+            try:
+                ext = extension['extension']
+                verb = extension['verb']
+                executable = extension['executable']
+            except KeyError:
+                raise ValueError('Each extension must have at least \
+                                  extension, verb, and executable')
+            try:
+                component = self.separate_components[executable]
+            except KeyError:
+                raise ValueError("Executable must be the base target name \
+                                  of one of the distribution's executables")
+            progid = msilib.make_id('{}.{}.{}'.format(
+                self.distribution.get_name(),
+                os.path.splitext(executable)[0],
+                self.distribution.get_version(),
+            ))
+            mime = extension.get('mime', None)
+            argument = extension.get('argument', None)  # "%1" a better default?
+            context = extension.get(
+                'context',
+                '{} {}'.format(self.distribution.get_fullname(), verb),
+            )
+            # Add rows via self.data to safely ignore duplicates
+            self._append_to_data('ProgId',
+                progid,
+                None,
+                None,
+                self.distribution.get_description(),
+                None,
+                None,
+            )
+            self._append_to_data('Extension',
+                ext,
+                component,
+                progid,
+                mime,
+                'default',
+            )
+            self._append_to_data('Verb',
+                ext,
+                verb,
+                0,
+                context,
+                argument,
+            )
+            if mime is not None:
+                self._append_to_data('MIME',
+                    mime,
+                    ext,
+                    'None',
+                )
+            # Registry entries that allow proper display of the app in menu
+            self._append_to_data('Registry',
+                '{}-name'.format(progid),
+                -1,
+                r'Software\Classes\{}'.format(progid),
+                'FriendlyAppName',
+                self.distribution.get_name(),
+                component,
+            )
+            self._append_to_data('Registry',
+                '{}-verb-{}'.format(progid, verb),
+                -1,
+                r'Software\Classes\{}\shell\{}'.format(progid, verb),
+                'FriendlyAppName',
+                self.distribution.get_name(),
+                component,
+            )
+            self._append_to_data('Registry',
+                '{}-author'.format(progid),
+                -1,
+                r'Software\Classes\{}\Application'.format(progid),
+                'ApplicationCompany',
+                self.distribution.get_author(),
+                component,
+            )
+
 
     def initialize_options(self):
         distutils.command.bdist_msi.bdist_msi.initialize_options(self)
@@ -787,6 +896,7 @@ class bdist_msi(distutils.command.bdist_msi.bdist_msi):
         self.summary_data = None
         self.install_icon = None
         self.all_users = False
+        self.extensions = None
 
     def run(self):
         if not self.skip_build:

--- a/doc/src/distutils.rst
+++ b/doc/src/distutils.rst
@@ -275,6 +275,12 @@ command:
        upgrade code prior to the installation of this one; the valid format for
        a GUID is {XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX} where X is a hex digit.
        Refer to `Windows GUID <https://docs.microsoft.com/en-us/windows/win32/api/guiddef/ns-guiddef-guid>`_.
+   * - extensions
+     - list of dictionaries specifying the extensions that the installed program
+       handles. Each extension needs to specify at least the extension, a verb,
+       and an executable. Additional allowed keys are `argument` to specify
+       the invocation of the executable, `mime` for the extension’s mime type,
+       and `context` for the context menu text.
 
 For example:
 


### PR DESCRIPTION
This PR adds the ability to register a program as handling some file types on windows, using msi features, with minimal supplement of direct registry modifications.

I tried to keep the interface simple, so there’s a single option to modify, with a list of dicts, one per file-type association, which is comprised of:
1. a file type (extension without leading .)
2. an executable
3. a verb, e.g. “open”
4. optionally arguments, e.g. `"%1"` for proper quoting, but any other program arguments can be passed (see sample),
5. optionally a context menu display name for the association, defaults to `{program name} {verb}`
6. optionally a mime type associated with the extension

Most affected MSI tables are really straightforward: extension, verb, mime. 2 slightly less so:

**Component**: Executables have to be bundled into separate `Component`s (with the executable as its `keyfile`).

There was previously one automatically-created `Component` entry per directory, there now are 1 per directory + 1 per executable. If a directory has the same name as a Component we use for an executable, then a second Component with the same identifier will be created, however these have to be unique. I therefore tried to minimize the risk of Component id clashes by naming the executable Components `_cx_executable{N}_{executable base name}`, however I’m open to better suggestions. An alternative (that I find less pleasant because it relies on `msilib` internals) is to add the executable Component ids to `msilib._directory` so they won’t be reused.

**ProgId**: The `progId` are as close as possible to [recommendations](https://docs.microsoft.com/en-us/windows/win32/shell/fa-progids), which are `[Vendor or Application].[Component].[Version]`.

The 2 types of registry keys that are added are needed:
- `FriendlyAppName`: to set a display name other than the executable’s file name (`Hello Program` instead of `hello.exe` in the Open With submenu)
- `ApplicationCompany`: to have the application show directly in the « Open With » submenu rather than only in the « Choose another program » dialog from the « Open With » submenu.

----

Building & installing the sample I added modifies the context menu for the specified extensions / file types:
- it primarily adds an entry the « Open With » submenu,
- and also modifies the top options of the context menu (one per verb for the extension), when the program is selected as default handler for the file type

![hello-world](https://user-images.githubusercontent.com/6126377/115796900-f1325780-a3d2-11eb-934d-6d6dcf47da7a.png)

The executable + argument are called with the file when an action is selected, e.g.:

![action](https://user-images.githubusercontent.com/6126377/115796905-f2638480-a3d2-11eb-95b8-fd43ccd6b809.png)