### PR TITLE
Fix minor glitch in _GetDependentFiles.

### DIFF
--- a/cx_Freeze/freezer.py
+++ b/cx_Freeze/freezer.py
@@ -400,8 +400,9 @@ class Freezer:
         imagehlp library on Windows, otool on Mac OS X and ldd on Linux);
         limit this list by the exclusion lists as needed"""
         path = os.path.normcase(path)
-        dependentFiles = self.dependentFiles.get(path, [])
-        if not dependentFiles:
+        dependentFiles = self.dependentFiles.get(path, None)
+        if dependentFiles is None:
+            dependentFiles = []
             if sys.platform == "win32":
                 if path.endswith((".exe", ".dll", ".pyd")):
                     origPath = os.environ["PATH"]


### PR DESCRIPTION
As it currently is, the dependency-finding code could run repeatedly on any file that does not have any dependencies (because [] would be stored into the self.dependentFiles dictionary for that file, which is the same as the default value).  This PR fixes that by using None as the default.