### PR TITLE
Corrected silent_level to default to 0 (to agree with documentation)

### DIFF
--- a/cx_Freeze/dist.py
+++ b/cx_Freeze/dist.py
@@ -235,7 +235,8 @@ class build_exe(distutils.core.Command):
         if self.silent is not None and self.silent:
             self.silent_setting = 1
 
-        if self.silent_level is False: self.silent_setting = 0
+        if self.silent_level is None: pass
+        elif self.silent_level is False: self.silent_setting = 0
         elif self.silent_level is True: self.silent_setting = 1
         elif isinstance(self.silent_level, int): self.silent_setting = self.silent_level
         elif isinstance(self.silent_level, str):


### PR DESCRIPTION
I made a mistake in the recent silent option changes that caused the silent_level to default to 1, instead of 0 (which is what is identified as the default in the documentation).  This PR fixes that.

(Though, after using cx_Freeze this way, I think silent_level=1 might be a better default...  But either way, we need some change to make the program consistent with the documentation.)