### PR TITLE
check in advance whether the dependency should be copied to avoid changing the rpath unnecessarily

### DIFF
--- a/cx_Freeze/freezer.py
+++ b/cx_Freeze/freezer.py
@@ -1020,6 +1020,8 @@ class LinuxFreezer(Freezer):
             library_dir = os.path.join(self.targetdir, "lib")
             fix_rpath = set()
             for dependent_file in self._get_dependent_files(source):
+                if not self._should_copy_file(dependent_file):
+                    continue
                 dep_base = os.path.basename(dependent_file)
                 dep_abs = os.path.abspath(dependent_file)
                 dep_rel = os.path.relpath(dep_abs, source_dir)


### PR DESCRIPTION
partial fix for issue #1048
without this PR, patchelf corrupts dependencies of an extension, for example:
_cff_backend extension has a dependency libffi-*.so