### PR TITLE
Better reporting of why files are included.

### DIFF
--- a/cx_Freeze/darwintools2.py
+++ b/cx_Freeze/darwintools2.py
@@ -1,0 +1,517 @@
+import os
+import subprocess
+import stat
+from typing import List, Dict, Optional, Set, Iterable
+
+from .exception import DarwinException
+from .freezeutil import _norm_path
+
+# In a MachO file, need to deal specially with links that use @executable_path,
+# @loader_path, @rpath
+#
+# @executable_path - where ultimate calling executable is
+# @loader_path - directory of current object
+# @rpath - list of paths to check
+# (earlier rpaths have higher priority, i believe)
+#
+# Resolving these variables (particularly @rpath) requires tracing through the
+# sequence linked MachO files leading the the current file, to determine which
+# directories are included in the current rpath.
+
+
+def _isMachOFile(path: str) -> bool:
+    """Determines whether the file is a Mach-O file."""
+    if not os.path.isfile(path):
+        return False
+    p = subprocess.Popen(("file", path), stdout=subprocess.PIPE)
+    if b"Mach-O" in p.stdout.readline():
+        return True
+    return False
+
+
+class DarwinFileData:
+    """
+    A DarwinFile object represents a file that will be copied into the
+    application, and record where it was ultimately moved to in the application
+    bundle. Mostly used to provide special handling for copied files that are
+    Mach-O files.
+    """
+
+    def __init__(
+        self,
+        originalFilePath: str,
+        linkedFrom: Optional["DarwinFileData"] = None,
+        strictRPath: bool = False,
+    ):
+        """
+        :param originalFilePath: The original path of the DarwinFile (before
+        copying into app)
+        :param linkedFrom: DarwinFile object representing the referencing
+        source file
+        :param strictRPath: Do not make guesses about rpath resolution.  If the
+        load does not resolve, throw an Exception.
+        """
+        self.originalFilePath = _norm_path(originalFilePath)
+        self.linkedFrom: Optional[DarwinFileData] = linkedFrom
+        self.strictRPath = strictRPath
+
+        # commands in a Mach-O file
+        self.commands: List[MachOCommand] = []
+        self.loadCommands: List[MachOLoadCommand] = []
+        self.rpathCommands: List[MachORPathCommand] = []
+
+        # note: if file gets referenced twice (or more), it will only be the
+        # first reference that gets recorded.
+        # mapping of raw load paths to absolute resolved paths
+        # (or None, if no resolution was determined)
+        self.libraryPathResolution: Dict[str, Optional[str]] = {}
+        # the is of entries in the rpath in effect for this file.
+        self._rpath: Optional[List[str]] = None
+
+        self.isMachO = False
+
+        if not _isMachOFile(path=self.originalFilePath):
+            self._rpath = []
+            return
+
+        # if this is a MachO file, extract linking information from it
+        self.isMachO = True
+        self.commands = MachOCommand._getMachOCommands(
+            forFileAtPath=self.originalFilePath
+        )
+        self.loadCommands = [
+            c for c in self.commands if isinstance(c, MachOLoadCommand)
+        ]
+        self.rpathCommands = [
+            c for c in self.commands if isinstance(c, MachORPathCommand)
+        ]
+        self.linkedFrom = linkedFrom
+
+        self.getRPath()
+        self.resolveLibraryPaths()
+
+        return
+
+    def __str__(self):
+        l = []
+        # l.append("RPath Commands: {}".format(self.rpathCommands))
+        # l.append("Load commands: {}".format(self.loadCommands))
+        l.append(f"Mach-O File: {self.originalFilePath}")
+        l.append("Resolved rpath:")
+        for rp in self.getRPath():
+            l.append(f"   {rp}")
+        l.append("Loaded libraries:")
+        for rp in self.libraryPathResolution:
+            l.append("   {} -> {}".format(rp, self.libraryPathResolution[rp]))
+        return "\n".join(l)
+
+    def getResolvedPaths(self) -> List[str]:
+        """Returns list of resolved rpaths."""
+        resolved_paths: List[str] = []
+        for raw, resolved in self.libraryPathResolution.items():
+            if resolved is not None: resolved_paths.append(resolved)
+            pass
+        return resolved_paths
+
+    def getRemainingRPaths(self) -> List[str]:
+        """Returns remaining unresolved rpaths."""
+        rpaths: List[str] = []
+        for raw, resolved in self.libraryPathResolution.items():
+            if resolved is None:
+                if not raw.startswith("@rpath"):
+                    raise DarwinException(f"Unresolved path that is not an @rpath: {raw}")
+                rpaths.append(raw)
+            pass
+        return rpaths
+
+    def fileReferenceDepth(self) -> int:
+        """Returns how deep this Mach-O file is in the dynamic load order."""
+        if self.linkedFrom is not None:
+            return self.linkedFrom.fileReferenceDepth() + 1
+        return 0
+
+    def printFileInformation(self):
+        """Prints information about the Mach-O file."""
+        print(f'[{self.fileReferenceDepth()}] File: "{self.originalFilePath}"')
+        print("  Commands:")
+        if len(self.commands) > 0:
+            for c in self.commands:
+                print(f"    {c}")
+        else:
+            print("    [None]")
+
+        print("  RPath commands:")
+        if len(self.rpathCommands) > 0:
+            for rpc in self.rpathCommands:
+                print(f"    {rpc}")
+        else:
+            print("    [None]")
+        print("  Calculated RPath:")
+        rpath = self.getRPath()
+        if len(rpath) > 0:
+            for path in rpath:
+                print(f"    {path}")
+        else:
+            print("    [None]")
+        if self.linkedFrom is not None:
+            print("Referenced from:")
+            self.linkedFrom.printFileInformation()
+
+    def getBaseName(self) -> str:
+        return os.path.basename(self.originalFilePath)
+
+    @staticmethod
+    def isExecutablePath(path: str) -> bool:
+        return path.startswith("@executable_path")
+
+    @staticmethod
+    def isLoaderPath(path: str) -> bool:
+        return path.startswith("@loader_path")
+
+    @staticmethod
+    def isRPath(path: str) -> bool:
+        return path.startswith("@rpath")
+
+    def sourceDir(self) -> str:
+        return os.path.dirname(self.originalFilePath)
+
+    def resolveLoader(self, path: str) -> Optional[str]:
+        """Resolve a path that includes @loader_path.
+        @loader_path represents the directory in which the DarwinFile is
+        located."""
+        if self.isLoaderPath(path=path):
+            return path.replace("@loader_path", self.sourceDir(), 1)
+        raise DarwinException(f"resolveLoader() called on bad path: {path}")
+
+    def resolveExecutable(self, path: str) -> str:
+        """
+        @executable_path should resolve to the directory where the original
+        executable was located. By default, we set that to the directory of the
+        library, so it would resolve in the same was as if linked from an
+        executable in the same directory.
+        """
+        # consider making this resolve to the directory of the target script
+        # instead?
+        if self.isExecutablePath(path=path):
+            return path.replace("@executable_path", self.sourceDir(), 1)
+        raise DarwinException(
+            f"resolveExecutable() called on bad path: {path}"
+        )
+
+    def resolveRPath(self, path: str) -> Optional[str]:
+        for rp in self.getRPath():
+            testPath = os.path.abspath(path.replace("@rpath", rp, 1))
+            if _isMachOFile(testPath):
+                return testPath
+        if not self.strictRPath:
+            # If not strictly enforcing rpath, return None here, and leave any error to
+            # .finalizeReferences() instead.
+            return None
+        print(f"\nERROR: Problem resolving RPath [{path}] in file:")
+        self.printFileInformation()
+        raise DarwinException(f"resolveRPath() failed to resolve path: {path}")
+
+    def getRPath(self) -> List[str]:
+        """
+        Returns the rpath in effect for this file.  Determined by rpath
+        commands in this file and (recursively) the chain of files that
+        referenced this file.
+        """
+        if self._rpath is not None:
+            return self._rpath
+        rawPaths = [c.rPath for c in self.rpathCommands]
+        #TODO: Are the rpathCommands allowed to include an @rpath based path?
+        rpath = []
+        for rp in rawPaths:
+            if os.path.isabs(rp):
+                rpath.append(rp)
+            elif self.isLoaderPath(rp):
+                rpath.append(self.resolveLoader(rp))
+            elif self.isExecutablePath(rp):
+                rpath.append(self.resolveExecutable(rp))
+
+
+        rpath = [os.path.abspath(rp) for rp in rpath]
+        rpath = [rp for rp in rpath if os.path.exists(rp)]
+
+        if self.linkedFrom is not None:
+            rpath = self.linkedFrom.getRPath() + rpath
+        self._rpath = rpath
+        return self._rpath
+
+    def resolvePath(self, path) -> Optional[str]:
+        """
+        Resolves any @executable_path, @loader_path, and @rpath references
+        in a path.
+        """
+        if self.isLoaderPath(path):  # replace @loader_path
+            return self.resolveLoader(path)
+        if self.isExecutablePath(path):  # replace @executable_path
+            return self.resolveExecutable(path)
+        if self.isRPath(path):  # replace @rpath
+            return self.resolveRPath(path)
+        if os.path.isabs(path):  # just use the path, if it is absolute
+            return path
+        # if None of the above, check if is a relative path from the directory of this file?
+        testPath = os.path.abspath(os.path.join(self.sourceDir(), path))
+        if _isMachOFile(path=testPath):
+            return testPath
+        raise DarwinException(f"Could not resolve path: {path}")
+
+    def resolveLibraryPaths(self):
+        for lc in self.loadCommands:
+            rawPath = lc.loadPath
+            resolvedPath = self.resolvePath(path=rawPath)
+            self.libraryPathResolution[rawPath] = resolvedPath
+
+
+class MachOCommand:
+    """Represents a load command in a MachO file."""
+
+    def __init__(self, lines: List[str]):
+        self.lines = lines
+
+    def displayString(self) -> str:
+        l: List[str] = []
+        if len(self.lines) > 0:
+            l.append(self.lines[0].strip())
+        if len(self.lines) > 1:
+            l.append(self.lines[1].strip())
+        return " / ".join(l)
+
+    def __repr__(self):
+        return f"<MachOCommand ({self.displayString()})>"
+
+    @staticmethod
+    def _getMachOCommands(forFileAtPath: str) -> List["MachOCommand"]:
+        """
+        Returns a list of load commands in the specified file, using otool.
+        """
+        shellCommand = f'otool -l "{forFileAtPath}"'
+        commands: List[MachOCommand] = []
+        currentCommandLines = None
+
+        # split the output into separate load commands
+        for line in os.popen(shellCommand):
+            line = line.strip()
+            if line[:12] == "Load command":
+                if currentCommandLines is not None:
+                    commands.append(
+                        MachOCommand.parseLines(lines=currentCommandLines)
+                    )
+                currentCommandLines = []
+            if currentCommandLines is not None:
+                currentCommandLines.append(line)
+        if currentCommandLines is not None:
+            commands.append(MachOCommand.parseLines(lines=currentCommandLines))
+        return commands
+
+    @staticmethod
+    def parseLines(lines: List[str]) -> "MachOCommand":
+        if len(lines) < 2:
+            return MachOCommand(lines=lines)
+        commandLinePieces = lines[1].split(" ")
+        if commandLinePieces[0] != "cmd":
+            return MachOCommand(lines=lines)
+        if commandLinePieces[1] == "LC_LOAD_DYLIB":
+            return MachOLoadCommand(lines=lines)
+        if commandLinePieces[1] == "LC_RPATH":
+            return MachORPathCommand(lines=lines)
+        return MachOCommand(lines=lines)
+
+
+class MachOLoadCommand(MachOCommand):
+    def __init__(self, lines: List[str]):
+        super().__init__(lines=lines)
+        self.loadPath = None
+        if len(self.lines) < 4:
+            return
+        pathline = self.lines[3]
+        pathline = pathline.strip()
+        if not pathline.startswith("name "):
+            return
+        pathline = pathline[4:].strip()
+        pathline = pathline.split("(offset")[0].strip()
+        self.loadPath = pathline
+        return
+
+    def getPath(self):
+        return self.loadPath
+
+    def __repr__(self):
+        return f"<LoadCommand path={self.loadPath!r}>"
+
+
+class MachORPathCommand(MachOCommand):
+    def __init__(self, lines: List[str]):
+        super().__init__(lines=lines)
+        self.rPath = None
+        if len(self.lines) < 4:
+            return
+        pathline = self.lines[3]
+        pathline = pathline.strip()
+        if not pathline.startswith("path "):
+            return
+        pathline = pathline[4:].strip()
+        pathline = pathline.split("(offset")[0].strip()
+        self.rPath = pathline
+        return
+
+    def __repr__(self):
+        return f"<RPath path={self.rPath!r}>"
+
+
+def changeLoadReference(
+    fileName: str, oldReference: str, newReference: str, VERBOSE: bool = True
+):
+    """
+    Utility function that uses intall_name_tool to change oldReference to
+    newReference in the machO file specified by fileName.
+    """
+    if VERBOSE:
+        print("Redirecting load reference for ", end="")
+        print(f"<{fileName}> {oldReference} -> {newReference}")
+    original = os.stat(fileName).st_mode
+    newMode = original | stat.S_IWUSR
+    os.chmod(fileName, newMode)
+    subprocess.call(
+        ("install_name_tool", "-change", oldReference, newReference, fileName)
+    )
+    os.chmod(fileName, original)
+    return
+
+class DarwinFileTracker:
+    """Object to track the DarwinFiles that have been added during a freeze."""
+
+    def __init__(self):
+        # list of DarwinFile objects for files being copied into project
+        self._copiedFileList: List[DarwinFileData] = []
+
+        # mapping of (build directory) target paths to DarwinFile objects
+        self._darwinFileForBuildPath: Dict[str, DarwinFileData] = {}
+
+        # mapping of (source location) paths to DarwinFile objects
+        self._darwinFileForSourcePath: Dict[str, DarwinFileData] = {}
+        return
+
+    def __iter__(self) -> Iterable[DarwinFileData]:
+        return iter(self._copiedFileList)
+
+    def pathIsAlreadyCopiedTo(self, targetPath: str) -> bool:
+        """Check if the given targetPath has already has a file copied to it."""
+        if targetPath in self._darwinFileForBuildPath:
+            return True
+        return False
+
+    def getDarwinFile(self, sourcePath: str, targetPath: str) -> DarwinFileData:
+        """
+        Gets the DarwinFile for file copied from sourcePath to targetPath.
+        If either (i) nothing, or (ii) a different file has been copied to
+        targetPath, raises a DarwinException.
+        """
+        # check that the file has been copied to
+        if targetPath not in self._darwinFileForBuildPath:
+            raise DarwinException(
+                f"File {targetPath!r} already copied to, "
+                "but no DarwinFile object found for it."
+            )
+
+        # check that the target file came from the specified source
+        targetDarwinFile: DarwinFileData = self._darwinFileForBuildPath[targetPath]
+        realSource = os.path.realpath(sourcePath)
+        targetRealSource = os.path.realpath(targetDarwinFile.originalFilePath)
+        if realSource != targetRealSource:
+            # raise DarwinException(
+            print(
+                "*** WARNING ***\n"
+                f"Attempting to copy two files to {targetPath!r}\n"
+                f"source 1: {targetDarwinFile.originalFilePath!r} "
+                f"(real: {targetRealSource!r})\n"
+                f"source 2: {sourcePath!r} (real: {realSource!r})\n"
+                "(This may be caused by including modules in the zip file "
+                "that rely on binary libraries with the same name.)"
+                "\nUsing only source 1."
+            )
+        return targetDarwinFile
+
+    def recordCopiedFile(self, targetPath: str, darwinFile: DarwinFileData):
+        """
+        Record that a DarwinFile is being copied to a given path. If a
+         file has been copied to that path, raise a DarwinException.
+        """
+        if self.pathIsAlreadyCopiedTo(targetPath=targetPath):
+            raise DarwinException(
+                "addFile() called with targetPath already copied to "
+                f"(targetPath={targetPath!r})"
+            )
+
+        self._copiedFileList.append(darwinFile)
+        self._darwinFileForBuildPath[targetPath] = darwinFile
+        self._darwinFileForSourcePath[darwinFile.originalFilePath] = darwinFile
+
+    def findDarwinFileForFilename(self, fileName: str) -> Optional[DarwinFileData]:
+        """Attempts to locate a copied DarwinFile with the specified filename and returns that.
+        Otherwise returns None."""
+        for df in self._copiedFileList:
+            if df.getBaseName() == fileName:
+                return df
+        return None
+
+    def finalizeReferences(self):
+        """
+        This function does a final pass through the references for all the
+        copied DarwinFiles and attempts to clean up any remaining references
+        that are not already marked as copied.  It covers two cases where the
+        reference might not be marked as copied:
+        1) Files where _CopyFile was called without copyDependentFiles=True
+           (in which the information would not have been added to the
+            references at that time).
+        2) Files with broken @rpath references.  We try to fix that up here by
+           seeing if the relevant file was located *anywhere* as part of the
+           freeze process.
+        """
+        for copiedFile in self._copiedFileList:  # DarwinFile
+            for reference in copiedFile.getMachOReferenceList():
+                if not reference.isCopied:
+                    if reference.isResolved():
+                        # if reference is resolve, simply check if the resolved
+                        # path was otherwise copied and lookup the DarwinFile
+                        # object.
+                        realTargetPath = os.path.realpath(
+                            reference.resolvedReferencePath
+                        )
+                        if realTargetPath in self._darwinFileForSourcePath:
+                            reference.setTargetFile(
+                                self._darwinFileForSourcePath[realTargetPath]
+                            )
+                    else:
+                        # if reference is not resolved, look through the copied
+                        # files and try to find a candidate, and use it if found.
+                        potentialTarget = self.findDarwinFileForFilename(
+                            fileName=os.path.basename(
+                                reference.rawReferencePath
+                            )
+                        )
+                        if potentialTarget is None:
+                            # If we cannot find any likely candidate, fail.
+                            print(
+                                "\nERROR: Could not resolve RPath "
+                                f"[{reference.rawReferencePath}] in file "
+                                f"[{copiedFile.originalFilePath}], and could "
+                                "not find any likely intended reference."
+                            )
+                            copiedFile.printFileInformation()
+                            raise DarwinException(
+                                f"finalizeReferences() failed to resolve path "
+                                f"[{reference.rawReferencePath}] in file "
+                                f"[{copiedFile.originalFilePath}]."
+                            )
+                        print(
+                            f"WARNING: In file [{copiedFile.originalFilePath}]"
+                            f" guessing that {reference.rawReferencePath} "
+                            f"resolved to {potentialTarget.originalFilePath}."
+                        )
+                        reference.resolvedReferencePath = (
+                            potentialTarget.originalFilePath
+                        )
+                        reference.setTargetFile(potentialTarget)

--- a/cx_Freeze/dist.py
+++ b/cx_Freeze/dist.py
@@ -163,6 +163,11 @@ class build_exe(distutils.core.Command):
             " level 2: suppress missing missing-module warnings"
             " level 3: suppress all warning messages",
         ),
+        (
+            "why-report",
+            None,
+            "Print out a report explaining why each file has been included in the frozen executable."
+        ),
     ]
     boolean_options = ["no-compress", "include_msvcr", "silent"]
 
@@ -234,6 +239,7 @@ class build_exe(distutils.core.Command):
         self.include_msvcr = None
         self.silent = None
         self.silent_level = None
+        self.why_report = False
 
     def finalize_options(self):
         self.set_undefined_options("build", ("build_exe", "build_exe"))
@@ -298,6 +304,7 @@ class build_exe(distutils.core.Command):
             metadata=metadata,
             zipIncludePackages=self.zip_include_packages,
             zipExcludePackages=self.zip_exclude_packages,
+            whyReport=self.why_report
         )
 
         # keep freezer around so that its data case be used in bdist_mac phase

--- a/cx_Freeze/exception.py
+++ b/cx_Freeze/exception.py
@@ -21,3 +21,7 @@ class ConfigError(Exception):
 
 class DarwinException(Exception):
     pass
+
+
+class FileTrackerException(Exception):
+    pass

--- a/cx_Freeze/filetracker.py
+++ b/cx_Freeze/filetracker.py
@@ -1,0 +1,376 @@
+import os, shutil, stat, sys
+from abc import ABC, abstractmethod
+from collections import deque
+from typing import Tuple, List, Dict, Iterator, Optional, Deque, Callable
+
+from .freezeutil import _norm_path
+from .exception import FileTrackerException
+from .darwintools2 import DarwinFileData
+
+# TODO: Deal with
+#  (1) cases where a special path is set just before marking file to copy (e.g., in _WriteModules) (extra path used for finding dependencies)
+#  (2) dummy file for created files (so they are not copied initially, but are moved on a re-locate operation)
+#  (3) relative_source (as part of dependency copying)
+
+WEAK_WARNING = True
+
+class CopyReason(ABC):
+    def __init__(self, explanation: str, priorReason: Optional["CopyReason"]=None):
+        self.explanation = explanation
+        self.priorReason = priorReason
+        return
+
+class FileObject(ABC):
+    def __init__(self, target_rel_paths: List[str] = None):
+        if target_rel_paths is None:
+            self.target_rel_paths: List[str] = []
+        else:
+            self.target_rel_paths = target_rel_paths
+        return
+
+    def add_target_rel_path(self, path: str):
+        if path in self.target_rel_paths:
+            if WEAK_WARNING: print(f"WARNING: Attempting to add a duplicate target: {path}")
+            else: raise FileTrackerException(f"Attempting to add a duplicate target: {path}")
+        self.target_rel_paths.append(path)
+        return
+
+    def __str__(self) -> str:
+        return ""
+
+    def __repr__(self) -> str:
+        return "<FileObject>"
+
+    @abstractmethod
+    def copy_to(self, dest_root:str):
+        return
+
+    @staticmethod
+    def remove_file(target_path: str):
+        if os.path.exists(target_path):
+            os.chmod(target_path, stat.S_IWRITE)
+            os.remove(target_path)
+            pass
+        return
+
+class RealFileObject(FileObject):
+    """Represents a real file that should be copied into frozen application."""
+    def __init__(self,
+                 original_file_path: str,
+                 target_rel_paths: Optional[List[str]] = None,
+                 linking_file: Optional["RealFileObject"] = None,
+                 copy_links: bool = False,
+                 include_mode: bool = False,
+                 force_write_access: bool = False,
+                 relative_source: bool = False):
+        """
+        :param original_file_path: Path to source file.
+        :param target_rel_paths: List of relative paths where file should be copied (relative to the dest_root specified at the time of copying).
+        :param linking_file: the real file that this file is linked to from (used to resolve rpaths on Darwin, and for reporting of why files added)
+        :param copy_links: If True, also find and copy dynamic libraries linked by the file.
+        :param include_mode: If True, copies over file mode information.
+        :param force_write_access: If True, forces write access on copied file. (overrides include_mode)
+        :param relative_source: If True, then (on Linux only), any dependencies of the file that are in a subdirectory of the directory containing this file, will be placed in the same position relative to this file.
+        """
+        super().__init__(target_rel_paths=target_rel_paths)
+        self.original_file_path = original_file_path
+        self.linking_file: Optional[RealFileObject] = linking_file
+        self.copy_links = copy_links
+        self.links_processed: bool = False  # set to True once links processed for file
+        self.force_write_access = force_write_access
+        self.include_mode = include_mode
+        self.relative_source = relative_source
+
+        self.darwin_file_data = None
+        if sys.platform == "darwin":
+            self.darwin_file_data = DarwinFileData(originalFilePath=self.original_file_path,
+                                                   linkedFrom=None if (self.linking_file is None) else self.linking_file.darwin_file_data,
+                                                   strictRPath=False)
+        return
+
+    def __str__(self):
+        return f"<File {self.original_file_path} -> {self.target_rel_paths}>"
+
+    def __repr__(self) -> str:
+        return str(self)
+
+    def provide_linking_file(self, linking_file: "RealFileObject"):
+        """If no linking file currently specified, use the specified file as the source link."""
+        if self.linking_file is None:
+            self.linking_file = linking_file
+        return
+
+    def get_original_path(self) -> str:
+        return self.original_file_path
+
+    def get_target_paths(self) -> List[str]:
+        return self.target_rel_paths
+
+    def get_linked_paths(self) -> List[str]:
+        if sys.platform == "darwin":
+            return self.darwin_file_data.getResolvedPaths()
+        elif sys.platform == "win32":
+            #TODO: Complete this code for Windows / Linux (move over code from Freezer _GetDependentFiles)
+            raise FileTrackerException("Need to implement")
+        elif sys.platform == "linux":
+            raise FileTrackerException("Need to implement")
+        raise FileTrackerException(f"Unknown platform: {sys.platform}")
+
+    def copy_to(self, dest_root:str):
+        """
+        Copy the file into the specified target location relative to dest_path
+        """
+        abs_dest_root = os.path.abspath(dest_root)
+        for tpath in self.target_rel_paths:
+            abs_target_path = os.path.join(abs_dest_root, tpath)
+            #ensure target path exists
+            os.makedirs(os.path.dirname(abs_target_path), exist_ok=True)
+            self.remove_file(abs_target_path)
+            shutil.copyfile(self.original_file_path, abs_target_path)
+            shutil.copystat(self.original_file_path, abs_target_path)
+            if self.include_mode:
+                shutil.copymode(self.original_file_path, abs_target_path)
+            if self.force_write_access:
+                if not os.access(abs_target_path, os.W_OK):
+                    mode = os.stat(abs_target_path).st_mode
+                    os.chmod(abs_target_path, mode | stat.S_IWUSR)
+        return
+
+class VirtualFileObject(FileObject):
+    """Represents a file that should be created in frozen application, with specified content."""
+    def __init__(self, data: bytes, target_rel_paths: Optional[List[str]]):
+        super().__init__(target_rel_paths=target_rel_paths)
+        self.data: bytes = data
+        return
+
+    def __str__(self):
+        return f"<VirtualFile {len(self.data)} bytes -> {self.target_rel_paths}>"
+
+    def copy_to(self, dest_root:str):
+        """
+        Copy the file into the specified target location relative to dest_path
+        """
+        abs_dest_root = os.path.abspath(dest_root)
+        for tpath in self.target_rel_paths:
+            target_abs_path = os.path.join(abs_dest_root, tpath)
+            os.makedirs(os.path.dirname(target_abs_path), exist_ok=True)
+            self.remove_file(target_abs_path)
+            with open(target_abs_path, "wb") as f:
+                f.write(self.data)
+        return
+
+class FileTracker:
+    def __init__(self, copy_check_callback: Callable[[str], bool]):
+        """
+        :param copy_check_callback: A callback function to call to determine whether file as a specified path
+                                    should be included in frozen application.
+        """
+        self.copy_check_callback = copy_check_callback
+        # a dictionary of RealFileObjects by noramlized source path
+        self.real_files: Dict[str, RealFileObject] = {}
+        # a list of all File Objects created so far
+        self.all_files: List[FileObject] = []
+        # maps target paths to source File Objects
+        self.source_for_target_path: Dict[str, FileObject] = {}
+        self.links_check_queue: Deque[RealFileObject] = deque()
+        return
+
+    def print_copy_report(self):
+        source_paths = list(self.real_files.keys())
+        source_paths.sort()
+        print("Source files copied:")
+        for p in source_paths:
+            print(f'  {p}')
+        return
+
+    def file_is_marked_to_copy(self, source_path: str) -> bool:
+        """Returns True if the specified file is already marked for copying,
+        else False."""
+        np = _norm_path(source_path)
+        if np not in self.real_files:
+            return False
+        else:
+            rf = self.real_files[np]
+            if len(rf.get_target_paths()) > 0: return True
+        return False
+
+    def file_object_for_source_path(self, source_path: str) -> RealFileObject:
+        """Gets the FileObject for a file marked for copying."""
+        np = _norm_path(source_path)
+        if np not in self.real_files:
+            raise FileTrackerException("Attempt to get file object for file where no " 
+                                  f"FileObject created: {source_path}")
+        return self.real_files[np]
+
+    def queue_for_links_check(self, fobj: RealFileObject):
+        self.links_check_queue.append(fobj)
+        return
+
+    def mark_file(self,
+                  original_file_path: str,
+                  to_rel_path: Optional[str],
+                  copy_links: bool = False,
+                  force_write_access: bool = False,
+                  include_mode: bool = False,
+                  relative_source: bool = False,
+                  prioritize_links: bool = False):
+        """Mark that file at fromLocation should be copied to toLocation in the
+        target directory.
+        :param original_file_path: The full path to the source file.
+        :param to_rel_path: The relative path in the target directory (can be None, if we do not actually want to copy
+                            this file, and just want to copy its links.
+        :param copy_links: If True, files dynamically linked from this file are copied
+        :param prioritize_links: If True, prioritize checking links for this file (do it before unprioritized files).
+        """
+        # TODO: what was the point of this?
+        if os.path.basename(original_file_path).startswith("Python"):
+            print(f'{original_file_path} -> {to_rel_path}');
+            print("Copying python")
+            # raise FileTrackerException
+
+        normalized_source = _norm_path(original_file_path)
+        if to_rel_path is not None:
+            to_rel_path = os.path.normcase(os.path.normpath(to_rel_path))
+
+        if normalized_source in self.real_files:
+            # file object already created for the source.
+            # just add a new copying destination (if applicable) and mark to
+            # copy dependencies
+            realfile = self.real_files[normalized_source]
+            if to_rel_path is not None:
+                realfile.add_target_rel_path(path=to_rel_path)
+                self.source_for_target_path[to_rel_path] = realfile
+            if realfile.copy_links is False and copy_links:
+                realfile.copy_links = True
+            if prioritize_links:
+                self.queue_for_links_check(realfile)
+            return
+
+        if to_rel_path in self.source_for_target_path:
+            msg = f"Attempting to copying second file to same " + \
+                  f"destination: {original_file_path}->{to_rel_path} " + \
+                  f"(other: {self.source_for_target_path[to_rel_path]}"
+            if WEAK_WARNING: print(f"WARNING: {msg}")
+            else: raise FileTrackerException(msg)
+
+        if to_rel_path is None: target_paths = []
+        else: target_paths = [to_rel_path]
+
+        realfile = RealFileObject(original_file_path=normalized_source,
+                                  target_rel_paths=target_paths,
+                                  copy_links=copy_links,
+                                  force_write_access=force_write_access,
+                                  include_mode=include_mode,
+                                  relative_source=relative_source)
+        self.real_files[normalized_source] = realfile
+        self.all_files.append(realfile)
+        if to_rel_path is not None:
+            self.source_for_target_path[to_rel_path] = realfile
+        if prioritize_links:
+            self.queue_for_links_check(realfile)
+        return
+
+    def mark_file_to_create(self, to_rel_path: str, data: bytes):
+        """
+        Record that a file should be created at a specified location with specified contents.
+        """
+        to_rel_path = _norm_path(to_rel_path)
+        if to_rel_path in self.source_for_target_path:
+            # TODO, simply update options on the FileObject
+            raise FileTrackerException("Attempting to create second file a location "
+                                  f'\n target: {to_rel_path}')
+
+        fobj = VirtualFileObject(target_rel_paths=[to_rel_path],
+                                 data = data)
+        self.all_files.append(fobj)
+        self.source_for_target_path[to_rel_path] = fobj
+        return
+
+    def add_links(self):
+        """Go through files marked to have links copied, and determine and
+        add any additional files that are dynamically linked."""
+
+        # ensure that all files to be copied with links are put in queue for processing
+        # (files with prioritize_links=True will already be in queue)
+        for fobj in self.all_files:
+            if isinstance(fobj, RealFileObject) and fobj.copy_links:
+                self.queue_for_links_check(fobj=fobj)
+
+        # process files in the queue until empty
+        print("Adding dependencies for:")
+        while len(self.links_check_queue) > 0:
+            fobj = self.links_check_queue.popleft()
+            print(f"  {fobj}")
+            self.add_links_for_file(subject_file=fobj)
+            pass
+        return
+
+    def add_links_for_file(self, subject_file: RealFileObject):
+        """Add the dynamic links for the file."""
+        # return if links not supposed to be copied, or if links already processed for file
+        if not subject_file.copy_links or subject_file.links_processed:
+            return
+
+        subject_file.links_processed = True  # record that subject_file is now having links processed
+
+        linked_paths = subject_file.get_linked_paths()
+        for path in linked_paths:
+            path = _norm_path(path)
+            # if file has been marked for exclusion, skip over it
+            # TODO: we should maybe make a no-copying, non-linking file for this case, so the file at least appears in
+            #  self.real_files, when the time comes up update the links.
+            if not self.copy_check_callback(path):
+                continue
+            # if we are already planning to copy file, just making sure its links are copied
+            if path in self.real_files:
+                linked_file = self.real_files[path]
+                if len(linked_file.get_target_paths()) == 0:
+                    raise FileTrackerException("Linking to a file not being copied anywhere.")
+                    #TODO: In this case, presumably we should just add a copy target?
+                linked_file.copy_links = True  # set links on target file to be copied.
+                linked_file.linking_file = subject_file
+                self.queue_for_links_check(linked_file)
+                pass
+            else: # otherwise, need to create a new file object.
+                target_path = os.path.basename(path) # TODO: need to update this with appropriate path
+                linked_file = RealFileObject(original_file_path=path,
+                                             target_rel_paths=[target_path],
+                                             linking_file=subject_file,
+                                             copy_links=True,
+                                             include_mode=subject_file.include_mode,
+                                             force_write_access=subject_file.force_write_access,
+                                             relative_source=subject_file.relative_source)
+                self.all_files.append( linked_file )
+                self.real_files[path] = linked_file
+                #TODO: Need to check if that target is already used, an find a non-conflicting name
+                self.source_for_target_path[target_path] = linked_file
+                self.queue_for_links_check(linked_file)
+                pass
+        return
+
+    def copy_all_files(self, dest_root: str):
+        """Copies all marked files into the target directory."""
+        # print("All files to copy:")
+        # print(self.all_files)
+        for fobj in self.all_files:
+            print(f'Copying: {fobj}')
+            fobj.copy_to(dest_root=dest_root)
+            pass
+        return
+
+    def fixup_dynamic_links(self, path: str):
+        """Where necessary, fixes dynamic links appearing in copied files.
+        Only required for Darwin.
+        :param path: The location where all the files are located when doing the fixup
+        (this is different from target_directory, since files will have been copied into
+        app bundle directory)
+        """
+
+        if sys.platform != "darwin":
+            return
+
+        # TODO: complete this
+        #       needs to update the dynamic links in each of the copied MachO files.  Also need to detect @rpaths that were not yet
+        #       resolved, and make guesses (based on set of files being copied)
+
+        return

--- a/cx_Freeze/freezer.py
+++ b/cx_Freeze/freezer.py
@@ -159,7 +159,7 @@ class Freezer(ABC):
             self._copy_file(
                 source=from_path,
                 target=os.path.join(self.targetdir, to_relative_path),
-                recursion_reason=recursion_reason,
+                reason_for_dependencies=recursion_reason,
                 copy_dependent_files=copy_dependent_files, include_mode=include_mode
             )
 
@@ -168,7 +168,7 @@ class Freezer(ABC):
     def _copy_file(
             self,
             source, target,
-            recursion_reason: ReasonProtocol,
+            reason_for_dependencies: ReasonProtocol,
             copy_dependent_files,
             include_mode=False
     ):
@@ -203,7 +203,7 @@ class Freezer(ABC):
             target,
             normalized_source,
             normalized_target,
-            reason=recursion_reason,
+            reason=reason_for_dependencies,
             copy_dependent_files=copy_dependent_files,
             include_mode=include_mode,
         )
@@ -1055,7 +1055,7 @@ class DarwinFreezer(Freezer):
                 self._copy_file_recursion(
                     dependent_file,
                     self._make_target_path(rel_target),
-                    recursion_reason=recursion_reason,
+                    reason_for_dependences=recursion_reason,
                     copy_dependent_files=True,
                     machOReference=newDarwinFile.getMachOReferenceForPath(
                         path=dependent_file
@@ -1069,7 +1069,7 @@ class DarwinFreezer(Freezer):
         self,
         source,
         target,
-        recursion_reason: ReasonProtocol,
+        reason_for_dependences: ReasonProtocol,
         copy_dependent_files,
         include_mode=False,
         machOReference: Optional["MachOReference"] = None,
@@ -1116,7 +1116,7 @@ class DarwinFreezer(Freezer):
             target,
             normalized_source,
             normalized_target,
-            reason=recursion_reason,
+            reason=reason_for_dependences,
             copy_dependent_files=copy_dependent_files,
             include_mode=include_mode,
             machOReference=machOReference,
@@ -1146,7 +1146,7 @@ class DarwinFreezer(Freezer):
         self._copy_file_recursion(
             source,
             self._make_target_path(rel_target),
-            recursion_reason=reason,
+            reason_for_dependences=reason,
             copy_dependent_files=True,
             include_mode=True,
             machOReference=cachedReference,

--- a/cx_Freeze/freezeutil.py
+++ b/cx_Freeze/freezeutil.py
@@ -1,0 +1,5 @@
+import os
+
+def _norm_path(path: str) -> str:
+    """Returns a normalized version of the specified path."""
+    return os.path.normcase(os.path.realpath(path))


### PR DESCRIPTION
Allow better reporting of why files are being included in the frozen application.  Still work in progress.  Ultimately this code should also allow dynamic links to be handled better on Darwin, and avoid including multiple copies of certain files. 

(Having darwintools.py and darwintools2.py is temporary -- when this is all done, we should be able to get rid of the original darwintools.py.)

Adds a "--why-report" option to build_exe command that prints a report of why each file has been included.