### PR TITLE
Fix compatibility with msys2 python 3.9.6

### DIFF
--- a/cx_Freeze/hooks.py
+++ b/cx_Freeze/hooks.py
@@ -10,7 +10,7 @@ from .common import code_object_replace
 from .finder import ModuleFinder
 from .module import Module
 
-MINGW = sysconfig.get_platform() == "mingw"
+MINGW = sysconfig.get_platform().startswith("mingw")
 WIN32 = sys.platform == "win32"
 
 


### PR DESCRIPTION
https://github.com/marcelotduarte/MINGW-packages/blob/9e1898c9caaacdbf8626fbc1c222ee0900cf3d75/mingw-w64-python/0099-Change-the-get_platform-method-in-sysconfig-and-dist.patch