### PR TITLE
Update hooks for tz to work with linux and conda

### DIFF
--- a/cx_Freeze/initscripts/__startup__.py
+++ b/cx_Freeze/initscripts/__startup__.py
@@ -59,7 +59,12 @@ def init():
         os.environ["PATH"] = add_to_path + os.path.pathsep + os.environ["PATH"]
 
     # set environment variables
-    for name in ("TCL_LIBRARY", "TK_LIBRARY", "PYTZ_TZDATADIR"):
+    for name in (
+        "TCL_LIBRARY",
+        "TK_LIBRARY",
+        "PYTZ_TZDATADIR",
+        "PYTHONTZPATH",
+    ):
         try:
             value = getattr(BUILD_CONSTANTS, name)
         except AttributeError:


### PR DESCRIPTION
In environments like linux and conda for windows, the zoneinfo.TZPATH is set. So, use this variable to locate and copy the tz data.