### PR TITLE
Fix #1250 missing executable on successive same-version installs 

### DIFF
--- a/cx_Freeze/windist.py
+++ b/cx_Freeze/windist.py
@@ -75,7 +75,7 @@ class bdist_msi(distutils.command.bdist_msi.bdist_msi):
         # This is needed in case the AlwaysInstallElevated policy is set.
         # Otherwise installation will not end up in TARGETDIR.
         msilib.add_data(
-            self.db, "Property", [("SecureCustomProperties", "TARGETDIR")]
+            self.db, "Property", [("SecureCustomProperties", "TARGETDIR;REINSTALLMODE")]
         )
         msilib.add_data(
             self.db,
@@ -86,13 +86,22 @@ class bdist_msi(distutils.command.bdist_msi.bdist_msi):
                     256 + 51,
                     "TARGETDIR",
                     self.initial_target_dir,
-                )
+                ),
+                (
+                    "A_SET_REINSTALL_MODE",
+                    256 + 51,
+                    "REINSTALLMODE",
+                    "amus",
+                ),
             ],
         )
         msilib.add_data(
             self.db,
             "InstallExecuteSequence",
-            [("A_SET_TARGET_DIR", 'TARGETDIR=""', 401)],
+            [
+                ("A_SET_TARGET_DIR", 'TARGETDIR=""', 401),
+                ("A_SET_REINSTALL_MODE", 'REINSTALLMODE=""', 402),
+            ],
         )
         msilib.add_data(
             self.db,
@@ -100,6 +109,7 @@ class bdist_msi(distutils.command.bdist_msi.bdist_msi):
             [
                 ("PrepareDlg", None, 140),
                 ("A_SET_TARGET_DIR", 'TARGETDIR=""', 401),
+                ("A_SET_REINSTALL_MODE", 'REINSTALLMODE=""', 402),
                 ("SelectDirectoryDlg", "not Installed", 1230),
                 (
                     "MaintenanceTypeDlg",


### PR DESCRIPTION
Set REINSTALLMODE to force installing same-version executables

In development, or other sitations with successive installs with
same-version executables, this avoids the following “strange” behaviour:

1. installer determines previous executable does not need replacing
2. the Upgrade table determines the previous executable is part of an
   older product
3. the RemoveExistingProducts action removes the previous installation,
   including the previous executable
4. during install, the new executable is not installed as it was deemed
   unnecessary initially and this appraisal has not been affected by
   the previous version uninstall.