### PR TITLE
fix bugs in certain subprocess calls

### DIFF
--- a/cx_Freeze/macdist.py
+++ b/cx_Freeze/macdist.py
@@ -87,7 +87,7 @@ class bdist_dmg(Command):
             )
 
         # Create the dmg
-        if subprocess.call(("hdiutil", createargs)) != 0:
+        if subprocess.call(createargs) != 0:
             raise OSError("creation of the dmg failed")
 
     def run(self):
@@ -487,5 +487,5 @@ class bdist_mac(Command):
 
             signargs.append(self.bundleDir)
 
-            if subprocess.call(("codesign", signargs)) != 0:
+            if subprocess.call(signargs) != 0:
                 raise OSError("Code signing of app bundle failed")


### PR DESCRIPTION
The argument lists already contained the name of the executable. 

FYI. Seems like the latest version might have some other problems on OSX (my frozen app is seg faulting).  Will try to look into it later.