### PR TITLE
Support for latest opencv-python release

### DIFF
--- a/cx_Freeze/hooks.py
+++ b/cx_Freeze/hooks.py
@@ -379,6 +379,17 @@ def load__ctypes(finder: ModuleFinder, module: Module) -> None:
         finder.IncludeFiles(dll_path, Path("lib", dll_name))
 
 
+def load_cv2(finder: ModuleFinder, module: Module) -> None:
+    """
+    Versions of cv2 (opencv-python) above 4.5.3 require additional
+    configuration files.
+    """
+    dest_dir = Path("lib", "cv2")
+    cv2_dir = module.path[0]
+    for path in cv2_dir.glob("config*.py"):
+        finder.IncludeFiles(path, dest_dir / path.name)
+
+
 def load_cx_Oracle(finder: ModuleFinder, module: Module) -> None:
     """
     The cx_Oracle module implicitly imports datetime; make sure this

--- a/cx_Freeze/hooks.py
+++ b/cx_Freeze/hooks.py
@@ -383,19 +383,17 @@ def load_cv2(finder: ModuleFinder, module: Module) -> None:
     """
     Versions of cv2 (opencv-python) above 4.5.3 require additional
     configuration files.
+
     Additionally, on Linux the opencv_python.libs directory is not
-    copied across for versions above 4.5.3.
+    copied across for versions above 4.5.3 unless the cv2 package is
+    included.
     """
+    finder.IncludePackage('cv2')
+
     dest_dir = Path("lib", "cv2")
     cv2_dir = module.path[0]
     for path in cv2_dir.glob("config*.py"):
         finder.IncludeFiles(path, dest_dir / path.name)
-
-    opencv_lib_source_dir = Path(cv2_dir, '../opencv_python.libs')
-    if opencv_lib_source_dir.exists():
-        dest_dir_libs = Path("lib", "opencv_python.libs")
-        for path in opencv_lib_source_dir.iterdir():
-            finder.IncludeFiles(path, dest_dir_libs / path.name)
 
 
 def load_cx_Oracle(finder: ModuleFinder, module: Module) -> None:

--- a/cx_Freeze/hooks.py
+++ b/cx_Freeze/hooks.py
@@ -383,11 +383,19 @@ def load_cv2(finder: ModuleFinder, module: Module) -> None:
     """
     Versions of cv2 (opencv-python) above 4.5.3 require additional
     configuration files.
+    Additionally, on Linux the opencv_python.libs directory is not
+    copied across for versions above 4.5.3.
     """
     dest_dir = Path("lib", "cv2")
     cv2_dir = module.path[0]
     for path in cv2_dir.glob("config*.py"):
         finder.IncludeFiles(path, dest_dir / path.name)
+
+    opencv_lib_source_dir = Path(cv2_dir, '../opencv_python.libs')
+    if opencv_lib_source_dir.exists():
+        dest_dir_libs = Path("lib", "opencv_python.libs")
+        for path in opencv_lib_source_dir.iterdir():
+            finder.IncludeFiles(path, dest_dir_libs / path.name)
 
 
 def load_cx_Oracle(finder: ModuleFinder, module: Module) -> None:


### PR DESCRIPTION
Fixes #1275.

This adds a hook which includes additional .py files which are now required in the latest opencv-python release (4.5.4). Since these files are directly executed (but not imported) in `cv2/__init__.py`, they may have been missed out when cx_Freeze creates a build depending on this library.

The `config.py` and `config-{python_version}.py` files are not part of the previous release, so nothing extra should be included if building with the old library.  

When testing on Ubuntu, I also found that a folder containing shared libraries `opencv-python.libs` was not copied into builds, but will be if the package itself is included.

This has been tested on opencv-python 4.5.3/4 and Windows 10/Ubuntu 20.04. But bearing in mind the additional issue which came up on Linux, it would be a great help if anyone could confirm this works on MacOS!