### PR TITLE
Include updated libffi 

### DIFF
--- a/cx_Freeze/hooks.py
+++ b/cx_Freeze/hooks.py
@@ -374,7 +374,7 @@ def load__ctypes(finder: ModuleFinder, module: Module) -> None:
     libffi dll to be present in the build directory.
     """
     if WIN32 and sys.version_info >= (3, 8) and not MINGW:
-        dll_pattern = "libffi*-.dll"
+        dll_pattern = "libffi-*.dll"
         dll_dir = Path(sys.base_prefix, "DLLs")
         for dll_path in dll_dir.glob(dll_pattern):
             finder.IncludeFiles(dll_path, Path("lib", dll_path.name))

--- a/cx_Freeze/hooks.py
+++ b/cx_Freeze/hooks.py
@@ -374,7 +374,7 @@ def load__ctypes(finder: ModuleFinder, module: Module) -> None:
     libffi dll to be present in the build directory.
     """
     if WIN32 and sys.version_info >= (3, 8) and not MINGW:
-        dll_pattern = "libffi?-.dll"
+        dll_pattern = "libffi*-.dll"
         dll_dir = Path(sys.base_prefix, "DLLs")
         for dll_path in dll_dir.glob(dll_pattern):
             finder.IncludeFiles(dll_path, Path("lib", dll_path.name))

--- a/cx_Freeze/hooks.py
+++ b/cx_Freeze/hooks.py
@@ -370,8 +370,8 @@ def pycryptodome_filename(dir_comps, filename):
 
 def load__ctypes(finder: ModuleFinder, module: Module) -> None:
     """
-    In Windows, the _ctypes module in Python 3.8+ requires an additional dll
-    libffi-7.dll or libffi-8.dll to be present in the build directory.
+    In Windows, the _ctypes module in Python 3.8+ requires an additional
+    libffi dll to be present in the build directory.
     """
     if WIN32 and sys.version_info >= (3, 8) and not MINGW:
         dll_pattern = "libffi?-.dll"

--- a/cx_Freeze/hooks.py
+++ b/cx_Freeze/hooks.py
@@ -371,12 +371,13 @@ def pycryptodome_filename(dir_comps, filename):
 def load__ctypes(finder: ModuleFinder, module: Module) -> None:
     """
     In Windows, the _ctypes module in Python 3.8+ requires an additional dll
-    libffi-7.dll to be present in the build directory.
+    libffi-7.dll or libffi-8.dll to be present in the build directory.
     """
     if WIN32 and sys.version_info >= (3, 8) and not MINGW:
-        dll_name = "libffi-7.dll"
-        dll_path = Path(sys.base_prefix, "DLLs", dll_name)
-        finder.IncludeFiles(dll_path, Path("lib", dll_name))
+        dll_pattern = "libffi?-.dll"
+        dll_dir = Path(sys.base_prefix, "DLLs")
+        for dll_path in dll_dir.glob(dll_pattern):
+            finder.IncludeFiles(dll_path, Path("lib", dll_path.name))
 
 
 def load_cv2(finder: ModuleFinder, module: Module) -> None:


### PR DESCRIPTION
Just a small thing I noticed while working on #1275.
On windows, upgrading from python 3.8.11 -> 3.8.12 means a newer version of `libffi` (`libffi-8.dll` vs `libffi-7.dll`) comes with `ctypes`. This just changes the search pattern to include any version rather than 7 specifically.

I've tested this on Windows with the python versions above.