### PR TITLE
Extend Module.in_file_system to support an optimized mode

### DIFF
--- a/cx_Freeze/finder.py
+++ b/cx_Freeze/finder.py
@@ -121,7 +121,7 @@ class ModuleFinder:
                 and module.name not in self.zip_exclude_packages
                 or module.name in self.zip_include_packages
             ):
-                module.in_file_system = False
+                module.in_file_system = 0
         if module.path is None and path is not None:
             module.path = [Path(p) for p in path]
         if module.file is None and file_name is not None:
@@ -475,7 +475,7 @@ class ModuleFinder:
         # and is not defined in the module, like 'six' do
         if (
             module.parent is None
-            or module.in_file_system
+            or module.in_file_system >= 1
             or "__package__" in module.global_names
             or code is None
         ):

--- a/cx_Freeze/hooks.py
+++ b/cx_Freeze/hooks.py
@@ -216,7 +216,7 @@ def load_asyncio(finder: ModuleFinder, module: Module) -> None:
 def load_babel(finder: ModuleFinder, module: Module) -> None:
     """The babel must be loaded as a package, and has pickeable data."""
     finder.IncludePackage("babel")
-    module.in_file_system = True
+    module.in_file_system = 1
 
 
 def load_bcrypt(finder: ModuleFinder, module: Module) -> None:
@@ -252,9 +252,9 @@ def load_certifi(finder: ModuleFinder, module: Module) -> None:
     to locate the cacert.pem in zip packages.
     In previous versions, it is expected to be stored in the file system.
     """
-    if not module.in_file_system:
+    if module.in_file_system == 0:
         if sys.version_info < (3, 7):
-            module.in_file_system = True
+            module.in_file_system = 1
             return
         cacert = Path(__import__("certifi").where())
         finder.ZipIncludeFiles(cacert, Path("certifi", cacert.name))
@@ -305,37 +305,37 @@ def load_cryptography_hazmat_bindings__padding(
 
 def load_Crypto_Cipher(finder: ModuleFinder, module: Module) -> None:
     """The Crypto.Cipher subpackage of pycryptodome package."""
-    if not module.in_file_system:
+    if module.in_file_system == 0:
         finder.IncludePackage(module.name)
 
 
 def load_Crypto_Hash(finder: ModuleFinder, module: Module) -> None:
     """The Crypto.Hash subpackage of pycryptodome package."""
-    if not module.in_file_system:
+    if module.in_file_system == 0:
         finder.IncludePackage(module.name)
 
 
 def load_Crypto_Math(finder: ModuleFinder, module: Module) -> None:
     """The Crypto.Math subpackage of pycryptodome package."""
-    if not module.in_file_system:
+    if module.in_file_system == 0:
         finder.IncludePackage(module.name)
 
 
 def load_Crypto_Protocol(finder: ModuleFinder, module: Module) -> None:
     """The Crypto.Protocol subpackage of pycryptodome package."""
-    if not module.in_file_system:
+    if module.in_file_system == 0:
         finder.IncludePackage(module.name)
 
 
 def load_Crypto_PublicKey(finder: ModuleFinder, module: Module) -> None:
     """The Crypto.PublicKey subpackage of pycryptodome package."""
-    if not module.in_file_system:
+    if module.in_file_system == 0:
         finder.IncludePackage(module.name)
 
 
 def load_Crypto_Util(finder: ModuleFinder, module: Module) -> None:
     """The Crypto.Util subpackage of pycryptodome package."""
-    if not module.in_file_system:
+    if module.in_file_system == 0:
         finder.IncludePackage(module.name)
 
 
@@ -355,7 +355,7 @@ def pycryptodome_filename(dir_comps, filename):
     root_lib = os.path.join(os.path.dirname(sys.executable), "lib")
     return os.path.join(root_lib, ".".join(dir_comps))
 """
-    if not module.in_file_system and module.code is not None:
+    if module.in_file_system == 0 and module.code is not None:
         new_code = compile(PYCRYPTODOME_CODE_STR, str(module.file), "exec")
         co_func = new_code.co_consts[2]
         name = co_func.co_name
@@ -541,7 +541,7 @@ def load_googleapiclient_discovery(
     """The googleapiclient.discovery module needs discovery_cache subpackage
     in file system."""
     discovery_cache = finder.IncludePackage("googleapiclient.discovery_cache")
-    discovery_cache.in_file_system = True
+    discovery_cache.in_file_system = 1
 
 
 def load_google_cloud_storage(finder: ModuleFinder, module: Module) -> None:
@@ -615,7 +615,7 @@ def load_matplotlib(finder: ModuleFinder, module: Module) -> None:
         data_path = __import__("matplotlib").get_data_path()
         need_patch = True
     else:
-        need_patch = not module.in_file_system
+        need_patch = (module.in_file_system == 0)
     finder.IncludeFiles(data_path, target_path, copy_dependent_files=False)
     finder.IncludePackage("matplotlib")
     finder.ExcludeModule("matplotlib.tests")
@@ -667,7 +667,7 @@ def load_numpy(finder: ModuleFinder, module: Module) -> None:
                 finder.ExcludeDependentFiles(path)
 
         # support for old versions (numpy <= 1.18.2)
-        if not module.in_file_system:
+        if module.in_file_system == 0:
             # copy any file at site-packages/numpy/.libs
             libs_dir = numpy_dir / ".libs"
             if libs_dir.is_dir():
@@ -827,12 +827,9 @@ def load_ptr(finder: ModuleFinder, module: Module) -> None:
 
 
 def load_pycountry(finder: ModuleFinder, module: Module) -> None:
-    """
-    The pycountry module has data in subdirectories.
-    """
+    """The pycountry module has data in subdirectories."""
     finder.ExcludeModule("pycountry.tests")
-    if not module.in_file_system:
-        module.in_file_system = True
+    module.in_file_system = 1
 
 
 def load_pycparser(finder: ModuleFinder, module: Module) -> None:
@@ -1133,7 +1130,7 @@ def load_pytz(finder: ModuleFinder, module: Module) -> None:
         if data_path.is_dir():
             finder.AddConstant("PYTZ_TZDATADIR", str(target_path))
     if data_path.is_dir():
-        if module.in_file_system:
+        if module.in_file_system >= 1:
             finder.IncludeFiles(
                 data_path, target_path, copy_dependent_files=False
             )
@@ -1542,7 +1539,7 @@ def load_zoneinfo(finder: ModuleFinder, module: Module) -> None:
     # when the tzdata exists, copy other files in this directory
     source = tzdata.path[0]
     target = Path("lib", "tzdata")
-    if tzdata.in_file_system:
+    if tzdata.in_file_system >= 1:
         finder.IncludeFiles(source, target, copy_dependent_files=False)
     else:
         finder.ZipIncludeFiles(source, "tzdata")

--- a/cx_Freeze/module.py
+++ b/cx_Freeze/module.py
@@ -92,7 +92,7 @@ class Module:
         self.in_import: bool = True
         self.source_is_string: bool = False
         self.source_is_zip_file: bool = False
-        self._in_file_system: bool = True
+        self._in_file_system: int = 1
         # cache the dist-info files (metadata)
         self.update_distribution(name)
 
@@ -137,17 +137,19 @@ class Module:
         return "<Module {}>".format(", ".join(parts))
 
     @property
-    def in_file_system(self) -> bool:
-        """Returns a boolean indicating if the module will be stored in the
-        file system or not."""
+    def in_file_system(self) -> int:
+        """Returns a value indicating where the module/package will be stored:
+            0. in zip file (not directly in file system)
+            1. in file system, package with modules and data
+            2. in file system, only detected modules."""
         if self.parent is not None:
             return self.parent.in_file_system
         if self.path is None or self.file is None:
-            return False
+            return 0
         return self._in_file_system
 
     @in_file_system.setter
-    def in_file_system(self, value) -> None:
+    def in_file_system(self, value: int) -> None:
         self._in_file_system = value
 
 

--- a/cx_Freeze/module.py
+++ b/cx_Freeze/module.py
@@ -139,9 +139,9 @@ class Module:
     @property
     def in_file_system(self) -> int:
         """Returns a value indicating where the module/package will be stored:
-            0. in zip file (not directly in file system)
-            1. in file system, package with modules and data
-            2. in file system, only detected modules."""
+            0. in a zip file (not directly in the file system)
+            1. in the file system, package with modules and data
+            2. in the file system, only detected modules."""
         if self.parent is not None:
             return self.parent.in_file_system
         if self.path is None or self.file is None:


### PR DESCRIPTION
Turn Module.in_file_system into an int (0,1,2), indicating where the module/package will be stored:

0. in a zip file (not directly in the file system)
1. in the file system, package with modules and data
2. in the file system, only detected modules

The last option, 2, will be used in hooks modules, to optimize packages like PyQt5 and PySide2. So, only detected modules/extensions will be copied link when used zip_include_packages, but directly in the file system. This approach avoids having to change the RPATH of the shared libraries that the extension depends on.
For instance, using zip_include_packages=PyQt5, generates a PyQt5.QtCore.abi3.so and its rpath point to PyQy5 directory. Now, the file is located in PyQt5, in the same way as when using zip_exclude_packages, so no rpath changes are necessary.