### PR TITLE
Drop references to shlwapi.dll on Windows to improve performance

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -192,16 +192,11 @@ class install_include(Command):
 
 if __name__ == "__main__":
     # build base executables
-    if WIN32:
-        libraries = ["imagehlp", "Shlwapi"]
-    else:
-        libraries = []
     depends = ["source/bases/Common.c"]
     console = Extension(
         "cx_Freeze.bases.Console",
         ["source/bases/Console.c"],
         depends=depends,
-        libraries=libraries,
     )
     extensions = [console]
     if WIN32:
@@ -209,7 +204,7 @@ if __name__ == "__main__":
             "cx_Freeze.bases.Win32GUI",
             ["source/bases/Win32GUI.c"],
             depends=depends,
-            libraries=libraries + ["user32"],
+            libraries=["user32"],
         )
         extensions.append(gui)
         service = Extension(
@@ -217,12 +212,14 @@ if __name__ == "__main__":
             ["source/bases/Win32Service.c"],
             depends=depends,
             extra_link_args=["/DELAYLOAD:cx_Logging"],
-            libraries=libraries + ["advapi32"],
+            libraries=["advapi32"],
         )
         extensions.append(service)
         # build utility module
         util_module = Extension(
-            "cx_Freeze.util", ["source/util.c"], libraries=libraries
+            "cx_Freeze.util",
+            ["source/util.c"],
+            libraries=["imagehlp", "shlwapi"],
         )
         extensions.append(util_module)
 

--- a/source/bases/Common.c
+++ b/source/bases/Common.c
@@ -38,21 +38,29 @@ static char *g_argv0;
 //-----------------------------------------------------------------------------
 static int SetExecutableName(void)
 {
+    wchar_t *wptr;
 #ifdef MS_WINDOWS
     if (!GetModuleFileNameW(NULL, g_ExecutableName, MAXPATHLEN + 1))
         return FatalError("Unable to get executable name!");
+
+    // get directory from executable name
     wcscpy(g_ExecutableDirName, g_ExecutableName);
-    PathRemoveFileSpecW(g_ExecutableDirName);
+    wptr = wcsrchr(g_ExecutableDirName, SEP);
+    if (!wptr)
+        return FatalError("Unable to calculate directory of executable!");
+    *wptr = '\0';
 
     // set lib directory as default for dll search
-    PathCombineW(g_LibDirName, g_ExecutableDirName, CX_LIB);
+    wcscpy(g_LibDirName, g_ExecutableDirName);
+    wcscat(g_LibDirName, L"\\");
+    wcscat(g_LibDirName, CX_LIB);
     if (!SetDllDirectoryW(g_LibDirName))
         return FatalError("Unable to change DLL search path!");
 
 #else
     char executableName[PATH_MAX + 1], *path, *ptr, *tempPtr;
     char tempname[MAXPATHLEN + 1];
-    wchar_t *wname, *wptr;
+    wchar_t *wname;
     size_t size, argv0Size;
     struct stat statData;
     int found = 0;

--- a/source/bases/Console.c
+++ b/source/bases/Console.c
@@ -9,7 +9,6 @@
 #ifdef MS_WINDOWS
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-#include <shlwapi.h>
 #endif
 
 // disable filename globbing on Windows

--- a/source/bases/Win32GUI.c
+++ b/source/bases/Win32GUI.c
@@ -8,7 +8,6 @@
 #include <locale.h>
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-#include <shlwapi.h>
 
 
 //-----------------------------------------------------------------------------

--- a/source/bases/Win32Service.c
+++ b/source/bases/Win32Service.c
@@ -9,7 +9,7 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <Winsvc.h>
-#include <shlwapi.h>
+#define OLECHAR WCHAR
 #include <cx_Logging.h>
 
 // define constants

--- a/source/util.c
+++ b/source/util.c
@@ -9,7 +9,7 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <imagehlp.h>
-#include <Shlwapi.h>
+#include <shlwapi.h>
 
 #pragma pack(2)
 


### PR DESCRIPTION
This patch was inspired by this issue: https://bugs.python.org/issue45720
