### PR TITLE
Search dlls in sys.path, then in the path [windows]

### DIFF
--- a/cx_Freeze/parser.py
+++ b/cx_Freeze/parser.py
@@ -58,7 +58,7 @@ class PEParser(Parser):
         if not self.is_PE(path):
             return dependent_files
         orig_path = os.environ["PATH"]
-        os.environ["PATH"] = orig_path + os.pathsep + os.pathsep.join(sys.path)
+        os.environ["PATH"] = os.pathsep.join(sys.path) + os.pathsep + orig_path
         try:
             files: List[str] = GetDependentFiles(path)
         except BindError as exc:


### PR DESCRIPTION
While apparently not an error, question #1065 lit the alert. And I recently had an error when trying to detect sqlite3.dll and saw that this error didn't appear because sqlite3.dll was always copied in the hooks.