### PR TITLE
Introduce tests in the GitHub CI

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,16 +10,13 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: 3.9
     - name: Install pip dependencies
       run: |
         python -m pip install --upgrade pip setuptools

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,28 @@
+name: cx_Freeze tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        # It's worthy to run the tests on each platform / python combination we support
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install test dependencies
+      run: python -m pip install -e .[test]
+    - name: Run tests with Pytest
+      run: pytest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,4 +25,4 @@ jobs:
     - name: Install test dependencies
       run: python -m pip install -e .[test]
     - name: Run tests with Pytest
-      run: pytest
+      run: python -m pytest


### PR DESCRIPTION
Toward https://github.com/marcelotduarte/cx_Freeze/pull/1368#issuecomment-1031961202.

The tests will run on every Python / OS combination we support (should we do that?), so everything will be covered. They run the steps described in https://github.com/marcelotduarte/cx_Freeze/blob/main/tests/Readme.md [^1]. I'm not using any additional automation tool [^2].

cc @marcelotduarte

[^1]: Initially, I'm just running `python -m pytest`. But the tests README also suggests using `python -m pytest -m "not long" --cov="cx_Freeze" --cov-report=html`. What should we use?

[^2]: I was thinking about using Nox to automate this, but then I noticed running pytest directly was cheaper :sweat_smile:. Just ignore that by now.