### PR TITLE
Bump black from 22.1.0 to 22.3.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
   - id: trailing-whitespace
 
 - repo: https://github.com/psf/black
-  rev: 22.1.0
+  rev: 22.3.0
   hooks:
   - id: black
 
@@ -22,7 +22,7 @@ repos:
   rev: v1.12.1
   hooks:
   - id: blacken-docs
-    additional_dependencies: [black==22.1.0]
+    additional_dependencies: [black==22.3.0]
     args: ["-l", "79"]
 
 - repo: https://github.com/PyCQA/isort


### PR DESCRIPTION
The current CI is failing, due to an issue with black + click. This upgrade fixes the issue.

See psf/black#2964 for full details.