### PR TITLE
More configuration to pylint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ exclude: |
     (?x)^(
         .bumpversion.cfg|
         tests/samples/invalid_syntax.py|
-        tests/samples/testpkg1
+        tests/samples/testpkg1/.*.py
     )$
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -58,7 +58,6 @@ repos:
     entry: pylint
     language: system
     types: [python]
-    files: ^tests$|finder.py
 
 - repo: https://github.com/thclark/pre-commit-sphinx
   rev: 0.0.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,31 @@ skip_gitignore = true
 [tool.pylint.format]
 max-line-length = 79
 
+[tool.pylint.master]
+ignore="""
+cli.py,
+darwintools.py,
+dist.py,
+freezer.py,
+macdist.py,
+module.py,
+parser.py,
+setupwriter.py,
+windist.py,
+winversioninfo.py
+"""
+ignore-paths = """
+^cx_Freeze/initscripts/.*.py$,
+^cx_Freeze/samples/.*.py$,
+^tests/samples/invalid_syntax.py$,
+^tests/samples/testpkg1/.*.py$,
+^doc/src/conf.py$
+"""
+py-version = 3.6
+
 [tool.pylint.messages_control]
 disable = [
+    "duplicate-code",
     "fixme",
     "import-error",
     "too-few-public-methods",


### PR DESCRIPTION
Modules in the 'ignore' list are not lint-ready and will be removed from the list as soon as they become parsable.