### PR TITLE
Call InitializePython from Service_Main instead of wmain.

### DIFF
--- a/samples/service-asyncio/Config.py
+++ b/samples/service-asyncio/Config.py
@@ -1,0 +1,45 @@
+# ------------------------------------------------------------------------------
+# Config.py
+#   This file defines information about the service. The first four
+# attributes are expected to be defined and if they are not an exception will
+# be thrown when attempting to create the service:
+#
+#   NAME
+#       the name to call the service with one %s place holder that will be used
+#       to identify the service further.
+#
+#   DISPLAY_NAME
+#       the value to use as the display name for the service with one %s place
+#       holder that will be used to identify the service further.
+#
+#   MODULE_NAME
+#       the name of the module implementing the service.
+#
+#   CLASS_NAME
+#       the name of the class within the module implementing the service. This
+#       class should accept no parameters in the constructor. It should have a
+#       method called 'initialize' which will accept the configuration file
+#       name. It should also have a method called 'run' which will be called
+#       with no parameters when the service is started. It should also have a
+#       method called 'stop' which will be called with no parameters when the
+#       service is stopped using the service control GUI.
+#
+#   DESCRIPTION
+#       the description of the service (optional)
+#
+#   AUTO_START
+#       whether the service should be started automatically (optional)
+#
+#   SESSION_CHANGES
+#       whether the service should monitor session changes (optional). If
+#       True, session changes will call the method 'session_changed' with the
+#       parameters sessionId and eventTypeId.
+# ------------------------------------------------------------------------------
+
+NAME = "cx_FreezeSampleServiceAsyncio%s"
+DISPLAY_NAME = "cx_Freeze Sample Service with asyncio - %s"
+MODULE_NAME = "ServiceHandler"
+CLASS_NAME = "Handler"
+DESCRIPTION = "Sample service description"
+AUTO_START = False
+SESSION_CHANGES = False

--- a/samples/service-asyncio/README.md
+++ b/samples/service-asyncio/README.md
@@ -1,0 +1,6 @@
+# Service sample with asyncio
+
+This is the same as the "service" sample, but with asyncio
+support. The ProactorEventLoop must be created in the service
+handler's __init__ method, because it's the only one which is
+guaranteed to be called from the main interpreter thread.

--- a/samples/service-asyncio/ServiceHandler.py
+++ b/samples/service-asyncio/ServiceHandler.py
@@ -1,0 +1,38 @@
+"""
+Implements a simple service using cx_Freeze.
+
+See below for more information on what methods must be implemented and how they
+are called.
+"""
+
+import threading
+import asyncio
+
+
+class Handler:
+
+    # no parameters are permitted; all configuration should be placed in the
+    # configuration file and handled in the initialize() method
+    def __init__(self):
+        # The loop MUST be created here.
+        self.loop = asyncio.ProactorEventLoop()
+
+        self.stopEvent = threading.Event()
+        self.stopRequestedEvent = asyncio.Event()
+
+    # called when the service is starting
+    def initialize(self, configFileName):
+        pass
+
+    # called when the service is starting immediately after initialize()
+    # use this to perform the work of the service; don't forget to set or check
+    # for the stop event or the service GUI will not respond to requests to
+    # stop the service
+    def run(self):
+        self.loop.run_until_complete(self.stopRequestedEvent.wait())
+        self.stopEvent.set()
+
+    # called when the service is being stopped by the service manager GUI
+    def stop(self):
+        self.loop.call_soon_threadsafe(self.stopRequestedEvent.set)
+        self.stopEvent.wait()

--- a/samples/service-asyncio/ServiceHandler.py
+++ b/samples/service-asyncio/ServiceHandler.py
@@ -5,8 +5,8 @@ See below for more information on what methods must be implemented and how they
 are called.
 """
 
-import threading
 import asyncio
+import threading
 
 
 class Handler:

--- a/samples/service-asyncio/setup.py
+++ b/samples/service-asyncio/setup.py
@@ -1,0 +1,36 @@
+"""
+A simple setup script for creating a Windows service.
+See the comments in the Config.py and ServiceHandler.py files for more
+information on how to set this up.
+
+Installing the service is done with the option --install <Name> and
+uninstalling the service is done with the option --uninstall <Name>. The
+value for <Name> is intended to differentiate between different invocations
+of the same service code -- for example for accessing different databases or
+using different configuration files.
+"""
+
+from cx_Freeze import Executable, setup
+
+options = {
+    "build_exe": {
+        "includes": ["ServiceHandler", "cx_Logging"],
+        "excludes": ["tkinter"],
+    }
+}
+
+executables = [
+    Executable(
+        "Config.py",
+        base="Win32Service",
+        target_name="cx_FreezeSampleServiceAsyncio.exe",
+    )
+]
+
+setup(
+    name="cx_FreezeSampleServiceAsyncio",
+    version="0.1",
+    description="Sample cx_Freeze Windows service with asyncio",
+    executables=executables,
+    options=options,
+)

--- a/source/bases/Win32Service.c
+++ b/source/bases/Win32Service.c
@@ -570,13 +570,13 @@ static int Service_Run(udt_ServiceInfo *info)
 // Service_Main()
 //   Main routine for the service.
 //-----------------------------------------------------------------------------
-static void WINAPI Service_Main(int argc, char **argv)
+static void WINAPI Service_Main(int argc, wchar_t **argv)
 {
     udt_ServiceInfo info;
 
     // initialize Python
     if (InitializePython(argc, argv) < 0)
-        return 1;
+        return;
 
     if (Service_SetupPython(&info) < 0)
         return;
@@ -620,8 +620,8 @@ int wmain(int argc, wchar_t **argv)
 {
     wchar_t *configFileName = NULL;
 
-    SERVICE_TABLE_ENTRY table[] = {
-        { "", (LPSERVICE_MAIN_FUNCTION) Service_Main },
+    SERVICE_TABLE_ENTRYW table[] = {
+        { L"", (LPSERVICE_MAIN_FUNCTIONW) Service_Main },
         { NULL, NULL }
     };
 
@@ -661,5 +661,5 @@ int wmain(int argc, wchar_t **argv)
     }
 
     // run the service normally
-    return StartServiceCtrlDispatcher(table);
+    return StartServiceCtrlDispatcherW(table);
 }


### PR DESCRIPTION
This makes the Service_Main thread the main interpreter thread, allowing
code that can only work in the main interpreter thread to be used in
a Windows service (for instance creating a ProactorEventLoop).

Also add a service sample using asyncio.