### PR TITLE
hooks: Support for pythonnet 3.0

### DIFF
--- a/cx_Freeze/hooks/__init__.py
+++ b/cx_Freeze/hooks/__init__.py
@@ -96,7 +96,7 @@ def load_clr(finder: ModuleFinder, module: Module) -> None:
     dll_name = "Python.Runtime.dll"
     finder.include_files(
         module.file.parent / "pythonnet/runtime" / dll_name,
-        Path("lib", dll_name)
+        Path("lib", dll_name),
     )
 
 

--- a/cx_Freeze/hooks/__init__.py
+++ b/cx_Freeze/hooks/__init__.py
@@ -103,7 +103,7 @@ def load_clr(finder: ModuleFinder, module: Module) -> None:
 def load_cryptography_hazmat_bindings__openssl(
     finder: ModuleFinder, module: Module
 ) -> None:
-    """The crptography module requires the _cffi_backend module."""
+    """The cryptography module requires the _cffi_backend module."""
     finder.include_module("_cffi_backend")
 
 

--- a/cx_Freeze/hooks/__init__.py
+++ b/cx_Freeze/hooks/__init__.py
@@ -94,7 +94,10 @@ def load_clr(finder: ModuleFinder, module: Module) -> None:
     """The pythonnet package (imported as 'clr') needs Python.Runtime.dll
     in runtime."""
     dll_name = "Python.Runtime.dll"
-    finder.include_files(module.file.parent / "pythonnet/runtime" / dll_name, Path("lib", dll_name))
+    finder.include_files(
+        module.file.parent / "pythonnet/runtime" / dll_name,
+        Path("lib", dll_name)
+    )
 
 
 def load_cryptography_hazmat_bindings__openssl(

--- a/cx_Freeze/hooks/__init__.py
+++ b/cx_Freeze/hooks/__init__.py
@@ -94,16 +94,16 @@ def load_clr(finder: ModuleFinder, module: Module) -> None:
     """The pythonnet package (imported as 'clr') needs Python.Runtime.dll
     in runtime."""
     dll_name = "Python.Runtime.dll"
-    finder.include_files(
-        module.file.parent / "pythonnet/runtime" / dll_name,
-        Path("lib", dll_name),
-    )
+    dll_path = module.file.parent / dll_name
+    if not dll_path.exists():
+        dll_path = module.file.parent / "pythonnet/runtime" / dll_name
+    finder.include_files(dll_path, Path("lib", dll_name))
 
 
 def load_cryptography_hazmat_bindings__openssl(
     finder: ModuleFinder, module: Module
 ) -> None:
-    """The cryptography module requires the _cffi_backend module."""
+    """The crptography module requires the _cffi_backend module."""
     finder.include_module("_cffi_backend")
 
 

--- a/cx_Freeze/hooks/__init__.py
+++ b/cx_Freeze/hooks/__init__.py
@@ -94,7 +94,7 @@ def load_clr(finder: ModuleFinder, module: Module) -> None:
     """The pythonnet package (imported as 'clr') needs Python.Runtime.dll
     in runtime."""
     dll_name = "Python.Runtime.dll"
-    finder.include_files(module.file.parent / dll_name, Path("lib", dll_name))
+    finder.include_files(module.file.parent / "pythonnet/runtime" / dll_name, Path("lib", dll_name))
 
 
 def load_cryptography_hazmat_bindings__openssl(


### PR DESCRIPTION
correct Python.Runtime.dll path for the pythonnet package (>3.0.0rc4).