### PR TITLE
Improved documentation of initial_target_dir option on bdist_msi

### DIFF
--- a/doc/src/setup_script.rst
+++ b/doc/src/setup_script.rst
@@ -349,7 +349,10 @@ command:
        installation
    * - .. option:: initial_target_dir
      - defines the initial target directory supplied to the user during
-       installation
+       installation; in order to specify a target directory of "XYZ" in the
+       default program directory use "[ProgramFiles64Folder]\XYZ" or
+       "[ProgramFilesFolder]\XYZ" (for the default 64-bit or non-64 bit
+       locations, respectively)
    * - .. option:: install_icon
      - path of icon to use for the add/remove programs window that pops up
        during installation


### PR DESCRIPTION
Expand the documentation for the initial_target_dir option on bdist_msi, in order to explain how the user can achieve the "normal" result of having the application installed under "Program Files".

Instead of this, we could consider modifying bdist_msi so that [ProgramFiles64Folder] or [ProgramFilesFolder] (as applicable) as added in front of any value that the user supplies.  That would be easier for the user most of the time, but allow less flexiblity.