### PR TITLE
Drop the external dependency on importlib-metadata

### DIFF
--- a/cx_Freeze/_compat.py
+++ b/cx_Freeze/_compat.py
@@ -1,4 +1,5 @@
 """Internal compatible module."""
+
 import sys
 
 __all__ = ["cached_property", "importlib_metadata"]
@@ -6,10 +7,7 @@ __all__ = ["cached_property", "importlib_metadata"]
 if sys.version_info >= (3, 10):
     import importlib.metadata as importlib_metadata
 else:
-    try:
-        import importlib_metadata
-    except ImportError:
-        import importlib.metadata as importlib_metadata
+    from setuptools.extern import importlib_metadata
 
 
 try:

--- a/doc/src/installation.rst
+++ b/doc/src/installation.rst
@@ -29,7 +29,6 @@ Python requirements are installed automatically by pip or conda.
 
    C compiler                  (required if installing from sources)
    cx_Logging >= 3.1           (Windows only)
-   importlib-metadata >= 4.8.3 (Python < 3.10)
    lief >= 0.11.5              (Windows only)
    packaging >= 21.0
    patchelf >= 0.12            (Linux)
@@ -92,7 +91,6 @@ using the same channel:
    python
    c-compiler
    libpython-static (for python >=3.8 in linux and macOS)
-   importlib-metadata
    py-lief (Windows)
    patchelf (Linux)
    declare SDKROOT or CONDA_BUILD_SYSROOT (for python 3.9+ in macOS)
@@ -107,7 +105,7 @@ An example using Miniconda3:
     # For macOS and Linux
     conda create -n cx39conda -c conda-forge python=3.9 libpython-static -y
     conda activate cx39conda
-    conda install -c conda-forge c-compiler importlib-metadata patchelf -y
+    conda install -c conda-forge c-compiler patchelf -y
     pip install --no-binary=cx_Freeze --pre cx_Freeze -v
 
 Download tarball or wheels

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ dependencies = [
     "packaging>=21.3",
     "setuptools>=61.2,<66",
     "cx_Logging>=3.1 ;sys_platform == 'win32'",
-    "importlib-metadata>=4.8.3 ;python_version < '3.10'",
     "lief>=0.12.0 ;sys_platform == 'win32'",
     "patchelf>=0.13 ;sys_platform == 'linux'",
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,6 @@
 packaging>=21.3
 setuptools>=61.2,<66
 cx_Logging>=3.1 ;sys_platform == 'win32'
-importlib-metadata>=4.8.3 ;python_version < '3.10'
 lief>=0.12.0 ;sys_platform == 'win32'
 patchelf>=0.13 ;sys_platform == 'linux'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,5 @@
 packaging>=21.3
 setuptools>=61.2,<66
 cx_Logging>=3.1 ;sys_platform == 'win32'
-importlib-metadata>=4.8.3 ;python_version < '3.10'
 lief>=0.12.0 ;sys_platform == 'win32'
 patchelf>=0.13 ;sys_platform == 'linux'


### PR DESCRIPTION
Now we are using setuptools > 61.2 that has internal importlib-metadata (since 60.8.0).