### PR TITLE
dist: Use setuptools plugins to extend Distribution instead of subclassing

### DIFF
--- a/cx_Freeze/__init__.py
+++ b/cx_Freeze/__init__.py
@@ -12,7 +12,6 @@ from .command.build import Build as build
 from .command.build_exe import BuildEXE as build_exe
 from .command.install import Install as install
 from .command.install_exe import InstallEXE as install_exe
-from .dist import Distribution
 from .exception import ConfigError
 from .finder import Module, ModuleFinder
 from .freezer import ConstantsModule, Executable, Freezer
@@ -55,7 +54,6 @@ def _add_command_class(command_classes, name, cls):
 
 
 def setup(**attrs):  # pylint: disable=C0116
-    attrs.setdefault("distclass", Distribution)
     command_classes = attrs.setdefault("cmdclass", {})
     if sys.platform == "win32":
         _add_command_class(command_classes, "bdist_msi", bdist_msi)

--- a/cx_Freeze/dist.py
+++ b/cx_Freeze/dist.py
@@ -2,34 +2,42 @@
 
 from __future__ import annotations
 
-from setuptools import Distribution as _Distribution
+from setuptools import Distribution
+from setuptools.errors import SetupError
+
+from .executable import Executable
 
 __all__ = ["Distribution", "DistributionMetadata"]
 
 
-class Distribution(_Distribution):
-    """Distribution with support for executables."""
+# pylint: disable-next=unused-argument
+def validate_executables(dist: Distribution, attr: str, value):
+    """Verify that value is a Executable list."""
 
-    def __init__(self, attrs):
-        self.executables = []
-        super().__init__(attrs)
-        self._fix_py_modules()
-
-    def _fix_py_modules(self):
-        # fix package discovery (setuptools >= 61)
-        if not self.executables:
-            return
-        self.include(
-            py_modules=[
-                executable.main_script.stem for executable in self.executables
-            ]
-        )
-
-    def has_executables(self):
-        """Predicate for build_exe command."""
-        return self.executables and len(self.executables) > 0
+    try:
+        # verify that value is a list or tuple to exclude unordered
+        # or single-use iterables
+        assert isinstance(value, (list, tuple))
+        # verify that elements of value are Executable
+        for executable in value:
+            assert isinstance(executable, Executable)
+    except (TypeError, ValueError, AttributeError, AssertionError) as exc:
+        raise SetupError(
+            f"{attr!r} must be a list of Executable (got {value!r})"
+        ) from exc
 
 
-DistributionMetadata = type(_Distribution().metadata)
+def finalize_distribution_options(dist: Distribution) -> None:
+    """Use a setuptools extension to customize Distribution options."""
+
+    if getattr(dist, "executables", None) is None:
+        return
+
+    # fix package discovery (setuptools >= 61)
+    if getattr(dist.metadata, "py_modules", None) is None:
+        dist.py_modules = []
+
+
+DistributionMetadata = type(Distribution().metadata)
 """Dummy class to hold the distribution meta-data: name, version, author,
 and so forth."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,12 @@ test = [
 cxfreeze = "cx_Freeze.cli:main"
 cxfreeze-quickstart = "cx_Freeze.setupwriter:main"
 
+[project.entry-points."distutils.setup_keywords"]
+executables = "cx_Freeze.dist:validate_executables"
+
+[project.entry-points."setuptools.finalize_distribution_options"]
+build = "cx_Freeze.dist:finalize_distribution_options"
+
 [tool.setuptools]
 include-package-data = true
 zip-safe = false

--- a/tests/test_command_bdist_msi.py
+++ b/tests/test_command_bdist_msi.py
@@ -1,4 +1,5 @@
 """Tests for cx_Freeze.command.bdist_msi."""
+
 from __future__ import annotations
 
 import sys
@@ -12,6 +13,13 @@ from cx_Freeze.sandbox import run_setup
 
 if sys.platform == "win32":
     from cx_Freeze.command.bdist_msi import BdistMSI
+
+DIST_ATTRS = {
+    "name": "foo",
+    "version": "0.0",
+    "executables": [],
+    "script_name": "setup.py",
+}
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="Windows tests")
@@ -40,9 +48,7 @@ def test_bdist_msi(fix_main_samples_path: Path):
 def test_bdist_msi_target_name():
     """Test the bdist_msi with extra target_name option."""
 
-    dist = Distribution(
-        {"name": "foo", "version": "0.0", "script_name": "setup.py"}
-    )
+    dist = Distribution(DIST_ATTRS)
     cmd = BdistMSI(dist)
     cmd.target_name = "mytest"
     cmd.finalize_options()
@@ -55,9 +61,7 @@ def test_bdist_msi_target_name():
 def test_bdist_msi_target_name_and_version():
     """Test the bdist_msi with extra target options."""
 
-    dist = Distribution(
-        {"name": "foo", "version": "0.0", "script_name": "setup.py"}
-    )
+    dist = Distribution(DIST_ATTRS)
     cmd = BdistMSI(dist)
     cmd.target_name = "mytest"
     cmd.target_version = "0.1"

--- a/tests/test_command_build_exe.py
+++ b/tests/test_command_build_exe.py
@@ -1,0 +1,32 @@
+"""Tests for cx_Freeze.command.build_exe."""
+
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path
+from sysconfig import get_platform, get_python_version
+
+from cx_Freeze.sandbox import run_setup
+
+PLATFORM = get_platform()
+PYTHON_VERSION = get_python_version()
+BUILD_EXE_DIR = f"build/exe.{PLATFORM}-{PYTHON_VERSION}"
+
+
+def test_build_exe(fix_main_samples_path: Path):
+    """Test the simple sample."""
+
+    setup_path = fix_main_samples_path / "simple"
+    dist_created = setup_path / BUILD_EXE_DIR
+    dist_already_exists = dist_created.exists()
+
+    run_setup(setup_path / "setup.py", ["build_exe", "--silent"])
+
+    suffix = ".exe" if sys.platform == "win32" else ""
+    file_created = dist_created / f"hello{suffix}"
+    assert file_created.is_file()
+    file_created.unlink()
+
+    if not dist_already_exists:
+        shutil.rmtree(dist_created)


### PR DESCRIPTION
This change is needed to facilitate the future implementation of pyproject support.