### PR TITLE
commands: accepts space-delimited string lists

### DIFF
--- a/cx_Freeze/__init__.py
+++ b/cx_Freeze/__init__.py
@@ -58,6 +58,7 @@ def setup(**attrs):  # pylint: disable=missing-function-docstring
     cmdclass.setdefault("build_exe", build_exe)
     cmdclass.setdefault("install", install)
     cmdclass.setdefault("install_exe", install_exe)
+    attrs.setdefault("executables", [])
     setuptools.setup(**attrs)
 
 

--- a/cx_Freeze/command/bdist_mac.py
+++ b/cx_Freeze/command/bdist_mac.py
@@ -8,6 +8,7 @@ import shutil
 import subprocess
 
 from setuptools import Command
+from setuptools.errors import OptionError
 
 from cx_Freeze.darwintools import (
     DarwinFile,
@@ -189,34 +190,50 @@ class BdistMac(Command):
     ]
 
     def initialize_options(self):
-        self.list_options = [
-            "plist_items",
+        self.string_list_options = [
             "include_frameworks",
             "include_resources",
         ]
-        for option in self.list_options:
+        for option in self.string_list_options:
             setattr(self, option, [])
 
-        self.iconfile = None
-        self.qt_menu_nib = False
-        self.bundle_name = self.distribution.get_fullname()
-        self.custom_info_plist = None
-        self.codesign_identity = None
-        self.codesign_entitlements = None
-        self.codesign_deep = None
-        self.codesign_resource_rules = None
         self.absolute_reference_path = None
+        self.bundle_name = self.distribution.get_fullname()
+        self.iconfile = None
+        self.codesign_deep = None
+        self.codesign_entitlements = None
+        self.codesign_identity = None
+        self.codesign_resource_rules = None
+        self.custom_info_plist = None
+        self.plist_items = None
+        self.qt_menu_nib = False
 
     def finalize_options(self):
         # Make sure all options of multiple values are lists
-        for option in self.list_options:
+        for option in self.string_list_options:
             self.ensure_string_list(option)
-        for item in self.plist_items:
-            if not isinstance(item, tuple) or len(item) != 2:
-                raise Exception(
-                    "Error, plist_items must be a list of key, value pairs "
-                    "(List[Tuple[str, str]]) (bad list item)."
-                )
+        self._ensure_dict("plist_items")
+
+    def _ensure_dict(self, option):
+        """Ensure that 'option' is a list of key/value."""
+        val = getattr(self, option)
+        if val is None:
+            return
+        try:
+            val = dict(val)
+            valid = all(
+                isinstance(k, str) and isinstance(v, str)
+                for k, v in val.items()
+            )
+        except ValueError:
+            valid = False
+        if valid:
+            setattr(self, option, val)
+        else:
+            raise OptionError(
+                f"{option!r} must be a list of key, value pairs or a dict "
+                f"(got {val!r})"
+            )
 
     def create_plist(self):
         """Create the Contents/Info.plist file"""
@@ -241,8 +258,8 @@ class BdistMac(Command):
         contents["CFBundleExecutable"] = self.bundle_executable
 
         # add custom items to the plist file
-        for key, value in self.plist_items:
-            contents[key] = value
+        if self.plist_items:
+            contents.update(self.plist_items)
 
         with open(os.path.join(self.contents_dir, "Info.plist"), "wb") as file:
             plistlib.dump(contents, file)

--- a/cx_Freeze/command/bdist_mac.py
+++ b/cx_Freeze/command/bdist_mac.py
@@ -9,7 +9,6 @@ import subprocess
 
 from setuptools import Command
 
-from cx_Freeze.common import normalize_to_list
 from cx_Freeze.darwintools import (
     DarwinFile,
     DarwinFileTracker,
@@ -211,7 +210,7 @@ class BdistMac(Command):
     def finalize_options(self):
         # Make sure all options of multiple values are lists
         for option in self.list_options:
-            setattr(self, option, normalize_to_list(getattr(self, option)))
+            self.ensure_string_list(option)
         for item in self.plist_items:
             if not isinstance(item, tuple) or len(item) != 2:
                 raise Exception(

--- a/cx_Freeze/command/build_exe.py
+++ b/cx_Freeze/command/build_exe.py
@@ -10,7 +10,6 @@ from sysconfig import get_platform, get_python_version
 from setuptools import Command
 from setuptools.errors import SetupError
 
-from ..common import normalize_to_list
 from ..freezer import Freezer
 from ..module import ConstantsModule
 
@@ -229,7 +228,7 @@ class BuildEXE(Command):
 
         # Make sure all options of multiple values are lists
         for option in self.list_options:
-            setattr(self, option, normalize_to_list(getattr(self, option)))
+            self.ensure_string_list(option)
 
     def run(self):
         metadata = self.distribution.metadata

--- a/cx_Freeze/command/build_exe.py
+++ b/cx_Freeze/command/build_exe.py
@@ -165,7 +165,7 @@ class BuildEXE(Command):
         )
 
     def initialize_options(self):
-        self.list_options = [
+        self.string_list_options = [
             "excludes",
             "includes",
             "packages",
@@ -181,7 +181,7 @@ class BuildEXE(Command):
             "zip_exclude_packages",
         ]
 
-        for option in self.list_options:
+        for option in self.string_list_options:
             setattr(self, option, [])
 
         self.zip_exclude_packages = ["*"]
@@ -227,7 +227,7 @@ class BuildEXE(Command):
             self.silent_setting = 1
 
         # Make sure all options of multiple values are lists
-        for option in self.list_options:
+        for option in self.string_list_options:
             self.ensure_string_list(option)
 
     def run(self):

--- a/doc/src/setup_script.rst
+++ b/doc/src/setup_script.rst
@@ -25,10 +25,8 @@ It looks something like this:
          from cx_Freeze import setup, Executable
 
          # Dependencies are automatically detected, but it might need fine tuning.
-         # "packages": ["os"] is used as example only
          build_exe_options = {
-             "packages": ["os"],
-             "excludes": ["tkinter"],
+             "excludes": ["tkinter", "unittest"],
              "zip_include_packages": ["encodings", "PySide6"],
          }
 
@@ -66,8 +64,7 @@ It looks something like this:
          description = "My GUI application!"
 
          [tool.distutils.build_exe]
-         packages = ["os"]
-         excludes = ["tkinter"]
+         excludes = ["tkinter", "unittest"]
          zip_include_packages = ["encodings", "PySide6"]
 
    .. group-tab:: setup.cfg
@@ -93,13 +90,8 @@ It looks something like this:
          description = My GUI application!
 
          [build_exe]
-         packages =
-             os
-         excludes =
-             tkinter
-         zip_include_packages =
-             encodings
-             PySide6
+         excludes = tkinter unittest
+         zip_include_packages = encodings PySide6
 
    .. group-tab:: command line
 
@@ -110,7 +102,7 @@ It looks something like this:
          from cx_Freeze import setup, Executable
 
          build_exe_options = {
-             "excludes": ["tkinter"],
+             "zip_include_packages": ["encodings", "PySide6"],
          }
 
          # base="Win32GUI" should be used only for Windows GUI app
@@ -150,7 +142,7 @@ The script is invoked as follows:
 
       .. code-block:: console
 
-         python setup.py build_exe --zip-include-packages=encodings,PySide6
+         python setup.py build_exe --excludes=tkinter,unittest
 
 .. seealso::
 

--- a/samples/simple_pyproject/pyproject.toml
+++ b/samples/simple_pyproject/pyproject.toml
@@ -4,4 +4,4 @@ version = "0.1.2.3"
 description = "Sample cx_Freeze script"
 
 [tool.distutils.build_exe]
-excludes = ["tkinter"]
+excludes = ["tkinter", "unittest"]

--- a/samples/simple_setup_cfg/setup.cfg
+++ b/samples/simple_setup_cfg/setup.cfg
@@ -4,5 +4,4 @@ version = 0.1.2.3
 description = Sample cx_Freeze script
 
 [build_exe]
-excludes =
-    tkinter
+excludes = tkinter,unittest

--- a/tests/samples/plist_items/setup.py
+++ b/tests/samples/plist_items/setup.py
@@ -1,5 +1,5 @@
-# A simple script demonstrating use of plist_items option.
-#
+"""A simple script demonstrating use of plist_items option."""
+
 # hello.py is a very simple 'Hello, world' type script which also displays the
 # environment in which the script runs
 #


### PR DESCRIPTION
setuptools accepts comma-delimited, space-delimited, or both for string lists.