### PR TITLE
windows: put all msvcr dlls in build_exe top directory

### DIFF
--- a/cx_Freeze/freezer.py
+++ b/cx_Freeze/freezer.py
@@ -672,7 +672,6 @@ class WinFreezer(Freezer, PEParser):
 
         # deal with C-runtime files
         self.runtime_files: set[str] = set()
-        self.runtime_files_to_dup: set[str] = set()
         self._set_runtime_files()
 
     def _add_resources(self, exe: Executable) -> None:
@@ -775,20 +774,12 @@ class WinFreezer(Freezer, PEParser):
 
     def _pre_copy_hook(self, source: Path, target: Path) -> tuple[Path, Path]:
         """Prepare the source and target paths. Also, adjust the target of
-        C runtime libraries and triggers an additional copy for files in
-        self.runtime_files_to_dup."""
+        C runtime libraries."""
 
         # fix the target path for C runtime files
         norm_target_name = target.name.lower()
         if norm_target_name in self.runtime_files:
-            target = self.targetdir / "lib" / norm_target_name
-
-            # vcruntime140.dll must be in the root and in the lib directory
-            if norm_target_name in self.runtime_files_to_dup:
-                self.runtime_files_to_dup.remove(norm_target_name)
-                self._copy_file(source, target, copy_dependent_files=False)
-                self.files_copied.remove(target)
-                target = self.targetdir / norm_target_name
+            target = self.targetdir / norm_target_name
         return source, target
 
     def _post_copy_hook(
@@ -931,7 +922,6 @@ class WinFreezer(Freezer, PEParser):
     def _set_runtime_files(self) -> None:
         if self.include_msvcr:
             self.runtime_files.update(winmsvcr.FILES)
-            self.runtime_files_to_dup.update(winmsvcr.FILES_TO_DUPLICATE)
         else:
             # just put on the exclusion list
             self.bin_excludes.extend([Path(name) for name in winmsvcr.FILES])

--- a/cx_Freeze/hooks/__init__.py
+++ b/cx_Freeze/hooks/__init__.py
@@ -602,11 +602,13 @@ def load_sklearn__distributor_init(
     """On Windows the sklearn/.libs directory is not copied."""
     source_dir = module.parent.path[0] / ".libs"
     if source_dir.exists():
-        # msvc files should be copied to lib directory
+        # msvcp140 and vcomp140 dlls should be copied
         finder.include_files(source_dir, "lib")
         # patch the code to search the correct directory
         code_string = module.file.read_text()
-        code_string = code_string.replace("libs_path =", "libs_path = 'lib'#")
+        code_string = code_string.replace(
+            "libs_path =", "libs_path = __import__('sys').frozen_dir  #"
+        )
         module.code = compile(code_string, os.fspath(module.file), "exec")
 
 

--- a/cx_Freeze/winmsvcr.py
+++ b/cx_Freeze/winmsvcr.py
@@ -64,5 +64,3 @@ FILES = (
     "msvcp140_atomic_wait.dll",
     "msvcp140_codecvt_ids.dll",
 )
-
-FILES_TO_DUPLICATE = ("vcruntime140.dll",)

--- a/tests/test_winmsvcr.py
+++ b/tests/test_winmsvcr.py
@@ -1,14 +1,12 @@
 """Test winmsvcr"""
 
-# pylint: disable=missing-function-docstring,unused-import
 from __future__ import annotations
 
-import pytest  # noqa
-
-from cx_Freeze.winmsvcr import FILES, FILES_TO_DUPLICATE
+from cx_Freeze.winmsvcr import FILES
 
 
 def test_files():
+    """Test winmsvcr.FILES"""
     expected = (
         # VC 2015 and 2017
         "api-ms-win-core-console-l1-1-0.dll",
@@ -66,8 +64,3 @@ def test_files():
         "msvcp140_codecvt_ids.dll",
     )
     assert expected == FILES
-
-
-def test_files_to_duplicate():
-    expected = ("vcruntime140.dll",)
-    assert expected == FILES_TO_DUPLICATE


### PR DESCRIPTION
Fixes #1732 
Fixes #1775 
When the VC runtime components demand occurs at program startup, they need to be in the same directory. As vcruntime140 needs to be in the same directory as python3x, the solution is for all of them to be in the top directory.