### PR TITLE
Exit with non-zero exit code on exception

### DIFF
--- a/source/bases/Win32Service.c
+++ b/source/bases/Win32Service.c
@@ -101,8 +101,6 @@ static int Service_SetStatus(udt_ServiceInfo* info, DWORD status, DWORD exit_cod
         serviceStatus.dwWin32ExitCode = ERROR_SERVICE_SPECIFIC_ERROR;
         serviceStatus.dwServiceSpecificExitCode = exit_code;
     }
-    serviceStatus.dwWin32ExitCode = 0;
-    serviceStatus.dwServiceSpecificExitCode = 0;
     serviceStatus.dwCheckPoint = 0;
     serviceStatus.dwWaitHint = 0;
     if (!SetServiceStatus(gServiceHandle, &serviceStatus))

--- a/source/bases/Win32Service.c
+++ b/source/bases/Win32Service.c
@@ -587,10 +587,10 @@ static void WINAPI Service_Main(int argc, wchar_t **argv)
     }
 
     // run the service
-    if (Service_Run(&info)) {
+    if (Service_Run(&info) < 0) {
         // exit the process without setting SERVICE_STOPPED, to indicate that the
         // service did not close intentionally
-        ExitProcess(-1:)
+        ExitProcess(-1);
     }
 
     // ensure that the main thread does not terminate before the control


### PR DESCRIPTION
# Intent: Resolve issue #898  

### How: 
Ensure that when the return value of `Service_Run()` is less than zero, we exit the service with an exit code of -1. This is done without setting the SERVICE_STOPPED state to indicate that this was not an intentional stop. 

According to the Windows API documentation, this is the expectation from the system.

> A service is considered failed when it terminates without reporting a status of SERVICE_STOPPED to the service controller.
[Source](https://learn.microsoft.com/en-us/windows/win32/api/winsvc/ns-winsvc-service_failure_actionsa)

### Why: 
Enable services to communicate internal failures, so that an automatic restart policy can be applied.

### Testing:
Testing has been done in a pair-dev setup with @TechnicalPirate.