### PR TITLE
Check that parent directory exists before writing to file

### DIFF
--- a/cx_Freeze/freezer.py
+++ b/cx_Freeze/freezer.py
@@ -610,8 +610,7 @@ class Freezer:
                             parts.append("__init__")
                         target_name = target_lib_dir.joinpath(*parts)
                         target_name = target_name.with_suffix(".pyc")
-                        if not os.path.exists(target_name.parent):
-                            self._create_directory(target_name.parent)
+                        self._create_directory(target_name.parent)
                         target_name.write_bytes(data)
 
                 # otherwise, write to the zip file

--- a/cx_Freeze/freezer.py
+++ b/cx_Freeze/freezer.py
@@ -611,7 +611,7 @@ class Freezer:
                         target_name = target_lib_dir.joinpath(*parts)
                         target_name = target_name.with_suffix(".pyc")
                         if not os.path.exists(target_name.parent):
-                            os.mkdir(target_name.parent)
+                            self._create_directory(target_name.parent)
                         target_name.write_bytes(data)
 
                 # otherwise, write to the zip file

--- a/cx_Freeze/freezer.py
+++ b/cx_Freeze/freezer.py
@@ -610,6 +610,8 @@ class Freezer:
                             parts.append("__init__")
                         target_name = target_lib_dir.joinpath(*parts)
                         target_name = target_name.with_suffix(".pyc")
+                        if not os.path.exists(target_name.parent):
+                            os.mkdir(target_name.parent)
                         target_name.write_bytes(data)
 
                 # otherwise, write to the zip file


### PR DESCRIPTION
I found that my system, which uses importlib, error'd when the parent directory at this line didn't exist, when I added a check and make if not it worked and completed the build.