### PR TITLE
Add a hook for ttkbootstrap that requires the tcl8 directory to be present.

### DIFF
--- a/cx_Freeze/hooks/__init__.py
+++ b/cx_Freeze/hooks/__init__.py
@@ -541,11 +541,12 @@ def load_ttkbootstrap(finder: ModuleFinder, module: Module) -> None:
         root = tkinter.Tk(useTk=False)
         source_path = Path(root.tk.exprstring("$tcl_library"))
         folders.append(("TCL_LIBRARY", source_path))
-    for env_name, source_path in folders:
+    for _, source_path in folders:
         # get the root tcl dir. If soure_path.name = tcl8.6 then tcl8
         new_name = os.path.splitext(source_path.name)[0]
         target_path = Path("lib", new_name)
-        finder.include_files(os.path.join(os.path.split(source_path)[0], new_name), target_path)
+        finder.include_files(
+            os.path.join(os.path.split(source_path)[0], new_name), target_path)
 
 
 def load_time(finder: ModuleFinder, module: Module) -> None:

--- a/cx_Freeze/hooks/__init__.py
+++ b/cx_Freeze/hooks/__init__.py
@@ -524,6 +524,7 @@ def load_tensorflow(finder: ModuleFinder, module: Module) -> None:
     finder.include_package("tensorflow.compiler")
     finder.include_package("tensorflow.python")
 
+
 def load_ttkbootstrap(finder: ModuleFinder, module: Module) -> None:
     """The ttkbootstrap package needs the tcl8 directory.
     This isn't copied by the Tkinter load hook, so we need an extra hook."""

--- a/cx_Freeze/hooks/__init__.py
+++ b/cx_Freeze/hooks/__init__.py
@@ -13,6 +13,7 @@ from contextlib import suppress
 from pathlib import Path
 
 from .._compat import IS_MINGW, IS_WINDOWS
+from ..common import get_resource_file_path
 from ..finder import ModuleFinder
 from ..module import Module
 from ._qthooks import get_qt_plugins_paths  # noqa: F401
@@ -522,6 +523,30 @@ def load_tensorflow(finder: ModuleFinder, module: Module) -> None:
     finder.include_package("tensorboard")
     finder.include_package("tensorflow.compiler")
     finder.include_package("tensorflow.python")
+
+def load_ttkbootstrap(finder: ModuleFinder, module: Module) -> None:
+    """The ttkbootstrap package needs the tcl8 directory.
+    The tkinter module has data files (also called tcl/tk libraries) that
+    are required to be loaded at runtime."""
+    folders = []
+    tcltk = get_resource_file_path("bases", "tcltk", "")
+    if tcltk and tcltk.is_dir():
+        # manylinux wheels and macpython wheels store tcl/tk libraries
+        folders.append(("TCL_LIBRARY", list(tcltk.glob("tcl*"))[0]))
+    else:
+        # Windows, MSYS2, Miniconda: collect the tcl/tk libraries
+        try:
+            tkinter = __import__("tkinter")
+        except (ImportError, AttributeError):
+            return
+        root = tkinter.Tk(useTk=False)
+        source_path = Path(root.tk.exprstring("$tcl_library"))
+        folders.append(("TCL_LIBRARY", source_path))
+    for env_name, source_path in folders:
+        # get the root tcl dir. If soure_path.name = tcl8.6 then tcl8
+        new_name = os.path.splitext(source_path.name)[0]
+        target_path = Path("lib", new_name)
+        finder.include_files(os.path.join(os.path.split(source_path)[0], new_name), target_path)
 
 
 def load_time(finder: ModuleFinder, module: Module) -> None:

--- a/cx_Freeze/hooks/__init__.py
+++ b/cx_Freeze/hooks/__init__.py
@@ -525,7 +525,7 @@ def load_tensorflow(finder: ModuleFinder, module: Module) -> None:
     finder.include_package("tensorflow.python")
 
 
-def load_ttkbootstrap(finder: ModuleFinder, module: Module) -> None:
+def load_ttkbootstrap(finder: ModuleFinder, _: Module) -> None:
     """The ttkbootstrap package needs the tcl8 directory.
     This isn't copied by the Tkinter load hook, so we need an extra hook."""
     folders = []

--- a/cx_Freeze/hooks/__init__.py
+++ b/cx_Freeze/hooks/__init__.py
@@ -546,7 +546,8 @@ def load_ttkbootstrap(finder: ModuleFinder, module: Module) -> None:
         new_name = os.path.splitext(source_path.name)[0]
         target_path = Path("lib", new_name)
         finder.include_files(
-            os.path.join(os.path.split(source_path)[0], new_name), target_path)
+            os.path.join(os.path.split(source_path)[0], new_name), target_path
+        )
 
 
 def load_time(finder: ModuleFinder, module: Module) -> None:

--- a/cx_Freeze/hooks/__init__.py
+++ b/cx_Freeze/hooks/__init__.py
@@ -526,8 +526,7 @@ def load_tensorflow(finder: ModuleFinder, module: Module) -> None:
 
 def load_ttkbootstrap(finder: ModuleFinder, module: Module) -> None:
     """The ttkbootstrap package needs the tcl8 directory.
-    The tkinter module has data files (also called tcl/tk libraries) that
-    are required to be loaded at runtime."""
+    This isn't copied by the Tkinter load hook, so we need an extra hook."""
     folders = []
     tcltk = get_resource_file_path("bases", "tcltk", "")
     if tcltk and tcltk.is_dir():


### PR DESCRIPTION
Tested for windows and with the newest version of cx_freeze that doesn't put the tkinter directories under tcltk.