### PR TITLE
fix: a missing check in matplotlib hooks

### DIFF
--- a/cx_Freeze/hooks/matplotlib.py
+++ b/cx_Freeze/hooks/matplotlib.py
@@ -59,6 +59,7 @@ def _remove_delvewheel(module: Module) -> None:
     if module.code is None:
         return
     code = module.code
+    name = None
     delvewheel_func = "_delvewheel_init_patch_"
     consts = list(code.co_consts)
     for constant in consts:
@@ -66,6 +67,8 @@ def _remove_delvewheel(module: Module) -> None:
             name = constant.co_name
             if name.startswith(delvewheel_func):
                 break
+    if name is None:
+        return
     source = f"""\
     def {name}():
         return


### PR DESCRIPTION
Do not break building with matplotlib < 3.7