### PR TITLE
fix: parse namespace packages as packages in zip options

### DIFF
--- a/cx_Freeze/finder.py
+++ b/cx_Freeze/finder.py
@@ -47,14 +47,14 @@ class ModuleFinder:
 
     def __init__(
         self,
-        include_files: IncludesList | None = None,
+        constants_module: ConstantsModule | None = None,
         excludes: list[str] | None = None,
+        include_files: IncludesList | None = None,
         path: list[str | Path] | None = None,
         replace_paths: list[tuple[str, str]] | None = None,
+        zip_exclude_packages: Sequence[str] | None = None,
+        zip_include_packages: Sequence[str] | None = None,
         zip_include_all_packages: bool = False,
-        zip_exclude_packages: list[str] | None = None,
-        zip_include_packages: list[str] | None = None,
-        constants_module: ConstantsModule | None = None,
         zip_includes: IncludesList | None = None,
     ):
         self.included_files: InternalIncludesList = process_path_specs(
@@ -65,8 +65,8 @@ class ModuleFinder:
         self.path: list[str] = list(map(os.fspath, path or sys.path))
         self.replace_paths = replace_paths or []
         self.zip_include_all_packages = zip_include_all_packages
-        self.zip_exclude_packages = zip_exclude_packages or []
-        self.zip_include_packages = zip_include_packages or []
+        self.zip_exclude_packages: set = zip_exclude_packages or set()
+        self.zip_include_packages: set = zip_include_packages or set()
         self.constants_module = constants_module
         self.zip_includes: InternalIncludesList = process_path_specs(
             zip_includes


### PR DESCRIPTION
Closes #1377 
I explained the usage in https://github.com/marcelotduarte/cx_Freeze/issues/1377#issuecomment-1291624681
So, this PR is a syntax suggar to the usage of zip-include-packages and zip-exclude-packages.
Instead of using --zip-include-packages=ruamel, you can use zip-include-packages=ruamel.yaml and it is accepted.