### PR TITLE
fix: restore build-exe option of build command (now deprecated)

### DIFF
--- a/cx_Freeze/__init__.py
+++ b/cx_Freeze/__init__.py
@@ -83,5 +83,13 @@ def plugin_install(dist: setuptools.Distribution) -> None:
 
     # Add build_exe as subcommand of setuptools build (plugin)
     build = dist.get_command_obj("build")
+    build.user_options.insert(
+        1,
+        (
+            "build-exe=",
+            None,
+            "directory for built executables and dependent files [DEPRECATED]",
+        ),
+    )
     build.sub_commands = [*build.sub_commands, ("build_exe", None)]
     build.build_exe = None

--- a/cx_Freeze/command/build_exe.py
+++ b/cx_Freeze/command/build_exe.py
@@ -203,10 +203,19 @@ class BuildEXE(Command):
         build = self.get_finalized_command("build")
         self.build_base = build.build_base
         if self.build_exe is None:
-            self.build_exe = build.build_exe
-            if self.build_exe is None:
-                dir_name = f"exe.{get_platform()}-{get_python_version()}"
-                self.build_exe = os.path.join(self.build_base, dir_name)
+            # get the value from deprecated option
+            options = build.distribution.get_option_dict("build")
+            build_exe = options.get("build_exe", (None, None))[1]
+            if build_exe:
+                build.warn(
+                    "[DEPRECATED] The use of build command with 'build-exe' "
+                    "option is deprecated.\n\t\t"
+                    "Use build_exe command with 'build-exe' option instead."
+                )
+                self.build_exe = build_exe
+        if self.build_exe is None:
+            dir_name = f"exe.{get_platform()}-{get_python_version()}"
+            self.build_exe = os.path.join(self.build_base, dir_name)
 
         self.optimize = int(self.optimize)
 

--- a/doc/src/setup_script.rst
+++ b/doc/src/setup_script.rst
@@ -214,13 +214,18 @@ the standard set of options for the command:
        below); note that this option is overwritten by the corresponding
        option on the build_exe command
 
+.. deprecated:: 6.14
+    ``build_exe`` option. To be removed in version 6.18 or 7.0.
+
 This is the equivalent help to specify the same options on the command line:
 
   .. code-block:: console
 
     python setup.py build --help
     Options for 'build' command:
-      --build-exe        build directory for executables
+      --build-base (-b)  base directory for build library
+      --build-exe        directory for built executables and dependent files
+      (...)
       --compiler (-c)    specify the compiler type
       --help-compiler    list available compilers
 


### PR DESCRIPTION
In the rewrite of build in #1737, this option was unimplemented.
It is planned to be removed, but not without warning.
Now I have reimplemented and deprecated it.