### PR TITLE
tests: add more test cases for ModuleFinder class

### DIFF
--- a/tests/generate_samples.py
+++ b/tests/generate_samples.py
@@ -1,0 +1,355 @@
+"""Source of samples to tests."""
+
+from pathlib import Path
+
+# Each test description is a list of 5 items:
+#
+# 1. a module name that will be imported by ModuleFinder
+# 2. a list of module names that ModuleFinder is required to find
+# 3. a list of module names that ModuleFinder should complain
+#    about because they are not found
+# 4. a list of module names that ModuleFinder should complain
+#    about because they MAY be not found
+# 5. a string specifying packages to create; the format is obvious imo.
+
+maybe_test = [
+    "a.module",
+    ["a", "a.module", "sys", "b"],
+    ["c"],
+    ["b.something"],
+    """\
+a/__init__.py
+a/module.py
+    from b import something
+    from c import something
+b/__init__.py
+    from sys import *
+""",
+]
+
+maybe_test_new = [
+    "a.module",
+    ["a", "a.module", "sys", "b", "__future__"],
+    ["c"],
+    ["b.something"],
+    """\
+a/__init__.py
+a/module.py
+    from b import something
+    from c import something
+b/__init__.py
+    from __future__ import absolute_import
+    from sys import *
+""",
+]
+
+package_test = [
+    "a.module",
+    ["a", "a.b", "a.c", "a.module", "mymodule", "sys"],
+    ["blahblah", "c"],
+    [],
+    """\
+mymodule.py
+a/__init__.py
+    import blahblah
+    from a import b
+    import c
+a/module.py
+    import sys
+    from a import b as x
+    from a.c import sillyname
+a/b.py
+a/c.py
+    from a.module import x
+    import mymodule as sillyname
+    from sys import version_info
+""",
+]
+
+absolute_import_test = [
+    "a.module",
+    ["a", "a.module", "b", "b.x", "b.y", "b.z", "__future__", "sys", "gc"],
+    ["blahblah", "z"],
+    [],
+    """\
+mymodule.py
+a/__init__.py
+a/module.py
+    from __future__ import absolute_import
+    import sys # sys
+    import blahblah # fails
+    import gc # gc
+    import b.x # b.x
+    from b import y # b.y
+    from b.z import * # b.z.*
+a/gc.py
+a/sys.py
+    import mymodule
+a/b/__init__.py
+a/b/x.py
+a/b/y.py
+a/b/z.py
+b/__init__.py
+    import z
+b/unused.py
+b/x.py
+b/y.py
+b/z.py
+""",
+]
+
+relative_import_test = [
+    "a.module",
+    [
+        "__future__",
+        "a",
+        "a.module",
+        "a.b",
+        "a.b.y",
+        "a.b.z",
+        "a.b.c",
+        "a.b.c.moduleC",
+        "a.b.c.d",
+        "a.b.c.e",
+        "a.b.x",
+        "gc",
+    ],
+    [],
+    [],
+    """\
+mymodule.py
+a/__init__.py
+    from .b import y, z # a.b.y, a.b.z
+a/module.py
+    from __future__ import absolute_import # __future__
+    import gc # gc
+a/gc.py
+a/sys.py
+a/b/__init__.py
+    from ..b import x # a.b.x
+    #from a.b.c import moduleC
+    from .c import moduleC # a.b.moduleC
+a/b/x.py
+a/b/y.py
+a/b/z.py
+a/b/g.py
+a/b/c/__init__.py
+    from ..c import e # a.b.c.e
+a/b/c/moduleC.py
+    from ..c import d # a.b.c.d
+a/b/c/d.py
+a/b/c/e.py
+a/b/c/x.py
+""",
+]
+
+relative_import_test_2 = [
+    "a.module",
+    [
+        "a",
+        "a.module",
+        "a.sys",
+        "a.b",
+        "a.b.y",
+        "a.b.z",
+        "a.b.c",
+        "a.b.c.d",
+        "a.b.c.e",
+        "a.b.c.moduleC",
+        "a.b.c.f",
+        "a.b.x",
+        "a.another",
+    ],
+    [],
+    [],
+    """\
+mymodule.py
+a/__init__.py
+    from . import sys # a.sys
+a/another.py
+a/module.py
+    from .b import y, z # a.b.y, a.b.z
+a/gc.py
+a/sys.py
+a/b/__init__.py
+    from .c import moduleC # a.b.c.moduleC
+    from .c import d # a.b.c.d
+a/b/x.py
+a/b/y.py
+a/b/z.py
+a/b/c/__init__.py
+    from . import e # a.b.c.e
+a/b/c/moduleC.py
+    #
+    from . import f   # a.b.c.f
+    from .. import x  # a.b.x
+    from ... import another # a.another
+a/b/c/d.py
+a/b/c/e.py
+a/b/c/f.py
+""",
+]
+
+relative_import_test_3 = [
+    "a.module",
+    ["a", "a.module"],
+    ["a.bar"],
+    [],
+    """\
+a/__init__.py
+    def foo(): pass
+a/module.py
+    from . import foo
+    from . import bar
+""",
+]
+
+relative_import_test_4 = [
+    "a.module",
+    ["a", "a.module"],
+    [],
+    [],
+    """\
+a/__init__.py
+    def foo(): pass
+a/module.py
+    from . import *
+""",
+]
+
+bytecode_test = ["a", ["a"], [], [], ""]
+
+syntax_error_test = [
+    "a.module",
+    ["a", "a.module", "b"],
+    ["b.module"],
+    [],
+    """\
+a/__init__.py
+a/module.py
+    import b.module
+b/__init__.py
+b/module.py
+    ?  # SyntaxError: invalid syntax
+""",
+]
+
+
+same_name_as_bad_test = [
+    "a.module",
+    ["a", "a.module", "b", "b.c"],
+    ["c"],
+    [],
+    """\
+a/__init__.py
+a/module.py
+    import c
+    from b import c
+b/__init__.py
+b/c.py
+""",
+]
+
+extended_opargs_test = [
+    "a",
+    ["a", "b"],
+    [],
+    [],
+    f"""\
+a.py
+    {list(range(2**16))!r}
+    import b
+b.py
+""",
+]  # 2**16 constants
+
+coding_default_utf8_test = [
+    "a_utf8",
+    ["a_utf8", "b_utf8"],
+    [],
+    [],
+    """\
+a_utf8.py
+    # use the default of utf8
+    print('Unicode test A code point 2090 \u2090 that is not valid in cp1252')
+    import b_utf8
+b_utf8.py
+    # use the default of utf8
+    print('Unicode test B code point 2090 \u2090 that is not valid in cp1252')
+""",
+]
+
+coding_explicit_utf8_test = [
+    "a_utf8",
+    ["a_utf8", "b_utf8"],
+    [],
+    [],
+    """\
+a_utf8.py
+    # coding=utf8
+    print('Unicode test A code point 2090 \u2090 that is not valid in cp1252')
+    import b_utf8
+b_utf8.py
+    # use the default of utf8
+    print('Unicode test B code point 2090 \u2090 that is not valid in cp1252')
+""",
+]
+
+coding_explicit_cp1252_test = [
+    "a_cp1252",
+    ["a_cp1252", "b_utf8"],
+    [],
+    [],
+    b"""\
+a_cp1252.py
+    # coding=cp1252
+    # 0xe2 is not allowed in utf8
+    print('CP1252 test P\xe2t\xe9')
+    import b_utf8
+"""
+    + """\
+b_utf8.py
+    # use the default of utf8
+    print('Unicode test A code point 2090 \u2090 that is not valid in cp1252')
+""".encode(),
+]
+
+sub_package_test = [
+    "main",
+    ["p", "p.p1", "p.q", "p.q.q1", "main"],
+    [],
+    [],
+    """\
+main.py
+    import p.p1
+    import p.q.q1
+p/__init__.py
+p/p1.py
+    print('This is p.p1')
+p/q/__init__.py
+p/q/q1.py
+    print('This is p.q.q1')
+""",
+]
+
+
+def create_package(test_dir: Path, source: str):
+    """Create package in test_dir, based on source."""
+    ofi = None
+    try:
+        for line in source.splitlines():
+            if not isinstance(line, bytes):
+                line = line.encode("utf-8")  # noqa: PLW2901
+            if line.startswith((b" ", b"\t")):
+                ofi.write(line.strip() + b"\n")
+            else:
+                if ofi:
+                    ofi.close()
+                if isinstance(line, bytes):
+                    line = line.decode("utf-8")  # noqa: PLW2901
+                path = test_dir / line.strip()
+                path.parent.mkdir(parents=True, exist_ok=True)
+                ofi = path.open("wb")
+    finally:
+        if ofi:
+            ofi.close()

--- a/tests/test_modulefinder.py
+++ b/tests/test_modulefinder.py
@@ -1,0 +1,157 @@
+"""Test ModuleFinder."""
+
+import os
+import py_compile
+import tempfile
+from importlib.machinery import BYTECODE_SUFFIXES, SOURCE_SUFFIXES
+
+import pytest
+from generate_samples import (
+    absolute_import_test,
+    bytecode_test,
+    coding_default_utf8_test,
+    coding_explicit_cp1252_test,
+    coding_explicit_utf8_test,
+    create_package,
+    extended_opargs_test,
+    maybe_test,
+    maybe_test_new,
+    package_test,
+    relative_import_test,
+    relative_import_test_2,
+    relative_import_test_3,
+    relative_import_test_4,
+    same_name_as_bad_test,
+    sub_package_test,
+)
+
+from cx_Freeze import ConstantsModule, ModuleFinder
+
+# Each test description is a list of 5 items:
+#
+# 1. a module name that will be imported by ModuleFinder
+# 2. a list of module names that ModuleFinder is required to find
+# 3. a list of module names that ModuleFinder should complain
+#    about because they are not found
+# 4. a list of module names that ModuleFinder should complain
+#    about because they MAY be not found
+# 5. a string specifying packages to create; the format is obvious imo.
+#
+# Each package will be created in test_dir, and test_dir will be
+# removed after the tests again.
+# ModuleFinder searches in a path that contains test_dir, plus
+# the standard Lib directory.
+
+
+def _do_test(
+    test_dir,
+    import_this,
+    modules,
+    missing,  # noqa: ARG001
+    maybe_missing,  # noqa: ARG001
+    source,
+    report=False,
+    debug=0,  # noqa: ARG001
+    modulefinder_class=ModuleFinder,
+    **kwargs,
+):
+    create_package(test_dir, source)
+    finder = modulefinder_class(
+        ConstantsModule(),
+        path=[test_dir, os.path.dirname(tempfile.__file__)],
+        # debug=debug,
+        **kwargs,
+    )
+    finder.modules = []  # remove default modules
+    finder._modules = {}  # pylint: disable=protected-access
+    finder.include_module(import_this)
+    if report:
+        finder.report_missing_modules()
+    modules = sorted(set(modules))
+    found = sorted([module.name for module in finder.modules])
+    # check if we found what we expected, not more, not less
+    assert found == modules
+
+    # check for missing and maybe missing modules
+    # bad, maybe = finder.any_missing_maybe()
+    # self.assertEqual(bad, missing)
+    # self.assertEqual(maybe, maybe_missing)
+
+
+@pytest.mark.parametrize(
+    ("import_this", "modules", "missing", "maybe_missing", "source"),
+    [
+        absolute_import_test,
+        coding_default_utf8_test,
+        coding_explicit_cp1252_test,
+        coding_explicit_utf8_test,
+        extended_opargs_test,
+        maybe_test,
+        maybe_test_new,
+        package_test,
+        relative_import_test,
+        relative_import_test_2,
+        relative_import_test_3,
+        relative_import_test_4,
+        same_name_as_bad_test,
+        sub_package_test,
+    ],
+    ids=[
+        "absolute_import_test",
+        "coding_default_utf8_test",
+        "coding_explicit_cp1252_test",
+        "coding_explicit_utf8_test",
+        "extended_opargs_test",
+        "maybe_test",
+        "maybe_test_new",
+        "package_test",
+        "relative_import_test",
+        "relative_import_test_2",
+        "relative_import_test_3",
+        "relative_import_test_4",
+        "same_name_as_bad_test",
+        "sub_package_test",
+    ],
+)
+def test_finder(
+    tmp_path,
+    import_this,
+    modules,
+    missing,
+    maybe_missing,
+    source,
+):
+    """Provides test cases for ModuleFinder class."""
+    _do_test(tmp_path, import_this, modules, missing, maybe_missing, source)
+
+
+def test_bytecode(tmp_path):
+    """Provides bytecode test case for ModuleFinder class."""
+    base_path = tmp_path / "a"
+    source_path = base_path.with_suffix(SOURCE_SUFFIXES[0])
+    bytecode_path = base_path.with_suffix(BYTECODE_SUFFIXES[0])
+    with source_path.open("wb") as file:
+        file.write(b"testing_modulefinder = True\n")
+    py_compile.compile(os.fspath(source_path), cfile=os.fspath(bytecode_path))
+    os.remove(source_path)
+    _do_test(tmp_path, *bytecode_test)
+
+
+def test_zip_include_packages(tmp_path):
+    """Provides test cases for ModuleFinder class."""
+    _do_test(
+        tmp_path,
+        *sub_package_test,
+        zip_exclude_packages=["*"],
+        zip_include_packages=["p"],
+    )
+
+
+def test_zip_exclude_packages(tmp_path):
+    """Provides test cases for ModuleFinder class."""
+    _do_test(
+        tmp_path,
+        *sub_package_test,
+        zip_exclude_packages=["p"],
+        zip_include_packages=["*"],
+    )

--- a/tests/test_modulefinder.py
+++ b/tests/test_modulefinder.py
@@ -2,7 +2,7 @@
 
 import os
 import py_compile
-import tempfile
+import sys
 from importlib.machinery import BYTECODE_SUFFIXES, SOURCE_SUFFIXES
 
 import pytest
@@ -40,7 +40,7 @@ from cx_Freeze import ConstantsModule, ModuleFinder
 # Each package will be created in test_dir, and test_dir will be
 # removed after the tests again.
 # ModuleFinder searches in a path that contains test_dir, plus
-# the standard Lib directory.
+# the standard path search directory.
 
 
 def _do_test(
@@ -58,7 +58,7 @@ def _do_test(
     create_package(test_dir, source)
     finder = modulefinder_class(
         ConstantsModule(),
-        path=[test_dir, os.path.dirname(tempfile.__file__)],
+        path=[test_dir, *sys.path],
         # debug=debug,
         **kwargs,
     )


### PR DESCRIPTION
These test cases are heavily based on test_modulefinder from Python sources, modified to our needs, and converted to use with pytest.