### PR TITLE
build-wheel: add support for ppc64le binary wheels for py310+

### DIFF
--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -39,7 +39,7 @@ jobs:
         if: runner.os == 'Linux'
         uses: docker/setup-qemu-action@v2
         with:
-          platforms: arm64
+          platforms: arm64,ppc64le
 
       - name: Install cibuildwheel
         run: python -m pip install "`grep cibuildwheel requirements-dev.txt`"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,7 +222,8 @@ build-verbosity = "1"
 manylinux-x86_64-image = "quay.io/pypa/manylinux2014_x86_64:latest"
 
 [tool.cibuildwheel.linux]
-archs = "x86_64 aarch64"
+archs = "x86_64 aarch64 ppc64le"
+skip = "cp3{8,9}-{many,musl}linux_{aarch64,ppc64le}"
 before-build = """
 cd /opt/_internal && tar -xvf static-libs-for-embedding-only.tar.xz
 """
@@ -230,7 +231,7 @@ repair-wheel-command = "auditwheel repair -L /bases/lib -w {dest_dir} {wheel}"
 
 [tool.cibuildwheel.macos]
 archs = "x86_64 arm64"
-skip = "cp38-macosx_arm64"
+skip = "cp3{8,9}-macosx_arm64"
 repair-wheel-command = """
 delocate-listdeps {wheel} &&
 delocate-wheel --require-archs {delocate_archs} -L bases/lib -w {dest_dir} {wheel}


### PR DESCRIPTION
Also, change the support for binaries in arm64 to build for py310+

Fixes #2010