### PR TITLE
Builds pass macOS notarization

### DIFF
--- a/cx_Freeze/command/bdist_mac.py
+++ b/cx_Freeze/command/bdist_mac.py
@@ -18,8 +18,8 @@ from cx_Freeze.darwintools import (
     changeLoadReference,
 )
 
-from ..exception import OptionError
 from ..darwintools import isMachOFile
+from ..exception import OptionError
 
 __all__ = ["BdistDMG", "BdistMac"]
 

--- a/cx_Freeze/command/bdist_mac.py
+++ b/cx_Freeze/command/bdist_mac.py
@@ -591,7 +591,7 @@ class BdistMac(Command):
                     binaries_to_sign.append(full_path)
 
         # Sort files by depth, so we sign the deepest files first
-        binaries_to_sign.sort(key=lambda x: x.count(os.sep), reverse=True)
+        binaries_to_sign.sort(key=lambda x: str(x).count(os.sep), reverse=True)
 
         for binary_path in binaries_to_sign:
             self._codesign_file(binary_path, self._get_sign_args())

--- a/cx_Freeze/command/bdist_mac.py
+++ b/cx_Freeze/command/bdist_mac.py
@@ -520,6 +520,8 @@ class BdistMac(Command):
         # TODO : Add some sort of verification step / asset if macOS folder isn't just the binaries!
 
         # Sign the app bundle if a key is specified
+
+
         self._codesign()
         # if self.codesign_identity:
         #
@@ -567,9 +569,21 @@ class BdistMac(Command):
 
         signargs.append(self.bundle_dir)
 
+        # YOLO HACK - test...
+        alt = list(signargs)
+        alt.append(os.path.join(self.resources_lib_dir, "Python"))
+        try:
+            result = subprocess.run(alt, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=True)
+            print(f"codesign command's output: '{result.stdout}'")
+        except subprocess.CalledProcessError as error:
+            print(f"codesign command exitcode: {error.returncode} \nstderr: '{error.stderr}'")
+            raise
+
+        root = list(signargs)
+        root.append(self.bundle_dir)
         print(f"Codesigning the bundle: '{self.bundle_dir}' containing executable '{self.bundle_executable}'")
         try:
-            result = subprocess.run(signargs, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=True)
+            result = subprocess.run(root, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=True)
             print(f"codesign command's output: '{result.stdout}'")
         except subprocess.CalledProcessError as error:
             print(f"codesign command exitcode: {error.returncode} \nstderr: '{error.stderr}'")

--- a/cx_Freeze/command/bdist_mac.py
+++ b/cx_Freeze/command/bdist_mac.py
@@ -555,6 +555,7 @@ class BdistMac(Command):
         for item in files_to_sign:
             self._codesign_file(item, signargs)
 
+        self._verify_signature()
         print("Finished .app signing")
 
     @staticmethod
@@ -624,13 +625,13 @@ class BdistMac(Command):
         subprocess.run(sign_args)  # TODO : Protections around this?
 
 
-        # TODO : prob *don't* want to do this on a file by file basis... but maybe we do ? :D
+    def _verify_signature(self):
         if self.codesign_verify:
             verify_args = ["codesign", "-vvv", "--deep", "--strict", self.bundle_dir]
             print("Running codesign verification")
             result = subprocess.run(verify_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
             output = f"ExitCode: {result.returncode} \n stdout: {result.stdout} \n stderr: {result.stderr}"
-            print(output)  # TODO - look at modifying this / merging with other subproc calls
+            print(output)
 
         if self.spctl_assess:
             spctl_args = [

--- a/cx_Freeze/command/bdist_mac.py
+++ b/cx_Freeze/command/bdist_mac.py
@@ -545,7 +545,7 @@ class BdistMac(Command):
         print(f"About to sign: '{self.bundle_dir}'")
         bundle_dir = Path(self.bundle_dir)
         files_to_sign = set()
-        for item in bundle_dir.iterdir():
+        for item in bundle_dir.rglob('*'):
             if item.is_file():
                 if item.suffix == '':
                     print(f"Found file without extension: {item}")

--- a/cx_Freeze/command/bdist_mac.py
+++ b/cx_Freeze/command/bdist_mac.py
@@ -403,6 +403,11 @@ class BdistMac(Command):
         self.bin_dir = os.path.join(self.contents_dir, "MacOS")
         self.frameworks_dir = os.path.join(self.contents_dir, "Frameworks")
 
+        # Remove App if it already exists ( avoids confusing issues where prior builds persist! )
+        if os.path.exists(self.bundle_dir):
+            shutil.rmtree(self.bundle_dir) # not tested!
+            print(f"Staging - Removed existing '{self.bundle_dir}'")
+
         # Find the executable name
         executable = self.distribution.executables[0].target_name
         _, self.bundle_executable = os.path.split(executable)

--- a/cx_Freeze/command/bdist_mac.py
+++ b/cx_Freeze/command/bdist_mac.py
@@ -197,12 +197,14 @@ class BdistMac(Command):
         (
             "codesign-verify",
             None,
-            "Boolean to verify codesign of the .app bundle using the codesign command",
+            "Boolean to verify codesign of the .app bundle using the codesign "
+            "command",
         ),
         (
             "spctl-assess",
             None,
-            "Boolean to verify codesign of the .app bundle using the spctl command",
+            "Boolean to verify codesign of the .app bundle using the spctl "
+            "command",
         ),
         (
             "codesign-strict=",
@@ -437,7 +439,8 @@ class BdistMac(Command):
         self.bin_dir = os.path.join(self.contents_dir, "MacOS")
         self.frameworks_dir = os.path.join(self.contents_dir, "Frameworks")
 
-        # Remove App if it already exists ( avoids confusing issues where prior builds persist! )
+        # Remove App if it already exists
+        # ( avoids confusing issues where prior builds persist! )
         if os.path.exists(self.bundle_dir):
             shutil.rmtree(self.bundle_dir)
             print(f"Staging - Removed existing '{self.bundle_dir}'")
@@ -459,14 +462,15 @@ class BdistMac(Command):
             os.path.join(self.bin_dir, "lib"), self.resources_lib_dir
         )
         shutil.rmtree(os.path.join(self.bin_dir, "lib"))
-        # Make symlink between contents/MacOS and resources/lib so we can use none-relative reference paths
-        # in order to pass codesign...
+        # Make symlink between contents/MacOS and resources/lib so we can use
+        # none-relative reference paths in order to pass codesign...
         origin = os.path.join(self.bin_dir, "lib")
         relative_reference = os.path.relpath(
             self.resources_lib_dir, self.bin_dir
         )
         print(
-            f"Creating symlink - Target: {origin} <-> Source: {relative_reference}"
+            "Creating symlink - "
+            f"Target: {origin} <-> Source: {relative_reference}"
         )
         os.symlink(relative_reference, origin, target_is_directory=True)
 
@@ -529,13 +533,15 @@ class BdistMac(Command):
 
     @staticmethod
     def _is_binary(file_path):
-        """Check if a file is binary by searching for null bytes in its content."""
-        with open(file_path, "rb") as f:
-            chunk = f.read(8192)  # read 8K bytes
+        """Check if a file is binary by searching for null bytes in its
+        content.
+        """
+        with open(file_path, "rb") as file:
+            chunk = file.read(8192)  # read 8K bytes
             while chunk:
                 if b"\0" in chunk:
                     return True
-                chunk = f.read(8192)
+                chunk = file.read(8192)
         return False
 
     @staticmethod
@@ -544,11 +550,12 @@ class BdistMac(Command):
             return True
         if file_path.suffix == "":
             return BdistMac._is_binary(file_path)
-        else:
-            return False
+        return False
 
     def _codesign(self, root_path):
-        """Run codesign on all .so, .dylib and binary files in reverse order. Signing from inside-out."""
+        """Run codesign on all .so, .dylib and binary files in reverse order.
+        Signing from inside-out.
+        """
         if not self.codesign_identity:
             return
 
@@ -596,7 +603,7 @@ class BdistMac(Command):
     def _codesign_file(self, file_path, sign_args):
         print(f"Signing file: {file_path}")
         sign_args.append(file_path)
-        subprocess.run(sign_args)
+        subprocess.run(sign_args, check=False)
 
     def _verify_signature(self):
         if self.codesign_verify:
@@ -609,10 +616,11 @@ class BdistMac(Command):
             ]
             print("Running codesign verification")
             result = subprocess.run(
-                verify_args, capture_output=True, text=True
+                verify_args, capture_output=True, text=True, check=False
             )
-            output = f"ExitCode: {result.returncode} \n stdout: {result.stdout} \n stderr: {result.stderr}"
-            print(output)
+            print("ExitCode:", result.returncode)
+            print(" stdout:", result.stdout)
+            print(" stderr:", result.stderr)
 
         if self.spctl_assess:
             spctl_args = [
@@ -632,9 +640,8 @@ class BdistMac(Command):
                     stderr=subprocess.STDOUT,
                 )
                 print(
-                    "spctl command's output: {}".format(
-                        completed_process.stdout.decode()
-                    )
+                    "spctl command's output: "
+                    f"{completed_process.stdout.decode()}"
                 )
             except subprocess.CalledProcessError as error:
                 print(f"spctl check got an error: {error.stdout.decode()}")

--- a/cx_Freeze/command/bdist_mac.py
+++ b/cx_Freeze/command/bdist_mac.py
@@ -469,8 +469,9 @@ class BdistMac(Command):
         self.execute(self.prepare_qt_app, ())
 
         # Sign the app bundle if a key is specified
+        # TODO: try "--force" "--timestamp" "--strict {options?all,library?}" "--options"...???
         if self.codesign_identity:
-            signargs = ["codesign", "-s", self.codesign_identity]
+            signargs = ["codesign", "-s", self.codesign_identity, "--force"]
 
             if self.codesign_entitlements:
                 signargs.append("--entitlements")

--- a/cx_Freeze/command/bdist_mac.py
+++ b/cx_Freeze/command/bdist_mac.py
@@ -3,8 +3,6 @@
 from __future__ import annotations
 
 import os
-import glob
-import itertools
 import plistlib
 import shutil
 import subprocess
@@ -181,7 +179,8 @@ class BdistMac(Command):
         (
             "codesign-timestamp",
             None,
-            "Boolean for whether to codesign using the –-timestamp option."),
+            "Boolean for whether to codesign using the –-timestamp option."
+        ),
         (
             "codesign-resource-rules",
             None,

--- a/cx_Freeze/command/bdist_mac.py
+++ b/cx_Freeze/command/bdist_mac.py
@@ -459,6 +459,12 @@ class BdistMac(Command):
         if self.absolute_reference_path:
             self.execute(self.set_absolute_reference_paths, ())
 
+        # Move license file to resources as it can't be signed
+        src_lfp = os.path.join(self.bin_dir, "frozen_application_license.txt")
+        if os.path.exists(src_lfp):
+            shutil.move(src_lfp, self.resources_dir)
+            print(f"Moved: {src_lfp} -> {self.resources_dir}")
+
         # For a Qt application, run some tweaks
         self.execute(self.prepare_qt_app, ())
 

--- a/cx_Freeze/command/bdist_mac.py
+++ b/cx_Freeze/command/bdist_mac.py
@@ -569,7 +569,7 @@ class BdistMac(Command):
         if self.codesign_deep:
             signargs.append('--deep')
 
-        if self.codesign_options:  # TODO : unhooked
+        if self.codesign_options:
             signargs.append(f'--options')
             signargs.append(self.codesign_options)
 

--- a/cx_Freeze/command/bdist_mac.py
+++ b/cx_Freeze/command/bdist_mac.py
@@ -579,6 +579,7 @@ class BdistMac(Command):
             print(f"codesign command exitcode: {error.returncode} \nstderr: '{error.stderr}'")
             raise
 
+        # Normal pathway
         root = list(signargs)
         root.append(self.bundle_dir)
         print(f"Codesigning the bundle: '{self.bundle_dir}' containing executable '{self.bundle_executable}'")
@@ -599,7 +600,6 @@ class BdistMac(Command):
         if self.spctl_assess:
             spctl_args = [
                 "spctl",
-                "-vvv",
                 "--assess",
                 "--raw",
                 "--verbose=10",

--- a/cx_Freeze/darwintools.py
+++ b/cx_Freeze/darwintools.py
@@ -497,7 +497,7 @@ def changeLoadReference(
 def applyAdHocSignature(fileName: str):
     if platform.machine() != "arm64":
         return
-
+    print("Applying AdHocSignature")
     args = (
         "codesign",
         "--sign",

--- a/cx_Freeze/darwintools.py
+++ b/cx_Freeze/darwintools.py
@@ -25,7 +25,7 @@ from .exception import PlatformError
 # directories are included in the current rpath.
 
 
-def _isMachOFile(path: Path) -> bool:
+def isMachOFile(path: Path) -> bool:
     """Determines whether the file is a Mach-O file."""
     if not path.is_file():
         return False
@@ -114,7 +114,7 @@ class DarwinFile:
         # unresolved load path.
         self.machOReferenceForTargetPath: dict[Path, MachOReference] = {}
 
-        if not _isMachOFile(self.path):
+        if not isMachOFile(self.path):
             self.isMachO = False
             return
 
@@ -254,7 +254,7 @@ class DarwinFile:
     def resolveRPath(self, path: str) -> Path | None:
         for rpath in self.getRPath():
             test_path = rpath / Path(path).relative_to("@rpath")
-            if _isMachOFile(test_path):
+            if isMachOFile(test_path):
                 return test_path
         if not self.strict:
             # If not strictly enforcing rpath, return None here, and leave any
@@ -302,7 +302,7 @@ class DarwinFile:
         if test_path.is_absolute():  # just use the path, if it is absolute
             return test_path
         test_path = self.path.parent / path
-        if _isMachOFile(test_path):
+        if isMachOFile(test_path):
             return test_path.resolve()
         if self.strict:
             raise PlatformError(

--- a/doc/src/setup_script.rst
+++ b/doc/src/setup_script.rst
@@ -621,6 +621,14 @@ bundle (a .app directory).
    * - .. option:: codesign_entitlements
      - The path to an entitlements file to use for your application's code
        signature.
+    * - .. option:: codesign-timestamp
+     - Use --timestamp when running codesign.
+    * - .. option:: codesign-strict
+     - Use --strict when running codesign.
+    * - .. option:: codesign-verify
+     - Use --verify when running codesign.
+    * - .. option:: spctl-assess
+     - Run spctl-assess to asses output from codesign.
    * - .. option:: codesign_deep
      - Boolean for whether to codesign using the --deep option.
    * - .. option:: codesign_options

--- a/doc/src/setup_script.rst
+++ b/doc/src/setup_script.rst
@@ -621,13 +621,13 @@ bundle (a .app directory).
    * - .. option:: codesign_entitlements
      - The path to an entitlements file to use for your application's code
        signature.
-    * - .. option:: codesign-timestamp
+   * - .. option:: codesign_timestamp
      - Use --timestamp when running codesign.
-    * - .. option:: codesign-strict
+   * - .. option:: codesign_strict
      - Use --strict when running codesign.
-    * - .. option:: codesign-verify
+   * - .. option:: codesign_verify
      - Use --verify when running codesign.
-    * - .. option:: spctl-assess
+   * - .. option:: spctl_assess
      - Run spctl-assess to asses output from codesign.
    * - .. option:: codesign_deep
      - Boolean for whether to codesign using the --deep option.

--- a/doc/src/setup_script.rst
+++ b/doc/src/setup_script.rst
@@ -623,6 +623,8 @@ bundle (a .app directory).
        signature.
    * - .. option:: codesign_deep
      - Boolean for whether to codesign using the --deep option.
+   * - .. option:: codesign_options
+     - Comma seperated string of options to use with codesign --options.
    * - .. option:: codesign_resource_rules
      - Plist file to be passed to codesign's --resource-rules option.
    * - .. option:: absolute_reference_path

--- a/samples/pyside2/codesign-entitlements.plist
+++ b/samples/pyside2/codesign-entitlements.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+</dict>
+</plist>

--- a/samples/pyside2/setup.py
+++ b/samples/pyside2/setup.py
@@ -60,12 +60,14 @@ options = {
         "zip_include_packages": ["PySide2", "shiboken2"],
     },
     "bdist_mac": {
-        'custom_info_plist': None, # Set this to use a custom info.plist file
-        'codesign_entitlements': os.path.join(os.path.dirname(__file__), "codesign-entitlements.plist"),
-        'codesign_identity': None, # Set this to enable signing with custom identity (replaces adhoc signature)
-        'codesign_options': 'runtime', # Ensure codesign uses 'hardened runtime'
-        'codesign_verify': False, # Enable to get more verbose logging regarding codesign
-        'spctl_assess': False, # Enable to get more verbose logging regarding codesign
+        "custom_info_plist": None,  # Set this to use a custom info.plist file
+        "codesign_entitlements": os.path.join(
+            os.path.dirname(__file__), "codesign-entitlements.plist"
+        ),
+        "codesign_identity": None,  # Set this to enable signing with custom identity (replaces adhoc signature)
+        "codesign_options": "runtime",  # Ensure codesign uses 'hardened runtime'
+        "codesign_verify": False,  # Enable to get more verbose logging regarding codesign
+        "spctl_assess": False,  # Enable to get more verbose logging regarding codesign
     },
 }
 executables = [Executable("test_pyside2.py", base=base)]

--- a/samples/pyside2/setup.py
+++ b/samples/pyside2/setup.py
@@ -13,6 +13,7 @@ subdirectory that contains the files needed to run the application.
 from __future__ import annotations
 
 import sys
+import os
 
 from cx_Freeze import Executable, setup
 
@@ -51,7 +52,22 @@ build_exe_options = {
     "include_files": include_files,
     "zip_include_packages": ["PySide2", "shiboken2"],
 }
-
+options = {
+    "build_exe": {
+        # exclude packages that are not really needed
+        "excludes": ["tkinter", "unittest", "email", "http", "xml", "pydoc"],
+        "include_files": include_files,
+        "zip_include_packages": ["PySide2", "shiboken2"],
+    },
+    "bdist_mac": {
+        'custom_info_plist': None, # Set this to use a custom info.plist file
+        'codesign_entitlements': os.path.join(os.path.dirname(__file__), "codesign-entitlements.plist"),
+        'codesign_identity': None, # Set this to enable signing with custom identity (replaces adhoc signature)
+        'codesign_options': 'runtime', # Ensure codesign uses 'hardened runtime'
+        'codesign_verify': False, # Enable to get more verbose logging regarding codesign
+        'spctl_assess': False, # Enable to get more verbose logging regarding codesign
+    },
+}
 executables = [Executable("test_pyside2.py", base=base)]
 
 setup(

--- a/samples/pyside2/setup.py
+++ b/samples/pyside2/setup.py
@@ -46,12 +46,6 @@ if get_qt_plugins_paths:
 # base="Win32GUI" should be used only for Windows GUI app
 base = "Win32GUI" if sys.platform == "win32" else None
 
-build_exe_options = {
-    # exclude packages that are not really needed
-    "excludes": ["tkinter", "unittest", "email", "http", "xml", "pydoc"],
-    "include_files": include_files,
-    "zip_include_packages": ["PySide2", "shiboken2"],
-}
 options = {
     "build_exe": {
         # exclude packages that are not really needed
@@ -74,6 +68,6 @@ setup(
     name="simple_PySide2",
     version="0.5",
     description="Sample cx_Freeze PySide2 script",
-    options={"build_exe": build_exe_options},
+    options=options,
     executables=executables,
 )


### PR DESCRIPTION
This PR is intended to resolve [this issue](https://github.com/marcelotduarte/cx_Freeze/issues/594) as its primary purpose, in the course of doing this we are also addressing some other smaller issues that are linked further down as well as extending the functionality of `cx_Freeze`'s signing options.

Our intent with this PR is to focus on ensuring the bundle structure is valid with the minimal impact on the internals of the freezer itself -> we are aware of further optimizations that can be made which are listed below - but we'd prefer not to increase the scope beyond whats necessary.

In order to ensure that application bundles pass macOS notarization the essential changes we had to make included the following:

## Changes:
- Moved license file to `Resources` (The folder `MacOS` may _only_ contain binaries) 
- Clean build directory between builds.
- Perform inside-out codesign of all libs/binary files.
- Added new parameters to control behavior of codesign
    - `codesign-verify` 
    - `codesign-timestamp`
    - `codesign-strict` 
    - `codesign-options`
    - `sptcl-assess`
- We now use `--force` when codesigning in order to replace existing signatures.

Upon making these changes and building + deploying a custom version of cx_freeze internally so our CI/CD could make use of it - Our internal pipeline that builds a .app bundle with cx_Freeze now runs and passes notarization by Apple.

We're submitting this as a draft for now for initial feedback as there are a couple of points worthy of further discussion before finalizing these changes.

### Questions
- The current implementation of the adhoc signing is signing as changes happen. In theory, we think it could be an optimization to replace the current adhoc signing flow with our signing method after creation of the .app bundle. Using an adhoc signature if no codesign identity is provided by the user. How would you like us to proceed?
- Would you like for us to update the existing samples? or create a new sample for this flow?

### Thoughts on future improvements/subsequent PR's
- The license file is today moved as a post-step. Is this something that could be modified inside the freezer that places the license file initially?
- Documentation for contributors could be improved regarding use of environment variables and requirements for CI builds. As well as steps for building locally.
- Even with this PR we are not fully adhering to Apples expectations for .app bundle structure because frameworks are not stored in `/Contents/Frameworks/` (but it's still working 😃)
- Consideration should be given to removing the `codesign-resourcerules` parameter as it's no longer supported on newer version of macOS.
- It might be worth adding validation/asserts when the `MacOS` folder only contains binaries

## Related Issues
- In our testing, this PR also resolved [this issue](https://github.com/marcelotduarte/cx_Freeze/issues/1511)
- While testing we discovered that the Qt SimpleBrowser example does not run on OSX due to missing the `QtWebEngineProcess` executable


The work in this PR has been a co-dev effort of myself and @TechnicalPirate. Feedback would be greatly appreciated @marcelotduarte 🙏. Thank you for your efforts in helping us make this contribution.


