### PR TITLE
hooks: initialize blas [numpy conda-forge]

### DIFF
--- a/cx_Freeze/hooks/numpy.py
+++ b/cx_Freeze/hooks/numpy.py
@@ -120,6 +120,7 @@ def load_numpy__distributor_init(finder: ModuleFinder, module: Module) -> None:
         blas_options = ["libopenblas", "mkl"]
         packages += blas_options
         files_to_copy: list[Path] = []
+        blas = None
         for package in packages:
             try:
                 pkg = next(conda_meta.glob(f"{package}-*.json"))


### PR DESCRIPTION
In order to prevent
```bash
cx_Freeze\hooks\numpy.py", line 142, in load_numpy__distributor_init
    os.path.dirname(os.path.dirname(__file__)), "{blas}"
UnboundLocalError: local variable 'blas' referenced before assignment
```