### PR TITLE
bdist_mac: skip text files in set_relative_reference_paths

### DIFF
--- a/cx_Freeze/command/bdist_mac.py
+++ b/cx_Freeze/command/bdist_mac.py
@@ -332,6 +332,10 @@ class BdistMac(Command):
         darwin_file: DarwinFile
 
         for darwin_file in self.darwin_tracker:
+            # Skip text files
+            if str(darwin_file.path).endswith(".txt"):
+                continue
+
             # get the relative path to darwin_file in build directory
             print(f"Setting relative_reference_path for: {darwin_file}")
             relative_copy_dest = os.path.relpath(

--- a/cx_Freeze/command/bdist_mac.py
+++ b/cx_Freeze/command/bdist_mac.py
@@ -333,7 +333,7 @@ class BdistMac(Command):
 
         for darwin_file in self.darwin_tracker:
             # Skip text files
-            if str(darwin_file.path).endswith(".txt"):
+            if darwin_file.path.suffix == ".txt":
                 continue
 
             # get the relative path to darwin_file in build directory


### PR DESCRIPTION
I'm trying to make a release of OnionShare on an ARM64 Apple Silicon Mac. When run `bdist_mac`, it fails with this error:

```
Setting relative_reference_path for: Mach-O File: /Users/user/Library/Caches/pypoetry/virtualenvs/onionshare-aqknF-N0-py3.11/lib/python3.11/site-packages/cx_Freeze/initscripts/frozen_application_license.txt
Resolved rpath:
Loaded libraries:
Applying AdHocSignature
/Users/user/code/onionshare/desktop/build/OnionShare.app/Contents/MacOS/frozen_application_license.txt: No such file or directory
error: [Errno 2] No such file or directory: '/Users/user/code/onionshare/desktop/build/OnionShare.app/Contents/MacOS/frozen_application_license.txt'
```

Looking at the code I saw that the `set_absolute_reference_paths` function has similar code that skips `txt` and `zip` files, and so this makes `set_relative_reference_paths` skip text files too, as these can't be code signed. This patch fixes the issue I ran into.