### PR TITLE
bdist_mac: move set_relative_reference_paths to build_exe

### DIFF
--- a/cx_Freeze/command/build_exe.py
+++ b/cx_Freeze/command/build_exe.py
@@ -277,8 +277,6 @@ class BuildEXE(Command):
             include_msvcr=self.include_msvcr,
         )
 
-        # keep freezer around so that its data case be used in bdist_mac phase
-        self.freezer = freezer
         freezer.freeze()
 
     def set_source_location(self, name, *pathParts):

--- a/cx_Freeze/freezer.py
+++ b/cx_Freeze/freezer.py
@@ -993,11 +993,14 @@ class DarwinFreezer(Freezer, Parser):
     def __init__(self, *args, **kwargs):
         Freezer.__init__(self, *args, **kwargs)
         Parser.__init__(self, self.path, self.bin_path_includes, self.silent)
-        self.darwin_tracker: DarwinFileTracker | None = None
-        self.darwin_tracker = DarwinFileTracker()
+        self.darwin_tracker: DarwinFileTracker = DarwinFileTracker()
 
     def _post_freeze_hook(self) -> None:
         self.darwin_tracker.finalizeReferences()
+        # Make all references to libraries relative
+        self.darwin_tracker.set_relative_reference_paths(
+            self.target_dir, self.target_dir
+        )
 
     def _pre_copy_hook(self, source: Path, target: Path) -> tuple[Path, Path]:
         """Prepare the source and target paths."""


### PR DESCRIPTION
The focus of this change is the separation of stages, and the result is that it solves some problems. Placing set_relative_reference_paths in the build_exe step corrects all rpaths without sharing a 'freezer' object between build_exe and bdist_mac and thus build_exe is complete. After that, samples (pyside2, pyqt5, etc.) that previously gave an error if run using just build_exe, are now run. And with bdist_mac they also run. To use codesign and notarization you will need the bdist_mac/bdist_dmg step.

This PR depends on #2107