### PR TITLE
build-exe: adds include_path option (formerly in cli)

### DIFF
--- a/cx_Freeze/cli.py
+++ b/cx_Freeze/cli.py
@@ -179,6 +179,7 @@ def main():
             deprecated.append("usage: required to use --script NAME")
     if command is None:
         command = "build_exe"
+
     # deprecated options
     if command == "build_exe" or "build_exe" in argv:
         args_to_replace = [
@@ -189,6 +190,7 @@ def main():
             ("-c", None),
             ("--compress", None),
             ("-z", "--zip-includes"),
+            ("--default-path", "--path"),
             ("-s", "--silent"),
         ]
         new_argv = []

--- a/doc/src/setup_script.rst
+++ b/doc/src/setup_script.rst
@@ -241,6 +241,8 @@ It can be further customized:
    * - .. option:: path
      - comma-separated list of paths to search for modules; the default value
        is sys.path (use only if you know what you are doing)
+   * - .. option:: include_path
+     - comma-separated list of paths to modify the search for modules
    * - .. option:: no_compress
      - create a zipfile with no compression
    * - .. option:: constants
@@ -322,6 +324,8 @@ This is the equivalent help to specify the same options on the command line:
     --path                  comma-separated list of paths to search for modules;
                             the default value is sys.path (use only if you know
                             what you are doing)
+    --include-path          comma-separated list of paths to modify the search
+                            for modules
     --no-compress           create a zipfile with no compression
     --constants             comma-separated list of constants to include
     --bin-includes          list of files to include when determining


### PR DESCRIPTION
Also, in CLI, the --default-path is defined as a deprecated option (use --path instead).

#2246