### PR TITLE
Update finder.py to fix RecursionError: maximum recursion depth exceeded

### DIFF
--- a/cx_Freeze/finder.py
+++ b/cx_Freeze/finder.py
@@ -463,13 +463,16 @@ class ModuleFinder:
             module.hook(self)
 
         import threading
+
         if module.code is not None:
             if self.replace_paths:
                 module.code = self._replace_paths_in_code(module)
 
             # Scan the module code for import statements
             # self._scan_code(module, deferred_imports)
-            thr = threading.Thread(target=self._scan_code, args=(module, deferred_imports))
+            thr = threading.Thread(
+                target=self._scan_code, args=(module, deferred_imports)
+            )
             thr.start()
             thr.join()
 
@@ -478,7 +481,10 @@ class ModuleFinder:
 
         elif module.stub_code is not None:
             # self._scan_code(module, deferred_imports, module.stub_code)
-            thr = threading.Thread(target=self._scan_code, args=(module, deferred_imports, module.stub_code))
+            thr = threading.Thread(
+                target=self._scan_code,
+                args=(module, deferred_imports, module.stub_code),
+            )
             thr.start()
             thr.join()
 

--- a/cx_Freeze/finder.py
+++ b/cx_Freeze/finder.py
@@ -462,18 +462,25 @@ class ModuleFinder:
         if module.hook:
             module.hook(self)
 
+        import threading
         if module.code is not None:
             if self.replace_paths:
                 module.code = self._replace_paths_in_code(module)
 
             # Scan the module code for import statements
-            self._scan_code(module, deferred_imports)
+            # self._scan_code(module, deferred_imports)
+            thr = threading.Thread(target=self._scan_code, args=(module, deferred_imports))
+            thr.start()
+            thr.join()
 
             # Verify __package__ in use
             module.code = self._replace_package_in_code(module)
 
         elif module.stub_code is not None:
-            self._scan_code(module, deferred_imports, module.stub_code)
+            # self._scan_code(module, deferred_imports, module.stub_code)
+            thr = threading.Thread(target=self._scan_code, args=(module, deferred_imports, module.stub_code))
+            thr.start()
+            thr.join()
 
         module.in_import = False
         return module


### PR DESCRIPTION
if module is to much , RecursionError: maximum recursion depth exceeded , fix to scan_code new one thread

`
  File "E:\git\python-3.11.6\Lib\site-packages\cx_Freeze\finder.py", line 348, in _internal_import_module
    module = self._load_module(
  File "E:\git\python-3.11.6\Lib\site-packages\cx_Freeze\finder.py", line 415, in _load_module
    self._load_module_code(module, loader, deferred_imports)
    │                      │       │       └ [(<Module name='scipy.interpolate.fitpack', file=WindowsPath('E:/git/python-3.11.6/Lib/site-packages/scipy/interpolate/fitpack.p...
    │                      │       └ <_frozen_importlib_external.SourceFileLoader object at 0x000001DBA2FF5410>
    │                      └ <Module name='sympy.printing.pretty', file=WindowsPath('E:/git/python-3.11.6/Lib/site-packages/sympy/printing/pretty/__init__.py...
    └ <cx_Freeze.finder.ModuleFinder object at 0x000001DB8B286ED0>
  File "E:\git\python-3.11.6\Lib\site-packages\cx_Freeze\finder.py", line 465, in _load_module_code
    self._scan_code(module.code, module, deferred_imports)
    │               │            │       └ [(<Module name='scipy.interpolate.fitpack', file=WindowsPath('E:/git/python-3.11.6/Lib/site-packages/scipy/interpolate/fitpack.p...
    │               │            └ <Module name='sympy.printing.pretty', file=WindowsPath('E:/git/python-3.11.6/Lib/site-packages/sympy/printing/pretty/__init__.py...
    │               └ <Module name='sympy.printing.pretty', file=WindowsPath('E:/git/python-3.11.6/Lib/site-packages/sympy/printing/pretty/__init__.py...
    └ <cx_Freeze.finder.ModuleFinder object at 0x000001DB8B286ED0>
  File "E:\git\python-3.11.6\Lib\site-packages\cx_Freeze\finder.py", line 626, in _scan_code
    imported_module = self._import_module(
  File "E:\git\python-3.11.6\Lib\site-packages\cx_Freeze\finder.py", line 294, in _import_module
    module = self._internal_import_module(name, deferred_imports)
             │                            │     └ [(<Module name='scipy.interpolate.fitpack', file=WindowsPath('E:/git/python-3.11.6/Lib/site-packages/scipy/interpolate/fitpack.p...
             │                            └ 'sympy.printing.pretty.pretty'
             └ <cx_Freeze.finder.ModuleFinder object at 0x000001DB8B286ED0>
  File "E:\git\python-3.11.6\Lib\site-packages\cx_Freeze\finder.py", line 348, in _internal_import_module
    module = self._load_module(
  File "E:\git\python-3.11.6\Lib\site-packages\cx_Freeze\finder.py", line 415, in _load_module
    self._load_module_code(module, loader, deferred_imports)
    │                      │       │       └ [(<Module name='scipy.interpolate.fitpack', file=WindowsPath('E:/git/python-3.11.6/Lib/site-packages/scipy/interpolate/fitpack.p...
    │                      │       └ <_frozen_importlib_external.SourceFileLoader object at 0x000001DBA2FF6AD0>
    │                      └ <Module name='sympy.printing.pretty.pretty', file=WindowsPath('E:/git/python-3.11.6/Lib/site-packages/sympy/printing/pretty/pret...
    └ <cx_Freeze.finder.ModuleFinder object at 0x000001DB8B286ED0>
  File "E:\git\python-3.11.6\Lib\site-packages\cx_Freeze\finder.py", line 465, in _load_module_code
    self._scan_code(module.code, module, deferred_imports)
    │               │            │       └ [(<Module name='scipy.interpolate.fitpack', file=WindowsPath('E:/git/python-3.11.6/Lib/site-packages/scipy/interpolate/fitpack.p...
    │               │            └ <Module name='sympy.printing.pretty.pretty', file=WindowsPath('E:/git/python-3.11.6/Lib/site-packages/sympy/printing/pretty/pret...
    │               └ <Module name='sympy.printing.pretty.pretty', file=WindowsPath('E:/git/python-3.11.6/Lib/site-packages/sympy/printing/pretty/pret...
    └ <cx_Freeze.finder.ModuleFinder object at 0x000001DB8B286ED0>
  File "E:\git\python-3.11.6\Lib\site-packages\cx_Freeze\finder.py", line 626, in _scan_code
    imported_module = self._import_module(
  File "E:\git\python-3.11.6\Lib\site-packages\cx_Freeze\finder.py", line 260, in _import_module
    module = self._internal_import_module(name, deferred_imports)
             │                            │     └ [(<Mod
`