### PR TITLE
chore: refactor internal modules

### DIFF
--- a/cx_Freeze/_compat.py
+++ b/cx_Freeze/_compat.py
@@ -6,21 +6,7 @@ import sys
 import sysconfig
 from pathlib import Path
 
-if sys.version_info >= (3, 10):
-    import importlib.metadata as importlib_metadata
-else:
-    try:
-        from setuptools.extern import importlib_metadata
-    except ImportError:
-        import importlib_metadata
-
-try:
-    from setuptools.extern import packaging
-except ImportError:
-    import packaging
-
-__all__ = ["importlib_metadata", "packaging"]
-__all__ += ["PLATFORM", "IS_LINUX", "IS_MACOS", "IS_MINGW", "IS_WINDOWS"]
+__all__ = ["PLATFORM", "IS_LINUX", "IS_MACOS", "IS_MINGW", "IS_WINDOWS"]
 __all__ += ["IS_CONDA"]
 
 PLATFORM = sysconfig.get_platform()

--- a/cx_Freeze/_importlib.py
+++ b/cx_Freeze/_importlib.py
@@ -1,0 +1,15 @@
+"""The internal _importlib module."""
+
+from __future__ import annotations
+
+import sys
+
+if sys.version_info >= (3, 10, 2):
+    from importlib import metadata
+else:
+    try:
+        from setuptools.extern import importlib_metadata as metadata
+    except ImportError:
+        import importlib_metadata as metadata
+
+__all__ = ["metadata"]

--- a/cx_Freeze/_packaging.py
+++ b/cx_Freeze/_packaging.py
@@ -1,0 +1,10 @@
+"""The internal _packaging module."""
+
+from __future__ import annotations
+
+try:
+    from setuptools.extern.packaging.version import Version
+except ImportError:
+    from packaging.version import Version
+
+__all__ = ["Version"]

--- a/cx_Freeze/_typing.py
+++ b/cx_Freeze/_typing.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from pathlib import Path, PurePath
 
-from typing_extensions import TypeAlias
+try:
+    from typing import TypeAlias  # 3.10+
+except ImportError:
+    from typing_extensions import TypeAlias
 
 from cx_Freeze.module import Module
 
@@ -15,3 +18,5 @@ IncludesList: TypeAlias = list[
 ]
 
 InternalIncludesList: TypeAlias = list[tuple[Path, PurePath]]
+
+__all__ = ["TypeAlias", "DeferredList", "IncludesList", "InternalIncludesList"]

--- a/cx_Freeze/command/bdist_msi.py
+++ b/cx_Freeze/command/bdist_msi.py
@@ -28,7 +28,7 @@ from typing import ClassVar
 
 from setuptools import Command
 
-from cx_Freeze._compat import packaging
+from cx_Freeze._packaging import Version
 from cx_Freeze.command._pydialog import PyDialog
 from cx_Freeze.exception import OptionError
 
@@ -1045,7 +1045,7 @@ class bdist_msi(Command):
         author = self.distribution.metadata.get_contact() or "UNKNOWN"
         version = self.target_version or self.distribution.get_version()
         # ProductVersion must be strictly numeric
-        base_version = packaging.version.Version(version).base_version
+        base_version = Version(version).base_version
 
         # msilib is reloaded in order to reset the "_directories" global member
         # in that module.  That member is used by msilib to prevent any two

--- a/cx_Freeze/module.py
+++ b/cx_Freeze/module.py
@@ -13,7 +13,7 @@ from keyword import iskeyword
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from cx_Freeze._compat import importlib_metadata
+from cx_Freeze._importlib import metadata
 from cx_Freeze.exception import ModuleError, OptionError
 
 if TYPE_CHECKING:
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 __all__ = ["ConstantsModule", "Module", "ModuleHook"]
 
 
-class DistributionCache(importlib_metadata.PathDistribution):
+class DistributionCache(metadata.PathDistribution):
     """Cache the distribution package."""
 
     def __init__(self, cache_path: Path, name: str) -> None:
@@ -35,15 +35,15 @@ class DistributionCache(importlib_metadata.PathDistribution):
             metadata cannot be found.
         """
         try:
-            distribution = importlib_metadata.PathDistribution.from_name(name)
-        except importlib_metadata.PackageNotFoundError:
+            distribution = metadata.PathDistribution.from_name(name)
+        except metadata.PackageNotFoundError:
             distribution = None
         if distribution is None:
             raise ModuleError(name)
         # Cache dist-info files in a temporary directory
         normalized_name = getattr(distribution, "_normalized_name", None)
         if normalized_name is None:
-            normalized_name = importlib_metadata.Prepared.normalize(name)
+            normalized_name = metadata.Prepared.normalize(name)
         source_path = getattr(distribution, "_path", None)
         if source_path is None:
             mask = f"{normalized_name}-{distribution.version}.*-info"
@@ -97,7 +97,7 @@ class DistributionCache(importlib_metadata.PathDistribution):
         target = target_path / "WHEEL"
         if not target.exists():
             project = Path(__file__).parent.name
-            version = importlib_metadata.version(project)
+            version = metadata.version(project)
             root_is_purelib = "true" if purelib else "false"
             text = [
                 "Wheel-Version: 1.0",

--- a/cx_Freeze/util.pyi
+++ b/cx_Freeze/util.pyi
@@ -4,9 +4,9 @@
 
 from pathlib import Path
 
-import typing_extensions
+from cx_Freeze._typing import TypeAlias
 
-HANDLE: typing_extensions.TypeAlias = int | None
+HANDLE: TypeAlias = int | None
 
 class BindError(Exception):
     """BindError Exception."""

--- a/cx_Freeze/winversioninfo.py
+++ b/cx_Freeze/winversioninfo.py
@@ -10,9 +10,9 @@ from pathlib import Path
 from struct import calcsize, pack
 from typing import ClassVar
 
-from cx_Freeze._compat import packaging
+from cx_Freeze._packaging import Version
 
-__all__ = ["Version", "VersionInfo"]
+__all__ = ["VersionInfo"]
 
 # types
 CHAR = "c"
@@ -43,10 +43,6 @@ if os.environ.get("CX_FREEZE_STAMP", "") == "pywin32":
     CX_FREEZE_STAMP = "pywin32"
 else:
     CX_FREEZE_STAMP = "internal"
-
-
-class Version(packaging.version.Version):
-    """A valid PEP440 version."""
 
 
 class Structure:

--- a/doc/src/installation.rst
+++ b/doc/src/installation.rst
@@ -51,8 +51,11 @@ Python requirements are installed automatically by pip, pipenv or conda.
   .. code-block:: console
 
    setuptools >= 62.6
+   typing_extensions >= 4.10.0 (Python 3.8, 3.9)
+   wheel >= 0.42.0
    cx_Logging >= 3.1           (Windows only)
    lief >= 0.12.0              (Windows only)
+   filelock >=3.11.0           (Linux)
    patchelf >= 0.14            (Linux)
    C compiler                  (required only if installing from sources)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ keywords = ["cx-freeze cxfreeze cx_Freeze freeze python"]
 requires-python = ">=3.8"
 dependencies = [
     "setuptools>=62.6,<70",
-    "typing_extensions>=4.10.0",
+    "typing_extensions>=4.10.0 ;python_version < '3.10'",
     "wheel>=0.42.0,<=0.43.0",
     "cx_Logging>=3.1 ;sys_platform == 'win32'",
     "lief>=0.12.0,<0.15.0 ;sys_platform == 'win32'",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 --extra-index-url https://marcelotduarte.github.io/packages/
 
 setuptools>=62.6,<70
-typing_extensions>=4.10.0
+typing_extensions>=4.10.0 ;python_version < '3.10'
 wheel>=0.42.0,<=0.43.0
 cx_Logging>=3.1 ;sys_platform == 'win32'
 lief>=0.12.0,<0.15.0 ;sys_platform == 'win32'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 --extra-index-url https://marcelotduarte.github.io/packages/
 
 setuptools>=62.6,<70
-typing_extensions>=4.10.0
+typing_extensions>=4.10.0 ;python_version < '3.10'
 wheel>=0.42.0,<=0.43.0
 cx_Logging>=3.1 ;sys_platform == 'win32'
 lief>=0.12.0,<0.15.0 ;sys_platform == 'win32'

--- a/tests/test_winversioninfo.py
+++ b/tests/test_winversioninfo.py
@@ -10,12 +10,8 @@ from sysconfig import get_platform, get_python_version
 import pytest
 from generate_samples import create_package, run_command
 
-from cx_Freeze.winversioninfo import (
-    COMMENTS_MAX_LEN,
-    Version,
-    VersionInfo,
-    main_test,
-)
+from cx_Freeze._packaging import Version
+from cx_Freeze.winversioninfo import COMMENTS_MAX_LEN, VersionInfo, main_test
 
 PLATFORM = get_platform()
 PYTHON_VERSION = get_python_version()


### PR DESCRIPTION
Also, use stdlib importlib.metadata for Python >= 3.10.2 (like https://github.com/pypa/build/pull/693)