### PR TITLE
tests: add command line tests for build_exe

### DIFF
--- a/cx_Freeze/common.py
+++ b/cx_Freeze/common.py
@@ -41,7 +41,7 @@ def normalize_to_list(
     """Takes the different formats of options containing multiple values and
     returns the value as a list object.
     """
-    if value is None:
+    if not value:  # empty or None
         return []
     if isinstance(value, str):
         return value.split(",")


### PR DESCRIPTION
This catches some bugs using `python setup.py build_exe --bin-includes=filename` for example.