### PR TITLE
hooks: fix unbound variable in load_subprocess under MINGW

### DIFF
--- a/cx_Freeze/hooks/__init__.py
+++ b/cx_Freeze/hooks/__init__.py
@@ -602,6 +602,8 @@ def load_subprocess(finder: ModuleFinder, module: Module) -> None:
         exclude_names = ("_posixsubprocess", "fcntl", "grp", "pwd")
     elif not IS_MINGW:
         exclude_names = ("msvcrt", "_winapi")
+    else:
+        return
     module.exclude_names.update(exclude_names)
 
 


### PR DESCRIPTION
This was introduced by f97cbce2da045352539a8fc0a7ad1209bad018ab