### PR TITLE
bdist_rpm: Fix string concat error due to order of op for + and or in RPM

### DIFF
--- a/cx_Freeze/command/bdist_rpm.py
+++ b/cx_Freeze/command/bdist_rpm.py
@@ -401,7 +401,7 @@ class bdist_rpm(Command):
             "%define unmangled_version " + self.distribution.get_version(),
             "%define release " + self.release.replace("-", "_"),
             "",
-            "Summary: " + self.distribution.get_description() or "UNKNOWN",
+            f"Summary: {self.distribution.get_description() or "UNKNOWN"}",
             "Name: %{name}",
             "Version: %{version}",
             "Release: %{release}",

--- a/cx_Freeze/command/bdist_rpm.py
+++ b/cx_Freeze/command/bdist_rpm.py
@@ -401,7 +401,7 @@ class bdist_rpm(Command):
             "%define unmangled_version " + self.distribution.get_version(),
             "%define release " + self.release.replace("-", "_"),
             "",
-            f"Summary: {self.distribution.get_description() or "UNKNOWN"}",
+            f"Summary: {self.distribution.get_description() or 'UNKNOWN'}",
             "Name: %{name}",
             "Version: %{version}",
             "Release: %{release}",


### PR DESCRIPTION
# Background

When running an rpm build, if you don't have self.distribution.get_description populated, cx_Freeze should use 'UNKNOWN'. However, due to an order of operations bug, it attempts to concat str with None which isn't possible

# Changes
- Reformat the string concat to an f-string so that "or" is evaluated before the concat