### PR TITLE
freezer: include_msvcr now uses Redistributable files

### DIFF
--- a/cx_Freeze/command/build_exe.py
+++ b/cx_Freeze/command/build_exe.py
@@ -45,8 +45,9 @@ class build_exe(Command):
         (
             "path=",
             None,
-            "comma-separated list of paths to search for modules; the default "
-            "value is sys.path (use only if you know what you are doing)",
+            "comma-separated list of paths to search for modules "
+            "(use only if you know what you are doing) "
+            "[default: sys.path]",
         ),
         (
             "include-path=",
@@ -137,7 +138,16 @@ class build_exe(Command):
         (
             "include-msvcr",
             None,
-            "include the Microsoft Visual C runtime files",
+            "include the Microsoft Visual C++ Redistributable "
+            "files without needing the redistributable package "
+            "installed (--include-msvcr-version=17 equivalent)",
+        ),
+        (
+            "include-msvcr-version=",
+            None,
+            "like --include-msvcr but the version can be set "
+            "with one of the following values: 15, 16 or 17 "
+            "(version 15 includes UCRT for Windows 8.1 and below)",
         ),
     ]
     boolean_options: ClassVar[list[str]] = [
@@ -211,6 +221,7 @@ class build_exe(Command):
 
         self.build_exe = None
         self.include_msvcr = None
+        self.include_msvcr_version = None
         self.no_compress = False
         self.optimize = 0
         self.path = None
@@ -262,7 +273,12 @@ class build_exe(Command):
             self.zip_filename = "library.zip"
 
         # include-msvcr is used on Windows, but not in MingW
-        self.include_msvcr = IS_WINDOWS and bool(self.include_msvcr)
+        if IS_WINDOWS:
+            if self.include_msvcr_version is not None:
+                self.include_msvcr = True
+            self.include_msvcr = bool(self.include_msvcr)
+        else:
+            self.include_msvcr = False
 
         # optimization level: 0,1,2
         self.optimize = int(self.optimize or 0)
@@ -295,6 +311,7 @@ class build_exe(Command):
             silent=self.silent,
             metadata=metadata,
             include_msvcr=self.include_msvcr,
+            include_msvcr_version=self.include_msvcr_version,
             zip_filename=self.zip_filename,
         )
 

--- a/cx_Freeze/freezer.py
+++ b/cx_Freeze/freezer.py
@@ -993,7 +993,6 @@ class WinFreezer(Freezer, PEParser):
             target_dir = self.target_dir
             license_dir = target_dir / "share/licenses/vc_redist"
             for source in get_msvcr_files(self.include_msvcr_version):
-                print(source)
                 if source.stem == "LICENSE":
                     target = license_dir / source.name
                 else:

--- a/cx_Freeze/winmsvcr.py
+++ b/cx_Freeze/winmsvcr.py
@@ -1,20 +1,18 @@
 """DLL list of MSVC runtimes.
 
 Extracted from:
-    https://github.com/conda-forge/vc-feedstock/blob/master/recipe/meta.yaml
+    https://github.com/conda-forge/vc-feedstock/blob/main/recipe/meta.yaml
 
 """
 
 from __future__ import annotations
 
-FILES = (
-    "api-ms-win-*.dll",
+MSVC_FILES = (
     # VC 2015 and 2017
     "concrt140.dll",
+    "msvcp140.dll",
     "msvcp140_1.dll",
     "msvcp140_2.dll",
-    "msvcp140.dll",
-    "ucrtbase.dll",
     "vcamp140.dll",
     "vccorlib140.dll",
     "vcomp140.dll",
@@ -25,4 +23,9 @@ FILES = (
     "vcruntime140_1.dll",
     # VS 2022
     "vcruntime140_threads.dll",
+)
+
+UCRT_FILES = (
+    "api-ms-win-*.dll",
+    "ucrtbase.dll",
 )

--- a/cx_Freeze/winmsvcr_repack.py
+++ b/cx_Freeze/winmsvcr_repack.py
@@ -1,0 +1,301 @@
+"""Extract MSVC runtime package.
+
+Code based on:
+    https://github.com/conda-forge/vc-feedstock/blob/main/recipe/vc_repack.py
+    https://github.com/conda-forge/vc-feedstock/blob/main/recipe/meta.yaml
+
+But using cabarchive package (instead of 7z) to extract the cabs.
+
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import tempfile
+import time
+import xml.dom.minidom
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+from urllib.request import urlretrieve
+
+import cabarchive
+from filelock import FileLock
+from striprtf.striprtf import rtf_to_text
+
+from cx_Freeze._compat import PLATFORM
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+__all__ = ["copy_msvcr_files"]
+
+# All Microsoft CAB archives start with this signature
+MS_CAB_HEADER = b"MSCF\0\0\0\0"
+
+VC_REDIST_BASE_URL = "https://aka.ms/vs/{version}/release/{name}"
+
+VC_VERSION_TABLE = {
+    "15": "14.16.27052",
+    "16": "14.29.30156",
+    "17": "14.40.33816",
+}
+
+EXE_FILENAMES = {
+    "win-arm64": "vc_redist.arm64.exe",
+    "win-amd64": "vc_redist.x64.exe",
+    "win32": "vc_redist.x86.exe",
+}
+
+
+def split_self_extract_exe(
+    exe_file: Path, target_directory: Path
+) -> list[str]:
+    # The self-extracting exe file contains two embedded CAB archives.
+    # Split these out using a match against the known Microsoft CAB
+    # header.  It's not ideal, but it works.
+    contents = exe_file.read_bytes()
+    splits = contents.split(MS_CAB_HEADER)
+    fnames = []
+    for index, s in enumerate(splits[1:]):
+        fname = f"cab{index:02}.cab"
+        target_directory.joinpath(fname).write_bytes(MS_CAB_HEADER + s)
+        fnames.append(fname)
+    return fnames
+
+
+def unpack_cab(cabfile: Path, tmpdir: Path) -> None:
+    tmpdir.mkdir(exist_ok=True)
+    cab = cabarchive.CabArchive(cabfile.read_bytes())
+    for file in cab.values():
+        target = tmpdir / file.filename
+        target.write_bytes(file.buf)
+        # Preserve timestamp
+        date_time = time.mktime(
+            datetime.combine(file.date, file.time).timetuple()
+        )
+        os.utime(target, (date_time, date_time))
+
+
+def decode_manifest(directory: Path) -> dict[str, str]:
+    # The first CAB file contains a manifest in the file "0" in XML format.
+    dom = xml.dom.minidom.parse(os.fspath(directory / "0"))  # noqa: S318
+
+    # The version is contained in Registration.Version
+    registration = dom.documentElement.getElementsByTagName("Registration")
+    version = registration[0].attributes["Version"].value
+    line = f"MSVC Runtimes version: {version}"
+    print("*" * len(line))
+    print(line)
+    print("*" * len(line))
+    print(flush=True)
+
+    # The other files have generic names such as a0, a1, etc.  The manifest
+    # gives us their true names.  The FilePath contains the a0 type filename,
+    # the SourcePath the true filename.
+    payloads = dom.documentElement.getElementsByTagName("Payload")
+
+    # Find the licence file.
+    licences = [
+        x.attributes
+        for x in payloads
+        if "FilePath" in x.attributes
+        and x.attributes["FilePath"].value.lower() == "license.rtf"
+    ]
+    if len(licences) == 0:
+        msg = "Found no licences in the manifest"
+        raise RuntimeError(msg)
+    if len(licences) > 1:
+        msg = "Found more than one licence in the manfiest"
+        raise RuntimeError(msg)
+
+    # Find the files that are in the second CAB file. These have
+    # helpful filenames of u0, u1, etc.
+    containers = [x for x in payloads if "Container" in x.attributes]
+
+    # The DLL files we want are in the second CAB file, with a name of
+    # "packages\vcRuntimeMinimum_amd64\cab1.cab",
+    # "packages\VC_Runtime_arm64\cab1.cab",
+    # "packages\vcRuntimeMinimum_x86\cab1.cab" or similar
+    def find_cab(r, v) -> bool:
+        return r in v and v.endswith(".cab")
+
+    runtimes = [
+        i.attributes
+        for i in containers
+        if find_cab("vcRuntimeMinimum", i.attributes["FilePath"].value)
+    ]
+    if len(runtimes) == 0:
+        runtimes = [
+            i.attributes
+            for i in containers
+            if find_cab("VC_Runtime", i.attributes["FilePath"].value)
+        ]
+    if len(runtimes) == 0:
+        msg = "Found no matches in the manifest"
+        raise RuntimeError(msg)
+    if len(runtimes) > 1:
+        msg = "Found more than one match in the manfiest"
+        raise RuntimeError(msg)
+
+    return {
+        "cabfile": runtimes[0]["SourcePath"].value,
+        "licence": licences[0]["SourcePath"].value,
+        "version": version,
+    }
+
+
+def fix_filename_and_copy(
+    source_dir: Path, target_dir: Path
+) -> Generator[Path]:
+    # As of VS 17.6, the artifact contains intermediate DLL extensions,
+    # which get renamed correctly upon installation; do it manually
+    target_dir.mkdir(exist_ok=True)
+    for file in source_dir.glob("*.dll*"):
+        if file.name.startswith("api_"):
+            new_fname = file.name.replace("_", "-")
+        elif file.suffix.startswith(".dll_"):
+            new_fname = file.stem + ".dll"
+        else:
+            new_fname = file.name
+        print(f"Found DLL: {file.name} -> {new_fname}")
+        shutil.copy2(file, target_dir / new_fname)
+        yield target_dir / new_fname
+
+
+def unpack_exe(exe_filename: Path, unpack_dir: Path) -> Generator[Path]:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        cabs = split_self_extract_exe(exe_filename, tmp_path)
+        # The first cab is the installer data
+        # The second is the payload
+        cabfile1 = tmp_path / cabs[0]
+        cabdir1 = tmp_path / cabfile1.stem
+        unpack_cab(cabfile1, cabdir1)
+        payload = decode_manifest(cabdir1)
+        # Get LICENSE and converts to txt
+        unpack_dir.mkdir(parents=True, exist_ok=True)
+        license_rtf = unpack_dir / "LICENSE.RTF"
+        shutil.copy2(cabdir1 / payload["licence"], license_rtf)
+        yield license_rtf
+        text = rtf_to_text(
+            license_rtf.read_text(encoding="cp1252", errors="strict")
+        )
+        license_txt = unpack_dir / "LICENSE.txt"
+        license_txt.write_text(text, encoding="cp1252", errors="strict")
+        yield license_txt
+        # Get the payload
+        cabfile2 = tmp_path / cabs[1]
+        cabdir2 = tmp_path / cabfile2.stem
+        unpack_cab(cabfile2, cabdir2)
+        vc_redist = tmp_path / exe_filename.stem
+        vc_redist.mkdir(exist_ok=True)
+        unpack_cab(Path(cabdir2, payload["cabfile"]), vc_redist)
+        yield from fix_filename_and_copy(vc_redist, unpack_dir)
+
+
+def get_msvcr_files(
+    version: str | None = None,
+    target_platform: str | None = None,
+    no_cache: bool = False,
+) -> Generator[Path]:
+    """Get MSVC runtime files."""
+    if target_platform is None:
+        target_platform = (
+            PLATFORM if PLATFORM.startswith("win") else "win-amd64"
+        )
+    if target_platform in EXE_FILENAMES:
+        name = EXE_FILENAMES[target_platform]
+    else:
+        msg = f"Architecture {target_platform} not supported"
+        raise RuntimeError(msg)
+    if version is None:
+        version = max(VC_VERSION_TABLE.keys())
+    if version not in VC_VERSION_TABLE:
+        msg = f"Version {version} is not expected"
+        raise RuntimeError(msg)
+
+    # use a cache dir
+    if os.environ.get("APPDATA"):
+        cache_base = Path(os.path.expandvars("${APPDATA}"))
+    else:
+        cache_base = Path("~/.cache").expanduser()
+    cache_dir = cache_base / f"cx_Freeze/vc_redist/{ version }"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    filename = cache_dir / name
+    unpack_dir = cache_dir / name.replace(".", "_")
+    unpack_dir.mkdir(parents=True, exist_ok=True)
+    with FileLock(filename.with_suffix(".lock")):
+        if no_cache or not filename.exists():
+            urlretrieve(  # noqa: S310
+                VC_REDIST_BASE_URL.format(version=version, name=name), filename
+            )
+        if filename.exists():
+            files = list(unpack_dir.glob("*.dll"))
+            if no_cache or not files:
+                yield from unpack_exe(filename, unpack_dir)
+            else:
+                yield from unpack_dir.iterdir()
+        else:
+            msg = f"{filename} not found"
+            raise RuntimeError(msg)
+
+
+def copy_msvcr_files(
+    target_dir: Path | str,
+    target_platform: str | None = None,
+    version: str | None = None,
+    dry_run: bool = False,
+    no_cache: bool = False,
+) -> None:
+    """Copy MSVC runtime files."""
+    target_dir = Path(target_dir)
+    target_dir.mkdir(parents=True, exist_ok=True)
+    for file in get_msvcr_files(version, target_platform, no_cache):
+        if not dry_run:
+            shutil.copy2(file, target_dir / file.name)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Extract MSVC runtime package"
+    )
+    parser.add_argument(
+        "--dry-run",
+        "-n",
+        help="Do not copy files, list files only",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--target-dir", help="dist", metavar="DIR", default="dist"
+    )
+    parser.add_argument(
+        "--target-platform",
+        help="Target architecture (eg. win-arm64, win-amd64, win32)",
+        default=None,
+    )
+    parser.add_argument(
+        "--version",
+        help="Runtime version number",
+        default=None,
+    )
+    parser.add_argument(
+        "--no-cache",
+        help="Don't use the cached runtime",
+        action="store_true",
+    )
+    args = parser.parse_args()
+
+    copy_msvcr_files(
+        args.target_dir,
+        args.target_platform,
+        args.version,
+        args.dry_run,
+        args.no_cache,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/doc/src/faq.rst
+++ b/doc/src/faq.rst
@@ -96,15 +96,16 @@ Microsoft Visual C++ Redistributable Package
 
 Python 3.9-3.13 on Windows requires the `Microsoft Visual C++ Redistributable
 <https://docs.microsoft.com/en-US/cpp/windows/latest-supported-vc-redist>`_,
-and because of how this is installed, **cx_Freeze** doesn't automatically copy
-it for your application.
+and because of how this is installed, **cx_Freeze** by default does NOT
+automatically copy it for your application, however this can be changed,
+but note that:
 
-You're responsible for checking the license conditions associated with the DLLs
-you have installed.
+* You're responsible for checking the license conditions associated with the
+  DLLs you have installed.
 
 * If your license allows you to distribute these files, specify the
-  :option:`include_msvcr` option to :ref:`cx_freeze_build_exe` to have them
-  distributed automatically.
+  :option:`include_msvcr` option or :option:`include_msvcr_version` option to
+  :ref:`cx_freeze_build_exe` to have them distributed automatically.
 
 * If not, your users or installers must install the Microsoft Visual C++
   Redistributable Package.
@@ -122,10 +123,15 @@ you have installed.
     winget upgrade Microsoft.VCRedist.2015+.x64
     winget upgrade Microsoft.VCRedist.2015+.x86
 
-  If you are using an older Windows version than Windows 10 and the latest
+* If you are using an older Windows version than Windows 10 and the latest
   system updates are not installed, `Universal C Runtime
   <https://support.microsoft.com/en-us/help/2999226/
   update-for-universal-c-runtime-in-windows>`_ might also be required.
+  You can set :option:`include_msvcr_version` option to 15
+  (version 15 includes UCRT for Windows 8.1 and below). See more note-worthy
+  information at `Distributing Software that uses the Universal CRT
+  <https://devblogs.microsoft.com/cppblog/introducing-the-universal-crt/
+  #distributing-software-that-uses-the-universal-crt>`_.
 
 Removing the MAX_PATH Limitation
 --------------------------------

--- a/doc/src/installation.rst
+++ b/doc/src/installation.rst
@@ -50,16 +50,18 @@ Python requirements are installed automatically by pip, pipenv, or conda.
 
   .. code-block:: console
 
+   filelock >= 3.12.3
+   importlib_metadata >= 6     (Python 3.9-3.10.2)
    packaging >= 24
-   setuptools >= 65.6.3        (setuptools >= 70.1 to build)
-   importlib_metadata>=6       (Python 3.9-3.10.2)
+   setuptools >= 65.6.3        (setuptools >= 70.1 if installing from sources)
    tomli >= 2.0.1              (Python 3.9-3.10)
    typing_extensions >= 4.10.0 (Python 3.9)
-   cx_Logging >= 3.1           (Windows only)
-   lief >= 0.12.0              (Windows only)
-   filelock >= 3.12.3          (Linux)
    patchelf >= 0.14            (Linux)
    dmgbuild >= 1.6.1           (macOS)
+   cabarchive >= 0.2.4         (Windows only)
+   cx_Logging >= 3.1           (Windows only)
+   lief >= 0.12.0              (Windows only)
+   striprtf >= 0.0.26          (Windows only)
    C compiler                  (required only if installing from sources)
 
 .. note:: If you have trouble with patchelf, check :ref:`patchelf`.

--- a/doc/src/setup_script.rst
+++ b/doc/src/setup_script.rst
@@ -218,8 +218,9 @@ It can be further customized:
        relative path to the module; multiple values are separated by the
        standard path separator
    * - .. option:: path
-     - comma-separated list of paths to search for modules; the default value
-       is sys.path (use only if you know what you are doing)
+     - comma-separated list of paths to search for modules
+       (use only if you know what you are doing)
+       [default: sys.path]
    * - .. option:: include_path
      - comma-separated list of paths to modify the search for modules
    * - .. option:: constants
@@ -284,14 +285,22 @@ It can be further customized:
        2. also suppress missing-module warning messages;
        3. also suppress all other warning messages.
    * - .. option:: include_msvcr
-     - include the Microsoft Visual C runtime files without needing the
-       redistributable package installed
+     - include the Microsoft Visual C++ Redistributable
+       files without needing the redistributable package
+       installed (--include-msvcr-version=17 equivalent)
+   * - .. option:: include_msvcr_version
+     - like :option:`include_msvcr` but the version can be set
+       with one of the following values: 15, 16 or 17
+       (version 15 includes UCRT for Windows 8.1 and below)
 
 .. versionadded:: 6.7
     :option:`silent_level` option.
 
 .. versionadded:: 7.1
     :option:`zip_filename` option used in conjunction with :option:`no_compress`.
+
+.. versionadded:: 7.3
+    :option:`include_msvcr_version` option.
 
 This is the equivalent help to specify the same options on the command line:
 
@@ -306,9 +315,9 @@ This is the equivalent help to specify the same options on the command line:
                               includes all submodules in the package
       --replace-paths         comma-separated list of paths to replace in included
                               modules, using the form <search>=<replace>
-      --path                  comma-separated list of paths to search for modules;
-                              the default value is sys.path (use only if you know
-                              what you are doing)
+      --path                  comma-separated list of paths to search for modules
+                              (use only if you know what you are doing)
+                              [default: sys.path]
       --include-path          comma-separated list of paths to modify the search
                               for modules
       --constants             comma-separated list of constants to include
@@ -345,7 +354,12 @@ This is the equivalent help to specify the same options on the command line:
                               (equivalent to --silent) level 2: suppress missing
                               missing-module warnings level 3: suppress all
                               warning messages
-      --include-msvcr         include the Microsoft Visual C runtime files
+      --include-msvcr         include the Microsoft Visual C++ Redistributable
+                              files without needing the redistributable package
+                              installed (--include-msvcr-version=17 equivalent)
+      --include-msvcr         like --include-msvcr but the version can be set
+                              with one of the following values: 15, 16 or 17
+                              (version 15 includes UCRT for Windows 8.1 and below)
 
 
 install

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,21 +36,26 @@ classifiers = [
 keywords = ["cx-freeze cxfreeze cx_Freeze freeze python"]
 requires-python = ">=3.9"
 dependencies = [
+    "filelock>=3.12.3",
+    "importlib_metadata>=6 ;python_full_version < '3.10.2'",
     "packaging>=24",
     "setuptools>=65.6.3,<76",
-    "importlib_metadata>=6 ;python_full_version < '3.10.2'",
     "tomli>=2.0.1 ;python_version < '3.11'",
     "typing_extensions>=4.10.0 ;python_version < '3.10'",
-    "cx_Logging>=3.1 ;sys_platform == 'win32'",
-    "lief>=0.12.0,<0.16.0 ;sys_platform == 'win32'",
-    "filelock>=3.12.3 ;sys_platform == 'linux'",
+    # Linux
     "patchelf>=0.14 ;sys_platform == 'linux' and platform_machine == 'x86_64'",
     "patchelf>=0.14 ;sys_platform == 'linux' and platform_machine == 'i686'",
     "patchelf>=0.14 ;sys_platform == 'linux' and platform_machine == 'aarch64'",
     "patchelf>=0.14 ;sys_platform == 'linux' and platform_machine == 'armv7l'",
     "patchelf>=0.14 ;sys_platform == 'linux' and platform_machine == 'ppc64le'",
     "patchelf>=0.14 ;sys_platform == 'linux' and platform_machine == 's390x'",
-    "dmgbuild>=1.6.1 ;sys_platform == 'darwin'"
+    # macOS
+    "dmgbuild>=1.6.1 ;sys_platform == 'darwin'",
+    # Windows
+    "cabarchive>=0.2.4 ;sys_platform == 'win32'",
+    "cx_Logging>=3.1 ;sys_platform == 'win32'",
+    "lief>=0.12.0,<0.16.0 ;sys_platform == 'win32'",
+    "striprtf>=0.0.26 ;sys_platform == 'win32'",
 ]
 dynamic = ["version"]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,9 @@
+filelock>=3.12.3
+importlib_metadata>=6 ;python_full_version < '3.10.2'
 packaging>=24
 setuptools>=65.6.3,<76
-importlib_metadata>=6 ;python_full_version < '3.10.2'
 tomli>=2.0.1 ;python_version < '3.11'
 typing_extensions>=4.10.0 ;python_version < '3.10'
-cx_Logging>=3.1 ;sys_platform == 'win32'
-lief>=0.12.0,<0.16.0 ;sys_platform == 'win32'
-filelock>=3.12.3 ;sys_platform == 'linux'
 patchelf>=0.14 ;sys_platform == 'linux' and platform_machine == 'x86_64'
 patchelf>=0.14 ;sys_platform == 'linux' and platform_machine == 'i686'
 patchelf>=0.14 ;sys_platform == 'linux' and platform_machine == 'aarch64'
@@ -13,3 +11,7 @@ patchelf>=0.14 ;sys_platform == 'linux' and platform_machine == 'armv7l'
 patchelf>=0.14 ;sys_platform == 'linux' and platform_machine == 'ppc64le'
 patchelf>=0.14 ;sys_platform == 'linux' and platform_machine == 's390x'
 dmgbuild>=1.6.1 ;sys_platform == 'darwin'
+cabarchive>=0.2.4 ;sys_platform == 'win32'
+cx_Logging>=3.1 ;sys_platform == 'win32'
+lief>=0.12.0,<0.16.0 ;sys_platform == 'win32'
+striprtf>=0.0.26 ;sys_platform == 'win32'

--- a/tests/test_winmsvcr.py
+++ b/tests/test_winmsvcr.py
@@ -2,26 +2,22 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
 from generate_samples import create_package, run_command
 
 from cx_Freeze._compat import BUILD_EXE_DIR, EXE_SUFFIX, IS_MINGW, IS_WINDOWS
-from cx_Freeze.winmsvcr import FILES
 
 if TYPE_CHECKING:
     from pathlib import Path
 
-EXPECTED = (
-    "api-ms-win-*.dll",
+MSVC_EXPECTED = (
     # VC 2015 and 2017
     "concrt140.dll",
+    "msvcp140.dll",
     "msvcp140_1.dll",
     "msvcp140_2.dll",
-    "msvcp140.dll",
-    "ucrtbase.dll",
     "vcamp140.dll",
     "vccorlib140.dll",
     "vcomp140.dll",
@@ -32,6 +28,11 @@ EXPECTED = (
     "vcruntime140_1.dll",
     # VS 2022
     "vcruntime140_threads.dll",
+)
+
+UCRT_EXPECTED = (
+    "api-ms-win-*.dll",
+    "ucrtbase.dll",
 )
 
 SOURCE = """
@@ -45,7 +46,10 @@ command
 @pytest.mark.skipif(not IS_WINDOWS, reason="Windows tests")
 def test_files() -> None:
     """Test MSVC files."""
-    assert EXPECTED == FILES
+    from cx_Freeze.winmsvcr import MSVC_FILES, UCRT_FILES
+
+    assert MSVC_EXPECTED == MSVC_FILES
+    assert UCRT_EXPECTED == UCRT_FILES
 
 
 @pytest.mark.skipif(not (IS_MINGW or IS_WINDOWS), reason="Windows tests")
@@ -69,7 +73,7 @@ def test_build_exe_with_include_msvcr(
     names = [
         file.name.lower()
         for file in build_exe_dir.glob("*.dll")
-        if any(filter(file.match, EXPECTED))
+        if any(filter(file.match, MSVC_EXPECTED))
     ]
     # include-msvcr copies the files only on Windows, but not in MingW
     if IS_WINDOWS and include_msvcr:


### PR DESCRIPTION
- Download and extract the MSVC Redistributable files (cached)
- Exclude by default the MSVC runtime files locally installed
- Exclude by default UCRT
- Copy MSVC runtime files to build_exe directory if required
