### PR TITLE
bdist_rpm: fix use of 'cxfreeze bdist_rpm' command

### DIFF
--- a/cx_Freeze/cli.py
+++ b/cx_Freeze/cli.py
@@ -176,7 +176,7 @@ def main() -> None:
     if script is None:
         if command is None:
             parser.error("--script or command must be specified")
-        elif not command.startswith(("build", "bdist")):
+        elif not command.startswith(("build", "bdist", "install")):
             args.script, command = command, script  # backwards compatible
             deprecated.append("usage: required to use --script NAME")
     if command is None:

--- a/cx_Freeze/command/bdist_rpm.py
+++ b/cx_Freeze/command/bdist_rpm.py
@@ -55,8 +55,8 @@ class bdist_rpm(Command):
         # More meta-data: too RPM-specific to put in the setup script,
         # but needs to go in the .spec file -- so we make these options
         # to "bdist_rpm".  The idea is that packagers would put this
-        # info in setup.cfg, although they are of course free to
-        # supply it on the command line.
+        # info in pyproject.toml or setup.cfg, although they are of course free
+        # to supply it on the command line.
         (
             "distribution-name=",
             None,
@@ -470,8 +470,11 @@ class bdist_rpm(Command):
         ]
 
         # rpm scripts - figure out default build script
-        def_setup_call = f"{sys.executable} {dist.script_name}"
-        def_build = f"{def_setup_call} build_exe -O1 --silent"
+        if dist.script_name == "cxfreeze":
+            def_setup_call = shutil.which(dist.script_name)
+        else:
+            def_setup_call = f"{sys.executable} {dist.script_name}"
+        def_build = f"{def_setup_call} build_exe --optimize=1 --silent"
         def_build = 'env CFLAGS="$RPM_OPT_FLAGS" ' + def_build
 
         # insert contents of files

--- a/samples/simple_pyproject/pyproject.toml
+++ b/samples/simple_pyproject/pyproject.toml
@@ -6,7 +6,6 @@ description = "Sample cx_Freeze script"
 [tool.cxfreeze]
 executables = [
     "hello.py",
-    {script = "hello.py", target_name = "hello2"}
 ]
 
 [tool.cxfreeze.build_exe]

--- a/tests/test_command_install.py
+++ b/tests/test_command_install.py
@@ -14,11 +14,26 @@ SOURCE = """
 test.py
     print("Hello from cx_Freeze")
 setup.py
-    from cx_Freeze import setup, Executable
+    from cx_Freeze import setup
 
-    setup(name="hello", executables=[Executable("test.py")])
+    setup(name="hello", version = "0.1.2.3", executables=["test.py"])
 command
     python setup.py install --prefix=base --root=root
+"""
+
+SOURCE_PYPROJECT = """
+test.py
+    print("Hello from cx_Freeze")
+pyproject.toml
+    [project]
+    name = "hello"
+    version = "0.1.2.3"
+    description = "Sample cx_Freeze script"
+
+    [tool.cxfreeze]
+    executables = ["test.py"]
+command
+    cxfreeze install --prefix=base --root=root
 """
 
 
@@ -32,7 +47,27 @@ def test_install(tmp_path: Path) -> None:
         prefix = program_files.relative_to(program_files.anchor) / "hello"
     else:
         run_command(tmp_path)
-        prefix = "base/lib/hello-0.0.0"
+        prefix = "base/lib/hello-0.1.2.3"
+    install_dir = tmp_path / "root" / prefix
+
+    file_created = install_dir / f"test{EXE_SUFFIX}"
+    assert file_created.is_file(), f"file not found: {file_created}"
+
+    output = run_command(tmp_path, file_created, timeout=10)
+    assert output.startswith("Hello from cx_Freeze")
+
+
+def test_install_pyproject(tmp_path: Path) -> None:
+    """Test a simple install."""
+    create_package(tmp_path, SOURCE_PYPROJECT)
+
+    if sys.platform == "win32":
+        run_command(tmp_path, "cxfreeze install --root=root")
+        program_files = Path(os.getenv("PROGRAMFILES"))
+        prefix = program_files.relative_to(program_files.anchor) / "hello"
+    else:
+        run_command(tmp_path)
+        prefix = "base/lib/hello-0.1.2.3"
     install_dir = tmp_path / "root" / prefix
 
     file_created = install_dir / f"test{EXE_SUFFIX}"


### PR DESCRIPTION
Fixes #2527 
This also works for `python -m cx_Freeze bdist_rpm`.