### PR TITLE
build(deps): use setuptools >= 70.1 to build (get rid of wheel)

### DIFF
--- a/doc/src/installation.rst
+++ b/doc/src/installation.rst
@@ -50,13 +50,16 @@ Python requirements are installed automatically by pip, pipenv, or conda.
 
   .. code-block:: console
 
-   setuptools >= 62.6
-   typing_extensions >= 4.10.0 (Python 3.8, 3.9)
-   wheel >= 0.42.0
+   packaging >= 24
+   setuptools >= 65.6.3        (setuptools >= 70.1 to build)
+   importlib_metadata>=6       (Python 3.8-3.10.2)
+   tomli >= 2.0.1              (Python 3.8-3.10)
+   typing_extensions >= 4.10.0 (Python 3.8-3.9)
    cx_Logging >= 3.1           (Windows only)
    lief >= 0.12.0              (Windows only)
-   filelock >=3.11.0           (Linux)
+   filelock >=3.12.3           (Linux)
    patchelf >= 0.14            (Linux)
+   dmgbuild >= 1.6.1           (macOS)
    C compiler                  (required only if installing from sources)
 
 .. note:: If you have trouble with patchelf, check :ref:`patchelf`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = [
-    "setuptools>=65.6.3,<73",
-    "wheel>=0.42.0,<=0.43.0",
+    "setuptools>=70.1,<73",
     "cx_Logging>=3.1 ;sys_platform == 'win32'",
 ]
 build-backend = "setuptools.build_meta"
@@ -40,10 +39,9 @@ requires-python = ">=3.8"
 dependencies = [
     "packaging>=24",
     "setuptools>=65.6.3,<73",
-    "importlib_metadata>=6 ;python_version < '3.10.2'",
+    "importlib_metadata>=6 ;python_full_version < '3.10.2'",
     "tomli>=2.0.1 ;python_version < '3.11'",
     "typing_extensions>=4.10.0 ;python_version < '3.10'",
-    "wheel>=0.42.0,<=0.43.0",
     "cx_Logging>=3.1 ;sys_platform == 'win32'",
     "lief>=0.12.0,<0.16.0 ;sys_platform == 'win32'",
     "filelock>=3.12.3 ;sys_platform == 'linux'",
@@ -62,7 +60,7 @@ dev = [
     "bump-my-version==0.25.0",
     "cibuildwheel==2.20.0",
     "pre-commit==3.5.0 ;python_version < '3.9'",
-    "pre-commit==3.7.1 ;python_version >= '3.9'",
+    "pre-commit==3.8.0 ;python_version >= '3.9'",
 ]
 doc = [
     "sphinx==7.3.7",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
 bump-my-version==0.25.0
 cibuildwheel==2.20.0
 pre-commit==3.5.0 ;python_version < '3.9'
-pre-commit==3.7.1 ;python_version >= '3.9'
+pre-commit==3.8.0 ;python_version >= '3.9'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
 packaging>=24
 setuptools>=65.6.3,<73
-importlib_metadata>=6 ;python_version < '3.10.2'
+importlib_metadata>=6 ;python_full_version < '3.10.2'
 tomli>=2.0.1 ;python_version < '3.11'
 typing_extensions>=4.10.0 ;python_version < '3.10'
-wheel>=0.42.0,<=0.43.0
 cx_Logging>=3.1 ;sys_platform == 'win32'
 lief>=0.12.0,<0.16.0 ;sys_platform == 'win32'
 filelock>=3.12.3 ;sys_platform == 'linux'


### PR DESCRIPTION
https://setuptools.pypa.io/en/stable/history.html#v70-1-0
https://github.com/pypa/wheel/blob/7bb46d7727e6e89fe56b3c78297b3af2672bbbe2/docs/news.rst

Closes #2534 