### PR TITLE
hooks: torch - fix duplicate files

### DIFF
--- a/cx_Freeze/hooks/torch.py
+++ b/cx_Freeze/hooks/torch.py
@@ -34,6 +34,7 @@ def load_torch(finder: ModuleFinder, module: Module) -> None:
         module.in_file_system = 2
     else:
         module.in_file_system = 2
+
     # patch the code to ignore CUDA_PATH_Vxx_x installation directory
     code_string = module.file.read_text(encoding="utf_8")
     code_string = code_string.replace("CUDA_PATH", "NO_CUDA_PATH")
@@ -45,15 +46,26 @@ def load_torch(finder: ModuleFinder, module: Module) -> None:
         optimize=finder.optimize,
     )
 
+    # include the cuda libraries as fixed libraries
+    source_lib = module.file.parent.parent / "nvidia"
+    if source_lib.exists():
+        target_lib = f"lib/{source_lib.name}"
+        for source in source_lib.glob("*/lib/*"):
+            target = target_lib / source.relative_to(source_lib)
+            finder.lib_files[source] = target.as_posix()
+
+    # include the shared libraries in 'lib' as fixed libraries
+    source_lib = module.file.parent / "lib"
+    if source_lib.exists():
+        target_lib = f"lib/{module.name}/lib"
+        for source in source_lib.iterdir():
+            finder.lib_files[source] = f"{target_lib}/{source.name}"
+            finder.include_files(source, f"{target_lib}/{source.name}")
+
     # include the binaries (torch 2.1+)
     source_bin = module.file.parent / "bin"
     if source_bin.exists():
         finder.include_files(source_bin, f"lib/{module.name}/bin")
-    # include the shared libraries in 'lib' to avoid searching through the
-    # system.
-    source_lib = module.file.parent / "lib"
-    if source_lib.exists():
-        finder.include_files(source_lib, f"lib/{module.name}/lib")
     # hidden modules
     finder.include_module("torch._C")
     finder.include_module("torch._VF")

--- a/cx_Freeze/hooks/torch.py
+++ b/cx_Freeze/hooks/torch.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from cx_Freeze._compat import IS_MINGW, IS_WINDOWS
+
 if TYPE_CHECKING:
     from cx_Freeze.finder import ModuleFinder
     from cx_Freeze.module import Module
@@ -58,7 +60,8 @@ def load_torch(finder: ModuleFinder, module: Module) -> None:
     source_lib = module.file.parent / "lib"
     if source_lib.exists():
         target_lib = f"lib/{module.name}/lib"
-        for source in source_lib.iterdir():
+        extension = "*.dll" if (IS_WINDOWS or IS_MINGW) else "*.so*"
+        for source in source_lib.glob(extension):
             finder.lib_files[source] = f"{target_lib}/{source.name}"
             finder.include_files(source, f"{target_lib}/{source.name}")
 

--- a/cx_Freeze/hooks/torchvision.py
+++ b/cx_Freeze/hooks/torchvision.py
@@ -14,9 +14,14 @@ if TYPE_CHECKING:
 def load_torchvision(finder: ModuleFinder, module: Module) -> None:
     """Hook for torchvision."""
     module_path = module.file.parent
-    site_packages_path = module_path.parent
+    source_dir = module_path.parent / f"{module.name}.libs"
+    if source_dir.exists():
+        target_dir = f"lib/{source_dir.name}"
+        for source in source_dir.iterdir():
+            finder.lib_files[source] = f"{target_dir}/{source.name}"
 
     # include source of torchvision.models
+    site_packages_path = module_path.parent
     source_path = site_packages_path / "torchvision/models"
     for source in source_path.rglob("*.py"):  # type: Path
         target = "lib" / source.relative_to(site_packages_path)


### PR DESCRIPTION
Closes #2412 
Fixes #2526 

I used Python 3.10 Linux for the tests, using a minimal sample.
torch 2.2.3+cu118, the size was reduced from 11GB to 3.8GB
torch 2.4.1+cu118 the size is 4.0GB
torch 2.4.1+cpu, the size is 667MB.

On Windows, torch 2.2.2+cu118 the final size is 4.3GB.

The minimal sample:
```python
import torch
from multiprocessing import freeze_support

def per_device_launch_fn(current_gpu_index, num_gpu):
    for i in range(1, 1000):
        print("Train...")

num_gpu = 4

if __name__ == "__main__":
    freeze_support()
    print("Starting multiprocessing:", num_gpu, __file__)
    torch.multiprocessing.start_processes(
        per_device_launch_fn,
        args=(num_gpu,),
        nprocs=num_gpu,
        join=True,
        start_method="spawn",
    )
```
