### PR TITLE
hooks: zoneinfo refactored - add tests

### DIFF
--- a/cx_Freeze/freezer.py
+++ b/cx_Freeze/freezer.py
@@ -191,9 +191,15 @@ class Freezer:
         if self.silent < 1:
             print(f"copying {source} -> {target}")
         shutil.copyfile(source, target)
-        shutil.copystat(source, target)
         if include_mode:
             shutil.copymode(source, target)
+            shutil.copystat(source, target)
+        else:
+            try:
+                shutil.copystat(source, target)
+            except OSError:
+                if self.silent < 3:
+                    print("WARNING: unable to copy file metadata:", target)
         self.files_copied.add(target)
 
         # handle post-copy tasks, including copying dependencies

--- a/cx_Freeze/hooks/__init__.py
+++ b/cx_Freeze/hooks/__init__.py
@@ -653,12 +653,6 @@ def load_twitter(finder: ModuleFinder, module: Module) -> None:
     module.ignore_names.update(["json", "simplejson", "django.utils"])
 
 
-def load_tzdata(finder: ModuleFinder, module: Module) -> None:
-    """The tzdata package requires its zone and timezone data."""
-    if module.in_file_system == 0:
-        finder.zip_include_files(module.file.parent, "tzdata")
-
-
 def load_uvloop(finder: ModuleFinder, module: Module) -> None:
     """The uvloop module implicitly loads an extension module."""
     finder.include_module("uvloop._noop")

--- a/cx_Freeze/hooks/tzdata.py
+++ b/cx_Freeze/hooks/tzdata.py
@@ -1,0 +1,17 @@
+"""A collection of functions which are triggered automatically by finder when
+tzdata package is included.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from cx_Freeze.finder import ModuleFinder
+    from cx_Freeze.module import Module
+
+
+def load_tzdata(finder: ModuleFinder, module: Module) -> None:
+    """The tzdata package requires its zone and timezone data."""
+    if module.in_file_system == 0:
+        finder.zip_include_files(module.file.parent, "tzdata")

--- a/cx_Freeze/hooks/zoneinfo.py
+++ b/cx_Freeze/hooks/zoneinfo.py
@@ -5,6 +5,7 @@ zoneinfo package is included.
 from __future__ import annotations
 
 from pathlib import Path
+from textwrap import dedent
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -16,31 +17,62 @@ def load_zoneinfo(finder: ModuleFinder, module: Module) -> None:
     """The zoneinfo package requires timezone data,
     that can be the in tzdata package, if installed.
     """
+    module.global_names.add("TZPATH")
     try:
         finder.include_package("tzdata")
+        target_path = "lib/tzdata/zoneinfo"
     except ImportError:
-        pass
-    else:
-        return
+        target_path = None
 
-    # without tzdata, copy only zoneinfo directory
-    source_path = None
-    zoneinfo = __import__(module.name, fromlist=["TZPATH"])
-    if zoneinfo.TZPATH:
-        for path in zoneinfo.TZPATH:
-            if path.endswith("zoneinfo"):
-                source_path = Path(path)
-                break
-    if source_path is None or not source_path.is_dir():
-        return
-    if module.in_file_system == 0:
-        finder.zip_include_files(source_path, "tzdata/zoneinfo")
-    else:
+    if target_path is None:
+        # without tzdata, copy zoneinfo directory if available
+        source_path = None
+        zoneinfo = __import__(module.name, fromlist=["TZPATH"])
+        if zoneinfo.TZPATH:
+            for path in zoneinfo.TZPATH:
+                if path.endswith("zoneinfo"):
+                    source_path = Path(path).resolve()
+                    break
+        if source_path is None or not source_path.is_dir():
+            # add tzdata to missing modules
+            bad_modules = finder._bad_modules  # noqa: SLF001
+            callers = bad_modules.setdefault("tzdata", {})
+            callers[f"{module.name}_hook"] = None
+            return
+        if module.in_file_system == 0:
+            finder.zip_include_files(source_path, "tzdata/zoneinfo")
+            return
         target_path = "share/zoneinfo"
-        finder.add_constant("PYTHONTZPATH", target_path)
         finder.include_files(
             source_path, target_path, copy_dependent_files=False
         )
+
+    # patch source code
+    if module.file.suffix == ".pyc":  # source unavailable
+        return
+
+    source = f"""
+        # cx_Freeze patch start
+        import os as _os
+        import sys as _sys
+        _prefix = _sys.prefix if _sys.prefix else _sys.frozen_dir
+        if _sys.platform == "darwin":
+            _mac_prefix = _os.path.join(_os.path.dirname(_prefix), "Resources")
+            if _os.path.exists(_mac_prefix):
+                _prefix = _mac_prefix  # using bdist_mac
+        _os.environ["PYTHONTZPATH"] = _os.path.join(
+            _prefix, _os.path.normpath("{target_path}")
+        )
+        # cx_Freeze patch end
+    """
+    code_string = module.file.read_text(encoding="utf_8")
+    module.code = compile(
+        dedent(source) + code_string,
+        module.file.as_posix(),
+        "exec",
+        dont_inherit=True,
+        optimize=finder.optimize,
+    )
 
 
 __all__ = ["load_zoneinfo"]

--- a/cx_Freeze/initscripts/__startup__.py
+++ b/cx_Freeze/initscripts/__startup__.py
@@ -101,7 +101,6 @@ def init() -> None:
     for name in (
         "TCL_LIBRARY",
         "TK_LIBRARY",
-        "PYTZ_TZDATADIR",
         "PYTHONTZPATH",
     ):
         try:

--- a/samples/tz/test_tz.py
+++ b/samples/tz/test_tz.py
@@ -8,11 +8,15 @@ from __future__ import annotations
 from datetime import datetime, timezone
 
 try:
-    from zoneinfo import ZoneInfo
+    from zoneinfo import TZPATH, ZoneInfo, available_timezones
 except ImportError:
-    from backports.zoneinfo import ZoneInfo
+    from backports.zoneinfo import TZPATH, ZoneInfo, available_timezones
+
 
 RFC1123 = "%a, %d %b %Y %H:%M:%S %z"
+
+print("TZPATH:", TZPATH)
+print("Available timezones:", len(available_timezones()))
 
 utc_time = datetime.now(timezone.utc)
 print("UTC time:", utc_time.strftime(RFC1123))

--- a/tests/test_hooks_zoneinfo.py
+++ b/tests/test_hooks_zoneinfo.py
@@ -1,0 +1,66 @@
+"""Tests for cx_Freeze.hooks.zoneinfo."""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+import pytest
+from generate_samples import create_package, run_command
+
+from cx_Freeze._compat import BUILD_EXE_DIR, EXE_SUFFIX
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+SOURCE = """
+test_tz.py
+    from datetime import datetime, timezone
+    from zoneinfo import TZPATH, ZoneInfo, available_timezones
+
+    RFC1123 = "%a, %d %b %Y %H:%M:%S %z"
+
+    print("TZPATH:", TZPATH)
+    print("Available timezones:", len(available_timezones()))
+
+    utc_time = datetime.now(timezone.utc)
+    print("UTC time:", utc_time.strftime(RFC1123))
+
+    tz1 = ZoneInfo("America/Sao_Paulo")
+    brz_time = utc_time.astimezone(tz1)
+    print("Brazil time:", brz_time.strftime(RFC1123))
+
+    tz2 = ZoneInfo("US/Eastern")
+    eas_time = utc_time.astimezone(tz2)
+    print("US Eastern time:", eas_time.strftime(RFC1123))
+command
+    cxfreeze --script test_tz.py build_exe --excludes=tkinter --silent
+"""
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 9), reason="Python < 3.9 doesn't provide zoneinfo"
+)
+@pytest.mark.parametrize(
+    "zip_packages", [False, True], ids=["", "zip_packages"]
+)
+def test_tz(tmp_path: Path, zip_packages: bool) -> None:
+    """Test if zoneinfo hook is working correctly."""
+    create_package(tmp_path, SOURCE)
+    if zip_packages:
+        with tmp_path.joinpath("command").open("a") as f:
+            f.write(" --zip-include-packages=* --zip-include-packages=")
+    output = run_command(tmp_path)
+    if "? tzdata imported from zoneinfo_hook" in output:
+        pytest.skip(reason="tzdata must be installed")
+
+    executable = tmp_path / BUILD_EXE_DIR / f"test_tz{EXE_SUFFIX}"
+    assert executable.is_file()
+    output = run_command(tmp_path, executable, timeout=10)
+    lines = output.splitlines()
+    assert lines[0].startswith("TZPATH")
+    assert lines[1].startswith("Available")
+    assert lines[2].startswith("UTC")
+    assert lines[3].startswith("Brazil")
+    assert lines[4].startswith("US")


### PR DESCRIPTION
Fixes #2515 
Fixes:
- A warning in Python 3.12 conda-forge (https://github.com/marcelotduarte/cx_Freeze/issues/2515#issuecomment-2252180800)
- An error while copying zoneinfo data in macOS
- Always set TZPATH when possible
- Do not set TZPAT in the startup code; instead, it is in the hook code.
