### PR TITLE
freezer: change the order to fix bugs with patchelf

### DIFF
--- a/cx_Freeze/freezer.py
+++ b/cx_Freeze/freezer.py
@@ -1272,6 +1272,7 @@ class LinuxFreezer(Freezer, ELFParser):
         target_dir = target.parent
         lib_files = self.finder.lib_files
         fix_rpath = set()
+        fix_needed = {}
         for dependent in self.get_dependent_files(source):
             if not self._should_copy_file(dependent):
                 continue
@@ -1317,12 +1318,14 @@ class LinuxFreezer(Freezer, ELFParser):
                 dependent_source, dependent_target, copy_dependent_files
             )
             if dependent.name != dependent_name:
-                self.replace_needed(target, dependent.name, dependent_name)
+                fix_needed.setdefault(dependent.name, dependent_name)
         if fix_rpath:
             has_rpath = self.get_rpath(target)
             rpath = ":".join(f"$ORIGIN/{r}" for r in fix_rpath)
             if has_rpath != rpath:
                 self.set_rpath(target, rpath)
+        for needed_old, needed_new in fix_needed.items():
+            self.replace_needed(target, needed_old, needed_new)
 
     def _copy_top_dependency(self, source: Path) -> None:
         """Called for copying the top dependencies in _freeze_executable."""


### PR DESCRIPTION
Fixes #2508 
As far as I can tell, there are some issues with patchelf regarding the order in which modifications are made, so despite using only `--rpath` and `--needed`, the information in two issues helped me find a solution:
https://github.com/NixOS/patchelf/issues/446
https://github.com/NixOS/patchelf/issues/524

When issue 2508 was posted, I could not reproduce it on GHA, but two days ago I had the same error, so I could reproduce it using manylinux Python.
The error can be reproduced with files linked against Python 3.9 and 3.10.