### PR TITLE
bdist_dmg: catch errors when resource is busy

### DIFF
--- a/tests/test_command_bdist_dmg.py
+++ b/tests/test_command_bdist_dmg.py
@@ -32,7 +32,7 @@ def test_bdist_dmg(datafiles: Path) -> None:
         cwd=datafiles,
     )
     if process.returncode != 0:
-        expected_err = "hdiutil: create failed - Resource busy"
+        expected_err = "bdist_dmg: Unable to "
         if expected_err in process.stderr:
             pytest.xfail(expected_err)
         else:
@@ -56,7 +56,7 @@ def test_bdist_dmg_custom_layout(datafiles: Path) -> None:
         cwd=datafiles,
     )
     if process.returncode != 0:
-        expected_err = "hdiutil: create failed - Resource busy"
+        expected_err = "bdist_dmg: Unable to "
         if expected_err in process.stderr:
             pytest.xfail(expected_err)
         else:


### PR DESCRIPTION
And fix the test as #2396 