### PR TITLE
chore: use convenient functions from stdlib that exist since 3.9

### DIFF
--- a/cx_Freeze/command/build_exe.py
+++ b/cx_Freeze/command/build_exe.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import os
 import sys
+from pkgutil import resolve_name
 from typing import ClassVar
 
 from setuptools import Command
@@ -175,8 +176,8 @@ class build_exe(Command):
             script_args.append(f"--compiler={command.compiler}")
         os.chdir(source_dir)
         logging.info("building '%s' extension in '%s'", name, source_dir)
-        distutils_core = __import__("distutils.core", fromlist=["run_setup"])
-        distribution = distutils_core.run_setup("setup.py", script_args)
+        run_setup = resolve_name("distutils.core.run_setup")
+        distribution = run_setup("setup.py", script_args)
         ext_modules = distribution.ext_modules
         modules = [m for m in ext_modules if m.name == module_name]
         if not modules:

--- a/cx_Freeze/command/install.py
+++ b/cx_Freeze/command/install.py
@@ -48,7 +48,8 @@ class Install(_install):
 
     def finalize_options(self) -> None:
         if self.prefix is None and sys.platform == "win32":
-            winreg = __import__("winreg")
+            import winreg
+
             key = winreg.OpenKey(
                 winreg.HKEY_LOCAL_MACHINE,
                 r"Software\Microsoft\Windows\CurrentVersion",

--- a/cx_Freeze/freezer.py
+++ b/cx_Freeze/freezer.py
@@ -13,9 +13,9 @@ import time
 from abc import abstractmethod
 from contextlib import suppress
 from functools import cached_property
-from importlib import import_module
 from importlib.util import MAGIC_NUMBER
 from pathlib import Path
+from pkgutil import resolve_name
 from typing import TYPE_CHECKING, Any
 from zipfile import ZIP_DEFLATED, ZIP_STORED, PyZipFile, ZipFile, ZipInfo
 
@@ -830,8 +830,7 @@ class WinFreezer(Freezer, PEParser):
                 if self.silent < 3:
                     print(warning_msg, "version must be specified")
             else:
-                winversioninfo = import_module("cx_Freeze.winversioninfo")
-                version = winversioninfo.VersionInfo(
+                version = resolve_name("cx_Freeze.winversioninfo:VersionInfo")(
                     self.metadata.version,
                     comments=self.metadata.long_description,
                     description=self.metadata.description,

--- a/cx_Freeze/hooks/_qthooks.py
+++ b/cx_Freeze/hooks/_qthooks.py
@@ -10,6 +10,7 @@ import sys
 from contextlib import suppress
 from functools import cache
 from pathlib import Path
+from pkgutil import resolve_name
 from typing import TYPE_CHECKING
 
 from cx_Freeze._compat import IS_CONDA, IS_MACOS, IS_MINGW, IS_WINDOWS
@@ -28,7 +29,7 @@ def _qt_implementation(module: Module) -> str:
 def _qt_libraryinfo_paths(name: str) -> dict[str, tuple[Path, Path]]:
     """Cache the QtCore library paths."""
     try:
-        qtcore = __import__(name, fromlist=["QtCore"]).QtCore
+        qtcore = resolve_name(f"{name}.QtCore")
     except RuntimeError:
         print("WARNING: Tried to load multiple incompatible Qt ", end="")
         print("wrappers. Some incorrect files may be copied.")

--- a/cx_Freeze/hooks/pyqt5/_append_to_init.py
+++ b/cx_Freeze/hooks/pyqt5/_append_to_init.py
@@ -2,10 +2,11 @@
 
 import sys
 from pathlib import Path
+from pkgutil import resolve_name
 
 
 def _run() -> None:
-    qtcore = __import__("PyQt5", fromlist=["QtCore"]).QtCore
+    qtcore = resolve_name("PyQt5.QtCore")
 
     # With PyQt5 5.15.4, if the folder name contains non-ascii characters, the
     # libraryPaths returns empty. Prior to this version, this doesn't happen.

--- a/cx_Freeze/hooks/pyqt5/debug.py
+++ b/cx_Freeze/hooks/pyqt5/debug.py
@@ -5,6 +5,7 @@ variable QT_DEBUG is set.
 import os
 import sys
 from pathlib import Path
+from pkgutil import resolve_name
 
 
 def _debug() -> None:
@@ -12,7 +13,7 @@ def _debug() -> None:
     if not os.environ.get("QT_DEBUG"):
         return
     # Show QLibraryInfo paths.
-    qtcore = __import__("PyQt5", fromlist=["QtCore"]).QtCore
+    qtcore = resolve_name("PyQt5.QtCore")
     data = {}
     for key, value in qtcore.QLibraryInfo.__dict__.items():
         if isinstance(value, (qtcore.QLibraryInfo.LibraryLocation, int)):

--- a/cx_Freeze/hooks/pyqt6/debug.py
+++ b/cx_Freeze/hooks/pyqt6/debug.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import os
 import sys
 from pathlib import Path
+from pkgutil import resolve_name
 
 
 def _debug() -> None:
@@ -14,7 +15,7 @@ def _debug() -> None:
     if not os.environ.get("QT_DEBUG"):
         return
     # Show QLibraryInfo paths.
-    qtcore = __import__("PyQt6", fromlist=["QtCore"]).QtCore
+    qtcore = resolve_name("PyQt6.QtCore")
     lib = qtcore.QLibraryInfo
     source_paths: dict[str, Path] = {}
     if hasattr(lib.LibraryPath, "__members__"):

--- a/cx_Freeze/hooks/pyside2/debug.py
+++ b/cx_Freeze/hooks/pyside2/debug.py
@@ -5,6 +5,7 @@ variable QT_DEBUG is set.
 import os
 import sys
 from pathlib import Path
+from pkgutil import resolve_name
 
 
 def _debug() -> None:
@@ -12,7 +13,7 @@ def _debug() -> None:
     if not os.environ.get("QT_DEBUG"):
         return
     # Show QLibraryInfo paths.
-    qtcore = __import__("PySide2", fromlist=["QtCore"]).QtCore
+    qtcore = resolve_name("PySide2.QtCore")
     data = {}
     for key, value in qtcore.QLibraryInfo.__dict__.items():
         if isinstance(value, qtcore.QLibraryInfo.LibraryLocation):

--- a/cx_Freeze/hooks/pyside6/debug.py
+++ b/cx_Freeze/hooks/pyside6/debug.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import os
 import sys
 from pathlib import Path
+from pkgutil import resolve_name
 
 
 def _debug() -> None:
@@ -14,7 +15,7 @@ def _debug() -> None:
     if not os.environ.get("QT_DEBUG"):
         return
     # Show QLibraryInfo paths.
-    qtcore = __import__("PySide6", fromlist=["QtCore"]).QtCore
+    qtcore = resolve_name("PySide6.QtCore")
     lib = qtcore.QLibraryInfo
     source_paths: dict[str, Path] = {}
     if hasattr(lib.LibraryPath, "__members__"):

--- a/cx_Freeze/hooks/tkinter.py
+++ b/cx_Freeze/hooks/tkinter.py
@@ -42,8 +42,8 @@ def load_tkinter(finder: ModuleFinder, module: Module) -> None:
     if tcl_library is None:
         # search for the tcl/tk libraries (Windows, MSYS2, conda-forge, etc)
         try:
-            tkinter = __import__(module.name)
-        except (ImportError, AttributeError):
+            tkinter = __import__("tkinter")
+        except ImportError:
             return
         try:
             root = tkinter.Tk(useTk=False)

--- a/cx_Freeze/hooks/zoneinfo.py
+++ b/cx_Freeze/hooks/zoneinfo.py
@@ -5,6 +5,7 @@ zoneinfo package is included.
 from __future__ import annotations
 
 from pathlib import Path
+from pkgutil import resolve_name
 from textwrap import dedent
 from typing import TYPE_CHECKING
 
@@ -30,9 +31,9 @@ def load_zoneinfo(finder: ModuleFinder, module: Module) -> None:
     if target_path is None:
         # without tzdata, copy zoneinfo directory if available
         source_path = None
-        zoneinfo = __import__(module.name, fromlist=["TZPATH"])
-        if zoneinfo.TZPATH:
-            for path in zoneinfo.TZPATH:
+        tzpath = resolve_name("zoneinfo.TZPATH")
+        if tzpath:
+            for path in tzpath:
                 if path.endswith("zoneinfo"):
                     source_path = Path(path).resolve()
                     break


### PR DESCRIPTION
Using resolve_name and str.removesuffix makes the code easier to read.