### PR TITLE
chore: send wheel from pr to testpypi

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,37 @@ jobs:
     name: Build wheels
     uses: ./.github/workflows/build-wheel.yml
 
+  testpypi:
+    name: Publish package to TestPyPI
+    if: github.event_name == 'pull_request'
+    needs:
+      - build_wheel
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ github.event_name }}
+      url: https://test.pypi.org/p/cx-Freeze
+    permissions:
+      id-token: write
+    steps:
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Join files to upload
+        run: |
+          mkdir -p wheelhouse
+          mv artifacts/cx-freeze-whl-*/* wheelhouse/
+
+      - name: Publish package to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: wheelhouse/
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+          verbose: true
+
   tests:
     needs:
       - build_wheel


### PR DESCRIPTION
This is a duplicate code because this information in [Troubleshooting Reusable workflows on GitHub](https://docs.pypi.org/trusted-publishers/troubleshooting/):
 "[Reusable workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows) cannot currently be used as the workflow in a trusted publisher. This is a practical limitation, and is being tracked in [warehouse#11096](https://github.com/pypi/warehouse/issues/11096)."