### PR TITLE
Add definition for _PyMem_RawStrdup when compiling for Python 3.13 and later

### DIFF
--- a/source/legacy/console.c
+++ b/source/legacy/console.c
@@ -63,6 +63,7 @@ int wmain(int argc, wchar_t** argv)
     return status;
 }
 #else
+#if (PY_MAJOR_VERSION == 3) && (PY_MINOR_VERSION > 12)
 static char *
 _PyMem_RawStrdup(const char *str)
 {
@@ -75,6 +76,7 @@ _PyMem_RawStrdup(const char *str)
     memcpy(copy, str, size);
     return copy;
 }
+#endif
 
 int main(int argc, char** argv)
 {

--- a/source/legacy/console.c
+++ b/source/legacy/console.c
@@ -64,12 +64,11 @@ int wmain(int argc, wchar_t** argv)
 }
 #else
 #if (PY_MAJOR_VERSION == 3) && (PY_MINOR_VERSION > 12)
-static char *
-_PyMem_RawStrdup(const char *str)
+static char* _PyMem_RawStrdup(const char* str)
 {
     assert(str != NULL);
     size_t size = strlen(str) + 1;
-    char *copy = PyMem_RawMalloc(size);
+    char* copy = PyMem_RawMalloc(size);
     if (copy == NULL) {
         return NULL;
     }

--- a/source/legacy/console.c
+++ b/source/legacy/console.c
@@ -63,6 +63,19 @@ int wmain(int argc, wchar_t** argv)
     return status;
 }
 #else
+static char *
+_PyMem_RawStrdup(const char *str)
+{
+    assert(str != NULL);
+    size_t size = strlen(str) + 1;
+    char *copy = PyMem_RawMalloc(size);
+    if (copy == NULL) {
+        return NULL;
+    }
+    memcpy(copy, str, size);
+    return copy;
+}
+
 int main(int argc, char** argv)
 {
     int status = 0;


### PR DESCRIPTION
Fixes #2568