### PR TITLE
hooks: support opencv-python 4.10.x (including headless)

### DIFF
--- a/cx_Freeze/hooks/cv2.py
+++ b/cx_Freeze/hooks/cv2.py
@@ -6,13 +6,21 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from textwrap import dedent
 from typing import TYPE_CHECKING
 
-from cx_Freeze._compat import IS_MACOS, IS_MINGW, IS_MINGW64, IS_WINDOWS
+from cx_Freeze._compat import IS_MACOS, IS_MINGW, IS_WINDOWS, PYTHON_VERSION
 
 if TYPE_CHECKING:
     from cx_Freeze.finder import ModuleFinder
     from cx_Freeze.module import Module
+
+WARNING_NUMPY_VERSION = """WARNING:
+
+    {cv2_name} {cv2_version} isn't compatible with numpy {numpy_version}.
+    To fix this issue, the easiest solution will be to
+    downgrade to 'numpy<2' or try to upgrade {cv2_name}.
+"""
 
 
 def load_cv2(finder: ModuleFinder, module: Module) -> None:
@@ -22,23 +30,55 @@ def load_cv2(finder: ModuleFinder, module: Module) -> None:
     Additionally, on Linux the opencv_python.libs directory is not
     copied across for versions above 4.5.3.
     """
-    finder.include_package("numpy")
-    if module.distribution is None:
-        module.update_distribution("opencv-python")
-
     source_dir = module.file.parent
     target_dir = Path("lib", "cv2")
 
-    # conda-forge and msys2: cv2 4.6.0 is a extension module
-    if module.path is None:
-        # msys2 files is on 'share' subdirectory
-        if IS_MINGW:
-            if IS_MINGW64:
-                source = Path(sys.base_prefix, "share/qt6/plugins/platforms")
+    if module.distribution is None:
+        module.update_distribution("opencv-python")
+    if module.distribution is None:
+        module.update_distribution("opencv-python-headless")
+
+    if module.distribution:
+        name = module.distribution.normalized_name
+        version = module.distribution.version
+        if version[:2] < (4, 10):
+            m_numpy = finder.include_package("numpy")
+            if m_numpy.distribution and m_numpy.distribution.version[0] >= 2:
+                msg = WARNING_NUMPY_VERSION.format(
+                    cv2_name=module.distribution.name,
+                    cv2_version=module.distribution.original.version,
+                    numpy_version=m_numpy.distribution.original.version,
+                )
+                print(msg, file=sys.stderr)
+
+        # cv2 4.9.0-4.10.0 conda-forge uses qt6-main
+        if module.distribution.installer == "conda":
+            if version[:2] >= (4, 9):
+                source = Path(sys.base_prefix, "lib/qt6/plugins/platforms")
             else:
-                source = Path(sys.base_prefix, "share/qt5/plugins/platforms")
-        else:
-            source = Path(sys.base_prefix, "plugins/platforms")
+                source = Path(sys.base_prefix, "plugins/platforms")
+            if source.is_dir():
+                finder.include_files(
+                    source, target_dir / "plugins" / "platforms"
+                )
+            source = Path(sys.base_prefix, "fonts")
+            if source.is_dir():
+                finder.include_files(source, target_dir / "fonts")
+            qt_conf: Path = finder.cache_path / "qt.conf"
+            lines = ["[Paths]", f"Prefix = {target_dir.as_posix()}"]
+            with qt_conf.open(mode="w", encoding="utf_8", newline="") as file:
+                file.write("\n".join(lines))
+            finder.include_files(qt_conf, qt_conf.name)
+            if IS_MACOS:
+                finder.include_files(qt_conf, "Contents/Resources/qt.conf")
+    else:
+        name = "opencv_python"
+
+    # msys2: cv2 4.6.0-4.9.0 is a extension module
+    if IS_MINGW:
+        finder.include_package("numpy")
+        # msys2 files is on 'share' subdirectory
+        source = Path(sys.base_prefix, "share/qt6/plugins/platforms")
         if source.is_dir():
             finder.include_files(source, target_dir / "plugins" / "platforms")
         source = Path(sys.base_prefix, "fonts")
@@ -51,24 +91,64 @@ def load_cv2(finder: ModuleFinder, module: Module) -> None:
         with qt_conf.open(mode="w", encoding="utf_8", newline="") as file:
             file.write("\n".join(lines))
         finder.include_files(qt_conf, qt_conf.name)
-        if IS_MACOS:
-            finder.include_files(qt_conf, "Contents/Resources/qt.conf")
+
+    # conda-forge and msys2: cv2 4.6.0-4.9.0 is a extension module
+    if module.path is None:
         return
 
     # Use optimized mode
     module.in_file_system = 2
-    finder.include_package("cv2")
+    finder.exclude_module("cv2.config")
     finder.exclude_module("cv2.config-3")
     finder.exclude_module("cv2.load_config_py2")
     module.exclude_names.add("load_config_py2")
-    # include files config.py (empty) and config-3.py (original)
-    source = finder.cache_path / "cv2-config.py"
-    source.touch()
-    finder.include_files(source, target_dir / "config.py")
-    finder.include_files(
-        source_dir / "config-3.py", target_dir / "config-3.py"
-    )
-    # data files
+    finder.include_package("cv2")
+
+    # Include config files and libraries
+    source_config = finder.cache_path / "cv2-config.py"
+    source_libs = source_dir.parent / f"{name}.libs"
+    if source_libs.exists():
+        # Linux wheels
+        target_libs = f"lib/{source_libs.name}"
+        for source in source_libs.iterdir():
+            finder.lib_files[source] = f"{target_libs}/{source.name}"
+        source_config.write_text(
+            dedent(
+                f"""\
+                import os, sys
+                BINARIES_PATHS = [
+                    os.path.join(sys.frozen_dir, '{target_libs}')
+                ] + BINARIES_PATHS
+                """
+            )
+        )
+    else:
+        source_config.touch()
+
+    # Include config-3 (Linux wheels) or create it for conda-forge
+    finder.include_files(source_config, target_dir / "config.py")
+    source_config = source_dir / "config-3.py"
+    if not source_config.exists():
+        # create config-3 for cv2 4.10.x conda-forge
+        extension_dir = f"python-{PYTHON_VERSION}"
+        finder.include_files(
+            source_dir / extension_dir, target_dir / extension_dir
+        )
+        source_config = finder.cache_path / "cv2-config-3.py"
+        source_config.touch()
+        source_config.write_text(
+            dedent(
+                f"""\
+                import os
+                PYTHON_EXTENSIONS_PATHS = [
+                    os.path.join(LOADER_DIR, '{extension_dir}')
+                ] + PYTHON_EXTENSIONS_PATHS
+                """
+            )
+        )
+    finder.include_files(source_config, target_dir / "config-3.py")
+
+    # Include data files
     data_dir = source_dir / "data"
     if data_dir.exists():
         for path in data_dir.glob("*.xml"):
@@ -86,11 +166,7 @@ def load_cv2(finder: ModuleFinder, module: Module) -> None:
             finder.include_files(libs_dir, target_dir / ".dylibs")
         return
 
-    # Linux and others
-    libs_name = "opencv_python.libs"
-    libs_dir = source_dir.parent / libs_name
-    if libs_dir.exists():
-        finder.include_files(libs_dir, target_dir.parent / libs_name)
+    # Qt files distributed in wheels for Linux
     qt_files = source_dir / "qt"
     if qt_files.exists():
         finder.include_files(qt_files, target_dir / "qt")

--- a/cx_Freeze/hooks/cv2.py
+++ b/cx_Freeze/hooks/cv2.py
@@ -24,7 +24,7 @@ WARNING_NUMPY_VERSION = """WARNING:
 
 
 def load_cv2(finder: ModuleFinder, module: Module) -> None:
-    """Versions of cv2 (opencv-python) above 4.5.3 require additional
+    """Versions of cv2 (opencv-python) above 4.5.3 may require additional
     configuration files.
 
     Additionally, on Linux the opencv_python.libs directory is not
@@ -105,8 +105,14 @@ def load_cv2(finder: ModuleFinder, module: Module) -> None:
     finder.include_package("cv2")
 
     # Include config files and libraries
+    # When opencv_contrib_python or opencv_contrib_python_headless is used
+    # an optimization is possible, because cv2.abi3.so is changed and its
+    # rpath points to it .libs directory
     source_config = finder.cache_path / "cv2-config.py"
-    source_libs = source_dir.parent / f"{name}.libs"
+    contrib = name.replace("opencv_python", "opencv_contrib_python")
+    source_libs = source_dir.parent / f"{contrib}.libs"
+    if not source_libs.exists():
+        source_libs = source_dir.parent / f"{name}.libs"
     if source_libs.exists():
         # Linux wheels
         target_libs = f"lib/{source_libs.name}"

--- a/cx_Freeze/hooks/numpy.py
+++ b/cx_Freeze/hooks/numpy.py
@@ -262,13 +262,17 @@ def load_numpy__distributor_init(finder: ModuleFinder, module: Module) -> None:
                 for file in files:
                     if file.endswith(extensions):
                         continue
-                    source = prefix.joinpath(file).resolve()
+                    source = prefix.joinpath(file)
                     if not source.match("*.so*"):
                         continue
+                    if source.is_symlink():
+                        target = f"lib/{source.name}"
+                        finder.include_files(
+                            source, target, copy_dependent_files=False
+                        )
+                        source = source.resolve()
                     target = f"lib/{source.name}"
-                    finder.include_files(
-                        source, target, copy_dependent_files=False
-                    )
+                    finder.lib_files[source] = target
 
     # do not check dependencies already handled
     if exclude_dependent_files:

--- a/samples/opencv/README.md
+++ b/samples/opencv/README.md
@@ -9,3 +9,9 @@ In a virtual environment, install by issuing the command:
 ```
 pip install --upgrade cx_Freeze opencv-python
 ```
+
+Using conda-forge:
+
+```
+conda install --conda-forge cx_freeze py-opencv
+```

--- a/samples/opencv/test_opencv.py
+++ b/samples/opencv/test_opencv.py
@@ -4,7 +4,7 @@ import os
 import sys
 
 sys.OpenCV_LOADER_DEBUG = True
-import cv2 as cv  # noqa: E402
+import cv2  # noqa: E402
 
 
 def find_data_file(filename) -> str:
@@ -18,10 +18,16 @@ def find_data_file(filename) -> str:
     return os.path.join(datadir, filename)
 
 
-img = cv.imread(find_data_file("image.png"))
+img_file = find_data_file("image.png")
+img_file1 = find_data_file("image1.png")
+img = cv2.imread(img_file)
 if img is None:
     sys.exit("Could not read the image.")
-cv.imshow("Display window", img)
-k = cv.waitKey(15000)
-if k == ord("s"):
-    cv.imwrite("image1.png", img)
+cv2.imwrite(img_file1, img)
+print("OpenCV generated a new png:", img_file1)
+try:
+    cv2.imshow("Display window from cx_Freeze", img)
+    cv2.waitKey(5000)
+    cv2.destroyAllWindows()
+except cv2.error:
+    print("OpenCV headless mode does not implement 'imshow' function")


### PR DESCRIPTION
Fixes #2729 
Tested with:
opencv 4.8.1, 4.9.0 and 4.10.0 in Linux (pip and conda)
opencv 4.10 Windows (pip) and MinGW ucrt
Also, tested with contrib version in Linux