### PR TITLE
chore: enable experimental free-threaded python 3.13 on unix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,12 @@ jobs:
         shell: bash
     env:
       UV_SYSTEM_PYTHON: true
+      UV_NO_PROGRESS: true
     steps:
+
+      - name: Install dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get install -qy alien fakeroot rpm
 
       - uses: actions/checkout@v4
 
@@ -98,10 +103,6 @@ jobs:
           pattern: cx-freeze-whl-${{ matrix.os }}*
           path: wheelhouse
 
-      - name: Install dependencies (Linux)
-        if: runner.os == 'Linux'
-        run: sudo apt-get install -qy alien fakeroot rpm
-
       - name: Install dependencies to test
         run: |
           uv pip install -r requirements.txt -r tests/requirements.txt
@@ -111,6 +112,69 @@ jobs:
         env:
           COVERAGE_FILE: ".coverage.${{ matrix.python-version }}.${{ matrix.os }}"
         run: pytest -nauto --cov="cx_Freeze"
+
+      - name: Upload coverage reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: cov-${{ matrix.python-version }}.${{ matrix.os }}
+          path: .coverage.*
+          include-hidden-files: true
+
+  test_free_threaded:
+    needs:
+      - build_wheel
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-14]
+        python-version: ['3.13t']
+      fail-fast: false
+    defaults:
+      run:
+        shell: bash
+    env:
+      UV_NO_PROGRESS: true
+    steps:
+
+      - name: Install dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get install -qy alien fakeroot rpm
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+          repository: marcelotduarte/cx_Freeze
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            requirements.txt
+            tests/requirements.txt
+          python-version: ${{ matrix.python-version }}
+
+      - name: Env
+        run: env | sort
+
+      - name: Sysconfig
+        run: uv run --no-project -m sysconfig
+
+      - name: Download the wheel
+        uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+          pattern: cx-freeze-whl-${{ matrix.os }}*
+          path: wheelhouse
+
+      - name: Install dependencies to test
+        run: |
+          uv sync --no-install-project --extra tests
+          uv pip install cx_Freeze --no-index --no-deps -f wheelhouse --reinstall
+
+      - name: Generate coverage report
+        env:
+          COVERAGE_FILE: ".coverage.${{ matrix.python-version }}.${{ matrix.os }}"
+        run: uv run --no-project pytest -nauto --cov="cx_Freeze"
 
       - name: Upload coverage reports
         uses: actions/upload-artifact@v4

--- a/cx_Freeze/_compat.py
+++ b/cx_Freeze/_compat.py
@@ -7,6 +7,7 @@ import sysconfig
 from pathlib import Path
 
 __all__ = [
+    "ABI_THREAD",
     "BUILD_EXE_DIR",
     "EXE_SUFFIX",
     "EXT_SUFFIX",
@@ -21,8 +22,9 @@ __all__ = [
 
 PLATFORM = sysconfig.get_platform()
 PYTHON_VERSION = sysconfig.get_python_version()
+ABI_THREAD = sysconfig.get_config_var("abi_thread") or ""
 
-BUILD_EXE_DIR = Path(f"build/exe.{PLATFORM}-{PYTHON_VERSION}")
+BUILD_EXE_DIR = Path(f"build/exe.{PLATFORM}-{PYTHON_VERSION}{ABI_THREAD}")
 EXE_SUFFIX = sysconfig.get_config_var("EXE")
 EXT_SUFFIX = sysconfig.get_config_var("EXT_SUFFIX")
 

--- a/cx_Freeze/executable.py
+++ b/cx_Freeze/executable.py
@@ -11,6 +11,7 @@ from sysconfig import get_config_var
 from typing import TYPE_CHECKING
 
 from cx_Freeze._compat import (
+    ABI_THREAD,
     EXE_SUFFIX,
     IS_MACOS,
     IS_MINGW,
@@ -74,12 +75,17 @@ class Executable:
 
     @base.setter
     def base(self, name: str | Path | None) -> None:
-        # The default base is the legacy console, except for
+        # The default base is the legacy console, except for Python 3.13t and
         # Python 3.13 on macOS, that supports only the new console
-        if IS_MACOS and sys.version_info[:2] >= (3, 13):
-            name = name or "console"
-        else:
+        version = sys.version_info[:2]
+        if (
+            version <= (3, 13)
+            and ABI_THREAD == ""
+            and not (IS_MACOS and version == (3, 13))
+        ):
             name = name or "console_legacy"
+        else:
+            name = name or "console"
         # silently ignore gui and service on non-windows systems
         if not (IS_WINDOWS or IS_MINGW) and name in ("gui", "service"):
             name = "console"

--- a/cx_Freeze/freezer.py
+++ b/cx_Freeze/freezer.py
@@ -22,11 +22,13 @@ from zipfile import ZIP_DEFLATED, ZIP_STORED, PyZipFile, ZipFile, ZipInfo
 from setuptools import Distribution
 
 from cx_Freeze._compat import (
+    ABI_THREAD,
     BUILD_EXE_DIR,
     IS_CONDA,
     IS_MACOS,
     IS_MINGW,
     IS_WINDOWS,
+    PYTHON_VERSION,
 )
 from cx_Freeze.common import get_resource_file_path, process_path_specs
 from cx_Freeze.exception import FileError, OptionError
@@ -1035,9 +1037,10 @@ class WinFreezer(Freezer, PEParser):
             # MSYS2 python returns a static library.
             names = [name.replace(".dll.a", ".dll")]
         else:
+            py_version = f"{PYTHON_VERSION}{ABI_THREAD}"
             names = [
                 f"python{sys.version_info[0]}.dll",
-                f"python{sys.version_info[0]}{sys.version_info[1]}.dll",
+                f"python{py_version.replace('.','')}.dll",
             ]
         python_shared_libs: list[Path] = []
         for name in names:
@@ -1113,7 +1116,7 @@ class DarwinFreezer(Freezer, Parser):
     def _default_bin_includes(self) -> list[str]:
         python_shared_libs: list[Path] = []
         # Check for distributed "cx_Freeze/bases/lib/Python"
-        name = "Python"
+        name = f"Python{ABI_THREAD.upper()}"
         for bin_path in self._default_bin_path_includes():
             fullname = Path(bin_path, name).resolve()
             if fullname.is_file():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 dev = [
-    "bump-my-version==0.29.0",
+    "bump-my-version==0.29.0 ;python_version < '3.13'",
     "cibuildwheel==2.22.0",
     "pre-commit==4.0.1",           # python_version >= 3.9
 ]
@@ -164,9 +164,11 @@ optional_value = "final"
 before-build = "uv pip install -r requirements.txt"
 build-frontend = "build[uv]"
 build-verbosity = 1
+enable = ["cpython-freethreading"]
 skip = [
     "cp3{9,10,13}-musllinux_*",
     "cp3{9,10,13}-manylinux_ppc64le",
+    "cp313t-win*",
 ]
 
 [tool.cibuildwheel.linux]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,3 @@
-bump-my-version==0.29.0
+bump-my-version==0.29.0 ;python_version < '3.13'
 cibuildwheel==2.22.0
 pre-commit==4.0.1

--- a/tests/test_executables.py
+++ b/tests/test_executables.py
@@ -12,6 +12,7 @@ from setuptools import Distribution
 
 from cx_Freeze import Executable
 from cx_Freeze._compat import (
+    ABI_THREAD,
     BUILD_EXE_DIR,
     EXE_SUFFIX,
     IS_MACOS,
@@ -241,14 +242,18 @@ TEST_VALID_PARAMETERS = [
         ("icon.ico", "icon.icns", "icon.png", "icon.svg"),
     ),
 ]
-if IS_MACOS and sys.version_info[:2] >= (3, 13):
-    TEST_VALID_PARAMETERS += [
-        ("base", None, "console-"),
-    ]
-else:
+if (
+    sys.version_info[:2] <= (3, 13)
+    and ABI_THREAD == ""
+    and not (IS_MACOS and sys.version_info[:2] == (3, 13))
+):
     TEST_VALID_PARAMETERS += [
         ("base", None, "console_legacy-"),
         ("base", "console_legacy", "console_legacy-"),
+    ]
+else:
+    TEST_VALID_PARAMETERS += [
+        ("base", None, "console-"),
     ]
 if IS_WINDOWS or IS_MINGW:
     TEST_VALID_PARAMETERS += [

--- a/tests/test_freezer.py
+++ b/tests/test_freezer.py
@@ -12,6 +12,7 @@ from generate_samples import create_package, run_command
 
 from cx_Freeze import Freezer
 from cx_Freeze._compat import (
+    ABI_THREAD,
     BUILD_EXE_DIR,
     EXE_SUFFIX,
     IS_CONDA,
@@ -99,19 +100,20 @@ def test_freezer_default_bin_includes(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.chdir(tmp_path)
 
     freezer = Freezer(executables=["hello.py"])
+    py_version = f"{PYTHON_VERSION}{ABI_THREAD}"
     if IS_MINGW:
-        expected = f"libpython{PYTHON_VERSION}.dll"
+        expected = f"libpython{py_version}.dll"
     elif IS_WINDOWS:
-        expected = f"python{PYTHON_VERSION.replace('.','')}.dll"
+        expected = f"python{py_version.replace('.','')}.dll"
     elif IS_CONDA:  # macOS or Linux
         if IS_MACOS:
-            expected = f"libpython{PYTHON_VERSION}.dylib"
+            expected = f"libpython{py_version}.dylib"
         else:
-            expected = f"libpython{PYTHON_VERSION}.so*"
+            expected = f"libpython{py_version}.so*"
     elif IS_MACOS:
-        expected = "Python"
+        expected = f"Python{ABI_THREAD.upper()}"
     elif ENABLE_SHARED:  # Linux
-        expected = f"libpython{PYTHON_VERSION}.so*"
+        expected = f"libpython{py_version}.so*"
     else:
         assert freezer.default_bin_includes == []
         return


### PR DESCRIPTION
Python 3.13t works on Linux and macOS.
-  wheels are built with manylinux.
- tests run using `uv python 3.13t`

Support for Windows depends on cx_Logging and Lief.

Closes #2568 
Closes #2738 