### PR TITLE
bdist_msi: Add a launch on finish checkbox to the MSI installer

### DIFF
--- a/cx_Freeze/command/bdist_msi.py
+++ b/cx_Freeze/command/bdist_msi.py
@@ -339,7 +339,47 @@ class bdist_msi(Command):
             "Finish",
         )
         dialog.title("Completing the [ProductName] installer")
-        dialog.backbutton("< Back", "Finish", active=False)
+        dialog.checkbox("LaunchOnFinish", 15, 200, 300, 20, 3, "LAUNCHAPP", "Launch the installed app on finish?", "Finish")
+        add_data(
+            self.db,
+            "ControlEvent",
+            # Dialog, Control , Event, Argument, Condition, Ordering
+            [
+                (
+                    "ExitDialog",
+                    "Finish",
+                    "DoAction",
+                    "VSDCA_Launch",
+                    "LAUNCHAPP=1",
+                    0,
+                )
+            ],
+        )
+        add_data(
+            self.db,
+            "CustomAction",
+            # Action, Type, Source, Target
+            [
+                (
+                    "VSDCA_Launch",
+                    226,
+                    "TARGETDIR",
+                    f"[TARGETDIR]\\{self.distribution.executables[0].target_name}",
+                )
+            ],
+        )
+        add_data(
+            self.db,
+            "Property",
+            # Property, Value
+            [
+                (
+                    "LAUNCHAPP",
+                    "1",
+                )
+            ],
+        )
+        dialog.backbutton("< Back", "LaunchOnFinish", active=False)
         dialog.cancelbutton("Cancel", "Back", active=False)
         dialog.text(
             "Description",
@@ -351,7 +391,7 @@ class bdist_msi(Command):
             "Click the Finish button to exit the installer.",
         )
         button = dialog.nextbutton("Finish", "Cancel", name="Finish")
-        button.event("EndDialog", "Return")
+        button.event("EndDialog", "Return", "1", 1)
 
     def add_fatal_error_dialog(self) -> None:
         dialog = PyDialog(

--- a/cx_Freeze/command/bdist_msi.py
+++ b/cx_Freeze/command/bdist_msi.py
@@ -339,7 +339,17 @@ class bdist_msi(Command):
             "Finish",
         )
         dialog.title("Completing the [ProductName] installer")
-        dialog.checkbox("LaunchOnFinish", 15, 200, 300, 20, 3, "LAUNCHAPP", "Launch the installed app on finish?", "Finish")
+        dialog.checkbox(
+            "LaunchOnFinish",
+            15,
+            200,
+            300,
+            20,
+            3,
+            "LAUNCHAPP",
+            "Launch the installed app on finish?",
+            "Finish",
+        )
         add_data(
             self.db,
             "ControlEvent",

--- a/cx_Freeze/command/bdist_msi.py
+++ b/cx_Freeze/command/bdist_msi.py
@@ -339,6 +339,19 @@ class bdist_msi(Command):
             "Finish",
         )
         dialog.title("Completing the [ProductName] installer")
+        add_data(
+            self.db,
+            "ControlCondition",
+            # Dialog, Control , Action, Condition
+            [
+                (
+                    "ExitDialog",
+                    "LaunchOnFinish",
+                    "Hide",
+                    'MaintenanceForm_Action="Remove"',
+                )
+            ],
+        )
         dialog.checkbox(
             "LaunchOnFinish",
             15,


### PR DESCRIPTION
As the title says, this adds a launch on finish checkbox to the msi installer.

<details>
<summary>Old finish screen</summary>

![image](https://github.com/user-attachments/assets/9fa88dc8-6e2e-4fd9-b172-82fbf30d505b)

</details>

<details>
<summary>New finish screen</summary>

![image](https://github.com/user-attachments/assets/64f2491d-09c5-4eab-a6d5-7b84fca6f4d7)

</details>

This is an amazing library, and having this checkbox is basically the only thing I'd say is missing.

I am aware my implementation is probably very bad/could be improved a lot (both visually and code wise), this is my first time doing anything with MSIs and the code is mostly a port of [this SO answer](https://stackoverflow.com/a/1681410).

I am also aware it's a bit silly updating the MSI installer since `msilib` is removed in 3.13, but since it's the only option available in windows I figured I might as well improve it.

On the discussion in #2837, I don't care if it's MSI or AppX, I just want something that works.