### PR TITLE
bdist_mac: Update include_frameworks copy to preserve symlinks

### DIFF
--- a/cx_Freeze/command/bdist_mac.py
+++ b/cx_Freeze/command/bdist_mac.py
@@ -366,6 +366,8 @@ class bdist_mac(Command):
             self.copy_tree(
                 framework,
                 os.path.join(self.frameworks_dir, os.path.basename(framework)),
+                preserve_mode=True,
+                preserve_symlinks=True,
             )
 
         # Copy in Resources


### PR DESCRIPTION
Currently when using the `include_frameworks` option to bundle Frameworks in app bundles, symlinks are not preserved. So codesigning will fail with a `bundle format is ambiguous (could be app or framework)` error.

According to Apple's [documentation](https://developer.apple.com/library/archive/technotes/tn2206/_index.html#//apple_ref/doc/uid/DTS40007919-CH1-TNTAG314) symlinks in frameworks for the directory structure need to remain intact.

> codesign says my bundle format is ambiguous.
> codesign thinks your bundle looks a bit like an app and a bit like a framework.
> Perhaps you have both Contents and Versions directories, or files in the top directory that match reserved names for directories in a bundle.
> Perhaps there's an Info.plist in an odd place.
> Perhaps a framework was copied incorrectly so the symlinks it contained were converted to normal files.
> In short, put everything in the correct places.

This PR adds in maintaining the directory structure and the file modes when copying Frameworks into app bundles so codesign will successfully sign the app