### PR TITLE
freezer: Fix errors with invalid file dates in zipfile

### DIFF
--- a/cx_Freeze/freezer.py
+++ b/cx_Freeze/freezer.py
@@ -724,7 +724,7 @@ class Freezer:
                 # otherwise, write to the zip file
                 elif module.code is not None:
                     zip_time = time.localtime(mtime)[:6]
-                    if zip_time[0] < 1980: 
+                    if zip_time[0] < 1980:
                         zip_time = (1980, 1, 1, 0, 0, 0)
                     target_name = "/".join(mod_name_parts)
                     if module.path:

--- a/cx_Freeze/freezer.py
+++ b/cx_Freeze/freezer.py
@@ -724,6 +724,8 @@ class Freezer:
                 # otherwise, write to the zip file
                 elif module.code is not None:
                     zip_time = time.localtime(mtime)[:6]
+                    if zip_time[0] < 1980: 
+                        zip_time = (1980, 1, 1, 0, 0, 0)
                     target_name = "/".join(mod_name_parts)
                     if module.path:
                         target_name += "/__init__"


### PR DESCRIPTION
This patch checks if a file's date is invalid (before 1980), and modifies the date-time to avoid errors when building. 