### PR TITLE
tests: implement a venv to tests hooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ cov:
 	cp -a samples/ $(COV_TMPDIR)/
 	cp -a tests/ $(COV_TMPDIR)/
 	cp -a wheelhouse/ $(COV_TMPDIR)/
-	cd $(COV_TMPDIR) && pytest -nauto --cov="cx_Freeze" || true
+	cd $(COV_TMPDIR) && pytest --durations=20 -nauto --cov="cx_Freeze" || true
 	coverage combine -a $(COV_TMPDIR)/.coverage
 	coverage report
 	coverage html

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,7 @@ tests:
 	cp pyproject.toml $(COV_TMPDIR)/
 	cp -a samples/ $(COV_TMPDIR)/
 	cp -a tests/ $(COV_TMPDIR)/
+	cp -a wheelhouse/ $(COV_TMPDIR)/
 	cd $(COV_TMPDIR) && pytest -nauto --no-cov -v || true
 
 .PHONY: cov
@@ -82,6 +83,7 @@ cov:
 	cp pyproject.toml $(COV_TMPDIR)/
 	cp -a samples/ $(COV_TMPDIR)/
 	cp -a tests/ $(COV_TMPDIR)/
+	cp -a wheelhouse/ $(COV_TMPDIR)/
 	cd $(COV_TMPDIR) && pytest -nauto --cov="cx_Freeze" || true
 	coverage combine -a $(COV_TMPDIR)/.coverage
 	coverage report

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -237,11 +237,10 @@ class TempPackage:
         output = self.run("uv pip list --format=json -q")
         packages = json.loads(output)
         # create venv
+        cmd = f"uv venv --python={PYTHON_VERSION}{ABI_THREAD}"
         venv_prefix = self.path / ".venv"
         pyproject = self.system_path.joinpath("pyproject.toml")
-        if pyproject.is_file():
-            self.run(f"uv venv --python={PYTHON_VERSION}")
-        else:
+        if not pyproject.is_file():
             # use a venv clone
             if sys.prefix != sys.base_prefix:
                 copytree(
@@ -250,7 +249,8 @@ class TempPackage:
                     symlinks=True,
                     ignore=ignore_patterns(".lock"),
                 )
-            self.run(f"uv venv --python={PYTHON_VERSION} --allow-existing")
+            cmd += " --allow-existing"
+        self.run(cmd)
         # point to the new environment
         self.sys_executable = (
             venv_prefix / self.relative_bin / self.sys_executable.name

--- a/tests/hooks/test_async.py
+++ b/tests/hooks/test_async.py
@@ -46,6 +46,7 @@ pyproject.toml
 """
 
 
+@pytest.mark.venv
 @zip_packages
 def test_anyio(tmp_package, zip_packages) -> None:
     """Test if anyio is working correctly."""

--- a/tests/hooks/test_av.py
+++ b/tests/hooks/test_av.py
@@ -63,6 +63,7 @@ pyproject.toml
     reason="av (pyAV) does not support Python 3.13t",
     strict=True,
 )
+@pytest.mark.venv
 @zip_packages
 def test_av(tmp_package, zip_packages: bool) -> None:
     """Test if av hook is working correctly."""

--- a/tests/hooks/test_crypto.py
+++ b/tests/hooks/test_crypto.py
@@ -47,6 +47,7 @@ pyproject.toml
     reason="argon2-cffi does not support Python 3.13t",
     strict=True,
 )
+@pytest.mark.venv
 @zip_packages
 def test_argon2(tmp_package, zip_packages) -> None:
     """Test if argon2-cffi is working correctly."""
@@ -94,6 +95,7 @@ pyproject.toml
     reason="bcrypt not supported in windows arm64",
     strict=True,
 )
+@pytest.mark.venv
 @zip_packages
 def test_bcrypt(tmp_package, zip_packages) -> None:
     """Test if bcrypt is working correctly."""
@@ -144,6 +146,7 @@ pyproject.toml
 """
 
 
+@pytest.mark.venv
 @zip_packages
 def test_crypto(tmp_package, zip_packages) -> None:
     """Test if pycryptodome is working correctly."""
@@ -198,6 +201,7 @@ pyproject.toml
     reason="cryptography does not support Python 3.13t",
     strict=True,
 )
+@pytest.mark.venv
 @zip_packages
 def test_cryptography(tmp_package, zip_packages) -> None:
     """Test if cryptography is working correctly."""

--- a/tests/hooks/test_numpy.py
+++ b/tests/hooks/test_numpy.py
@@ -57,6 +57,7 @@ pyproject.toml
     reason="matplotlib not supported in windows arm64",
     strict=True,
 )
+@pytest.mark.venv
 @zip_packages
 def test_matplotlib(tmp_package, zip_packages: bool) -> None:
     """Test if matplotlib hook is working correctly."""
@@ -94,6 +95,7 @@ def test_matplotlib(tmp_package, zip_packages: bool) -> None:
     reason="pandas not supported in windows arm64",
     strict=True,
 )
+@pytest.mark.venv
 @zip_packages
 def test_pandas(tmp_package, zip_packages: bool) -> None:
     """Test that the pandas/numpy is working correctly."""
@@ -160,6 +162,7 @@ pyproject.toml
     reason="rasterio does not support Python 3.13t",
     strict=True,
 )
+@pytest.mark.venv
 @zip_packages
 def test_rasterio(tmp_package, zip_packages: bool) -> None:
     """Test if rasterio hook is working correctly."""
@@ -186,6 +189,7 @@ def test_rasterio(tmp_package, zip_packages: bool) -> None:
     reason="pandas not supported in windows arm64",
     strict=True,
 )
+@pytest.mark.venv
 @zip_packages
 def test_scipy(tmp_package, zip_packages: bool) -> None:
     """Test that the scipy/numpy is working correctly."""
@@ -275,6 +279,7 @@ pyproject.toml
     reason="shapely not supported in windows arm64",
     strict=True,
 )
+@pytest.mark.venv
 @zip_packages
 def test_shapely(tmp_package, zip_packages: bool) -> None:
     """Test if shapely hook is working correctly."""
@@ -372,6 +377,7 @@ pyproject.toml
     reason="vtkmodules (vtk) does not support Python 3.13t",
     strict=True,
 )
+@pytest.mark.venv
 @zip_packages
 def test_vtk(tmp_package, zip_packages: bool) -> None:
     """Test if vtkmodules hook is working correctly."""

--- a/tests/hooks/test_pillow.py
+++ b/tests/hooks/test_pillow.py
@@ -11,6 +11,7 @@ zip_packages = pytest.mark.parametrize(
 )
 
 
+@pytest.mark.venv
 @zip_packages
 def test_pillow(tmp_package, zip_packages: bool) -> None:
     """Test if pillow hook is working correctly."""

--- a/tests/hooks/test_pyarrow.py
+++ b/tests/hooks/test_pyarrow.py
@@ -48,6 +48,7 @@ pyproject.toml
     reason="pyarrow not supported in windows arm64",
     strict=True,
 )
+@pytest.mark.venv
 @zip_packages
 def test_pyarrow(tmp_package, zip_packages: bool) -> None:
     """Test if pyarrow hook is working correctly."""

--- a/tests/hooks/test_pymupdf.py
+++ b/tests/hooks/test_pymupdf.py
@@ -58,6 +58,7 @@ pyproject.toml
     reason="pymupdf does not support Python 3.13t",
     strict=True,
 )
+@pytest.mark.venv
 @zip_packages
 def test_pymupdf(tmp_package, zip_packages: bool) -> None:
     """Test if pymupdf hook is working correctly."""

--- a/tests/hooks/test_pytz.py
+++ b/tests/hooks/test_pytz.py
@@ -9,6 +9,7 @@ zip_packages = pytest.mark.parametrize(
 )
 
 
+@pytest.mark.venv
 @zip_packages
 def test_pytz(tmp_package, zip_packages: bool) -> None:
     """Test if pytz hook is working correctly."""

--- a/tests/hooks/test_win32com.py
+++ b/tests/hooks/test_win32com.py
@@ -14,6 +14,7 @@ zip_packages = pytest.mark.parametrize(
 )
 
 
+@pytest.mark.venv
 @zip_packages
 def test_win32com(tmp_package, zip_packages: bool) -> None:
     """Test that the win32com is working correctly."""
@@ -60,6 +61,7 @@ pyproject.toml
 """
 
 
+@pytest.mark.venv
 @zip_packages
 def test_win32com_shell(tmp_package, zip_packages: bool) -> None:
     """Test if zoneinfo hook is working correctly."""

--- a/tests/hooks/test_zeroconf.py
+++ b/tests/hooks/test_zeroconf.py
@@ -47,6 +47,7 @@ pyproject.toml
     reason="zeroconf does not support Python 3.13t",
     strict=True,
 )
+@pytest.mark.venv
 @zip_packages
 def test_zeroconf(tmp_package, zip_packages: bool) -> None:
     """Test if zeroconf hook is working correctly."""


### PR DESCRIPTION
In tests using pip, the gain in time reduction was just over 20% and disk usage remained the same, 5.7GB.
Using conda, the gain in time was huge, over 70%, and disk usage dropped from 28GB to 11GB.
Even so, using conda is 5x slower and uses almost 2x the disk than using pip (uv pip).