### PR TITLE
startup: Fixed crash when sys.path contains non-str type

### DIFF
--- a/cx_Freeze/initscripts/__startup__.py
+++ b/cx_Freeze/initscripts/__startup__.py
@@ -42,6 +42,8 @@ class ExtensionFinder(PathFinder):
             return None
         suffixes = EXTENSION_SUFFIXES
         for entry in sys.path:
+            if type(empty) is not str:
+                continue
             if ".zip" in entry:
                 continue
             for ext in suffixes:

--- a/cx_Freeze/initscripts/__startup__.py
+++ b/cx_Freeze/initscripts/__startup__.py
@@ -42,7 +42,7 @@ class ExtensionFinder(PathFinder):
             return None
         suffixes = EXTENSION_SUFFIXES
         for entry in sys.path:
-            if type(empty) is not str:
+            if not isinstance(entry, str):
                 continue
             if ".zip" in entry:
                 continue


### PR DESCRIPTION
Some code will add non-str types (such as pathlib.Path) to sys.path, which should be ignored at this time according to the official python documentation.But in cx_Freeze this causes a crash, so we need to skip the non-str type.

A program is free to modify this list for its own purposes. Only strings should be added to [sys.path](https://docs.python.org/3.13/library/sys.html#sys.path); **all other data types are ignored during import**.