### PR TITLE
finder: detect editable packages (Python 3.10+ only)

### DIFF
--- a/cx_Freeze/finder.py
+++ b/cx_Freeze/finder.py
@@ -393,9 +393,7 @@ class ModuleFinder:
                 ):
                     try:
                         mod = importlib.import_module(f.stem)
-                        spec = mod._EditableFinder.find_spec(
-                            name, path
-                        )  # noqa SLF001
+                        spec = mod._EditableFinder.find_spec(name, path)
                         if spec:
                             return spec
                     except (ImportError, AttributeError) as e:

--- a/cx_Freeze/finder.py
+++ b/cx_Freeze/finder.py
@@ -369,6 +369,40 @@ class ModuleFinder:
             return None
         return module
 
+    @staticmethod
+    def _find_editable_spec(
+        name: str, path: Sequence[str] | None
+    ) -> importlib.machinery.ModuleSpec | None:
+        """Find the spec for a module installed as an editable package."""
+        if hasattr(importlib.metadata, "packages_distributions"):
+            # the distribution name may vary from the module name (eg may include '-').
+            # packages_distributions returns the mapping but is only available on 3.10+
+            dist_names = importlib.metadata.packages_distributions().get(
+                name, []
+            )
+        else:
+            dist_names = [name]
+
+        for dist_name in dist_names:
+            dist = importlib.metadata.distribution(dist_name)
+            if not dist:
+                continue
+            for f in dist.files:
+                if f.name.startswith("__editable__") and f.name.endswith(
+                    "_finder.py"
+                ):
+                    try:
+                        mod = importlib.import_module(f.stem)
+                        spec = mod._EditableFinder.find_spec(name, path)
+                        if spec:
+                            return spec
+                    except (ImportError, AttributeError) as e:
+                        logger.warning(
+                            "Find editable spec failed for [%s]: %s", name, e
+                        )
+                        break
+        return None
+
     def _load_module(
         self,
         name: str,
@@ -401,6 +435,9 @@ class ModuleFinder:
                     self.modules.remove(module)
                 module.in_import = False
                 return module
+
+        if not spec:
+            spec = ModuleFinder._find_editable_spec(name, path)
 
         if spec:
             loader = spec.loader

--- a/cx_Freeze/finder.py
+++ b/cx_Freeze/finder.py
@@ -393,7 +393,9 @@ class ModuleFinder:
                 ):
                     try:
                         mod = importlib.import_module(f.stem)
-                        spec = mod._EditableFinder.find_spec(name, path)
+                        spec = mod._EditableFinder.find_spec(  # noqa: SLF001
+                            name, path
+                        )
                         if spec:
                             return spec
                     except (ImportError, AttributeError) as e:

--- a/cx_Freeze/finder.py
+++ b/cx_Freeze/finder.py
@@ -393,7 +393,9 @@ class ModuleFinder:
                 ):
                     try:
                         mod = importlib.import_module(f.stem)
-                        spec = mod._EditableFinder.find_spec(name, path)
+                        spec = mod._EditableFinder.find_spec(
+                            name, path
+                        )  # noqa SLF001
                         if spec:
                             return spec
                     except (ImportError, AttributeError) as e:

--- a/tests/datatest.py
+++ b/tests/datatest.py
@@ -445,3 +445,21 @@ setup.py
     )
 """,
 ]
+
+EDITABLE_PACKAGE_TEST = [
+    "main",
+    ["foobar", "foobar.baz", "main"],
+    [],
+    [],
+    """\
+main.py
+    import foobar.baz
+foo-bar/setup.py
+    from distutils.core import setup
+    setup(name="foo-bar", version="0.0.1", packages=["foobar"])
+foo-bar/foobar/__init__.py
+    print('This is foobar')
+foo-bar/foobar/baz.py
+    print('This is foobar.baz')
+""",
+]

--- a/tests/test_modulefinder.py
+++ b/tests/test_modulefinder.py
@@ -12,7 +12,6 @@ import pytest
 from cx_Freeze import ConstantsModule, ModuleFinder
 
 from .conftest import HAVE_UV
-
 from .datatest import (
     ABSOLUTE_IMPORT_TEST,
     BYTECODE_TEST,
@@ -169,9 +168,7 @@ def test_zip_exclude_packages(tmp_package) -> None:
 def test_editable_packages(tmp_package) -> None:
     """Provides test cases for ModuleFinder class."""
     tmp_package.create(EDITABLE_PACKAGE_TEST[4])
-    tmp_package._install_uv(
-        ["-e", f"{tmp_package.path}/foo-bar"]
-    )  # noqa SLF001
+    tmp_package._install_uv(["-e", f"{tmp_package.path}/foo-bar"])
     _do_test(
         tmp_package,
         *EDITABLE_PACKAGE_TEST,

--- a/tests/test_modulefinder.py
+++ b/tests/test_modulefinder.py
@@ -163,7 +163,8 @@ def test_zip_exclude_packages(tmp_package) -> None:
 
 
 @pytest.mark.skipif(
-    not HAVE_UV, reason="uv needed to install editable package"
+    not HAVE_UV or sys.version_info < (3, 10),
+    reason="uv and 3.10+ are needed for editable packages",
 )
 def test_editable_packages(tmp_package) -> None:
     """Provides test cases for ModuleFinder class."""

--- a/tests/test_modulefinder.py
+++ b/tests/test_modulefinder.py
@@ -11,12 +11,15 @@ import pytest
 
 from cx_Freeze import ConstantsModule, ModuleFinder
 
+from .conftest import HAVE_UV
+
 from .datatest import (
     ABSOLUTE_IMPORT_TEST,
     BYTECODE_TEST,
     CODING_DEFAULT_UTF8_TEST,
     CODING_EXPLICIT_CP1252_TEST,
     CODING_EXPLICIT_UTF8_TEST,
+    EDITABLE_PACKAGE_TEST,
     EXTENDED_OPARGS_TEST,
     IMPORT_CALL_TEST,
     MAYBE_TEST,
@@ -157,4 +160,19 @@ def test_zip_exclude_packages(tmp_package) -> None:
         zip_exclude_packages=["p"],
         zip_include_packages=["*"],
         zip_include_all_packages=True,
+    )
+
+
+@pytest.mark.skipif(
+    not HAVE_UV, reason="uv needed to install editable package"
+)
+def test_editable_packages(tmp_package) -> None:
+    """Provides test cases for ModuleFinder class."""
+    tmp_package.create(EDITABLE_PACKAGE_TEST[4])
+    tmp_package._install_uv(
+        ["-e", f"{tmp_package.path}/foo-bar"]
+    )  # noqa SLF001
+    _do_test(
+        tmp_package,
+        *EDITABLE_PACKAGE_TEST,
     )

--- a/tests/test_modulefinder.py
+++ b/tests/test_modulefinder.py
@@ -168,7 +168,9 @@ def test_zip_exclude_packages(tmp_package) -> None:
 def test_editable_packages(tmp_package) -> None:
     """Provides test cases for ModuleFinder class."""
     tmp_package.create(EDITABLE_PACKAGE_TEST[4])
-    tmp_package._install_uv(["-e", f"{tmp_package.path}/foo-bar"])
+    tmp_package._install_uv(  # noqa: SLF001
+        ["-e", f"{tmp_package.path}/foo-bar"]
+    )
     _do_test(
         tmp_package,
         *EDITABLE_PACKAGE_TEST,


### PR DESCRIPTION
Currently if a package is installed from a local path in editable mode it is not found by cx-freeze and exits with an ImportError no module named "foo" message. 

When a package is installed in editable mode it creates a module in the site-packages folder `__editable__<dist_name>_<version>_finder.py` that contains an implementation of [MetaPathFinder](https://docs.python.org/3/library/importlib.html#importlib.abc.MetaPathFinder) named `_EditableFinder` (at least on 3.10+).

This PR makes cx-freeze's finder try to use that to lookup the ModuleSpec when the normal PathFinder doesn't find a module.

I've tested this locally in a project using several editable packages (that include submodules) and it is working well.. but am not sure where to add a test in cx-freeze (or if this feature is wanted).