### PR TITLE
chore: use sphinx-issues

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,5 @@
 sphinx==8.2.3 ;python_version >= '3.11'
+sphinx-issues==5.0.1 ;python_version >= '3.11'
 sphinx-new-tab-link==0.8.0 ;python_version >= '3.11'
 sphinx-tabs==3.4.7 ;python_version >= '3.11'
 furo==2024.8.6 ;python_version >= '3.11'

--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -25,6 +25,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.viewcode",
     "sphinx.ext.extlinks",
+    "sphinx_issues",
     "sphinx_new_tab_link",
     "sphinx_tabs.tabs",
     "myst_parser",
@@ -235,24 +236,22 @@ man_pages = [
     )
 ]
 
+# -- Options for sphinx extensions --------------------------------------------
+
 # sphinx.ext.extlinks
 extlinks = {
     # github
     "repository": ("https://github.com/marcelotduarte/cx_Freeze/%s", "%s"),
-    "issue": (
-        "https://github.com/marcelotduarte/cx_Freeze/issues/%s",
-        "Issue #%s",
-    ),
-    "pull": ("https://github.com/marcelotduarte/cx_Freeze/pull/%s", "#%s"),
-    "user": ("https://github.com/%s", "@%s"),
-    # python
     "packaging": ("https://packaging.python.org/%s", "%s"),
-    "pypi": ("https://pypi.org/project/%s", "%s"),
     "pythondocs": ("https://docs.python.org/3/%s", "%s"),
     "setuptools": ("https://setuptools.pypa.io/en/latest/%s", "%s"),
 }
 
+# sphinx_issues
+issues_github_path = "marcelotduarte/cx_Freeze"
+
 # sphinx_tabs.tabs
 sphinx_tabs_disable_tab_closing = True
+
 # sphinx-new-tab-link
 new_tab_link_show_external_link_icon = True

--- a/doc/src/releasenotes-5x.rst
+++ b/doc/src/releasenotes-5x.rst
@@ -18,25 +18,25 @@ Version 5.1 (November 2017)
 ---------------------------
 
 #)  Use fixed library location on all platforms; should correct the error
-    "no module named __startup__" (:pull:`286`).
-#)  Correct sqlite3 hook for use in Python 2.7 (:pull:`272`).
-#)  Correct usage of scipy.lib (:pull:`281`).
-#)  Correct handling of __path__ attribute in module (:pull:`295`).
-#)  Fix gevent bug #42 (:pull:`301`).
+    "no module named __startup__" (:pr:`286`).
+#)  Correct sqlite3 hook for use in Python 2.7 (:pr:`272`).
+#)  Correct usage of scipy.lib (:pr:`281`).
+#)  Correct handling of __path__ attribute in module (:pr:`295`).
+#)  Fix gevent bug #42 (:pr:`301`).
 #)  Dropped support for Python 3.4.
 
 
 Version 5.0.2 (May 2017)
 ------------------------
 
-#) Correct handling of import in child thread (:pull:`245`)
+#) Correct handling of import in child thread (:pr:`245`)
 #) Correct handling of "dis" module with Python 3.5.1 (:issue:`225`)
 #) Correct handling of "multiprocess.process" module (:issue:`230`)
-#) Correct attempt to assign variable to an empty list (:pull:`260`)
-#) Improved README (:pull:`235`, :pull:`236`)
-#) Add hook for pythonnet package (:pull:`251`)
-#) Add hook for sqlite3 and improve win32file hook (:pull:`261`)
-#) Add FAQ entry (:pull:`267`)
+#) Correct attempt to assign variable to an empty list (:pr:`260`)
+#) Improved README (:pr:`235`, :pr:`236`)
+#) Add hook for pythonnet package (:pr:`251`)
+#) Add hook for sqlite3 and improve win32file hook (:pr:`261`)
+#) Add FAQ entry (:pr:`267`)
 
 
 Version 5.0.1 (January 2017)

--- a/doc/src/releasenotes-6x.rst
+++ b/doc/src/releasenotes-6x.rst
@@ -5,380 +5,380 @@ Version 6.15 (May 2023)
 -----------------------
 
 #)  Breaking changes:
-	- chore: remove the latest camelCase in Executable api (:pull:`1809`)
-	- chore: use utf-8 encoding with read_text (:pull:`1817`)
-	- chore: map internal exception classes to setuptools (:pull:`1866`)
+	- chore: remove the latest camelCase in Executable api (:pr:`1809`)
+	- chore: use utf-8 encoding with read_text (:pr:`1817`)
+	- chore: map internal exception classes to setuptools (:pr:`1866`)
 
 #)  New or improved hooks for:
-	- hooks: split more hooks in a separate module (:pull:`1790`)
-	- hooks: add support for matplotlib 3.7 (:pull:`1791`)
-	- hooks: improved hook for pytorch (:pull:`1804`)
-	- fix: add tcl8 directory to bases and fix tkinter hooks (:pull:`1812`)
-	- hooks: improved hook for matplotlib 3.7 work with bdist_msi (:pull:`1815`)
-	- fix: matplotlib hooks (:pull:`1818`, :pull:`1819`)
-	- hooks: pyside6/pyqt6 - fix svg and pdf, docs, modules (:pull:`1827`)
-	- hooks: pyside6 - check for conda (:pull:`1828`)
-	- hooks: include a qt.conf for pyqt6-webengine to work (:pull:`1829`)
-	- hooks: include a qt.conf for pyside2-webengine to work (:pull:`1832`)
-	- hooks: add new qt plugins based on the docs (:pull:`1835`)
-	- hooks: add pyimagej and jpype (:pull:`1842`)
-	- hooks: add librosa and lazy_loader hooks (:pull:`1856`)
-	- hooks: numpy can be used in conda-forge without mkl [windows] (:pull:`1867`)
-	- hooks: add pyreadstat (:pull:`1883`)
+	- hooks: split more hooks in a separate module (:pr:`1790`)
+	- hooks: add support for matplotlib 3.7 (:pr:`1791`)
+	- hooks: improved hook for pytorch (:pr:`1804`)
+	- fix: add tcl8 directory to bases and fix tkinter hooks (:pr:`1812`)
+	- hooks: improved hook for matplotlib 3.7 work with bdist_msi (:pr:`1815`)
+	- fix: matplotlib hooks (:pr:`1818`, :pr:`1819`)
+	- hooks: pyside6/pyqt6 - fix svg and pdf, docs, modules (:pr:`1827`)
+	- hooks: pyside6 - check for conda (:pr:`1828`)
+	- hooks: include a qt.conf for pyqt6-webengine to work (:pr:`1829`)
+	- hooks: include a qt.conf for pyside2-webengine to work (:pr:`1832`)
+	- hooks: add new qt plugins based on the docs (:pr:`1835`)
+	- hooks: add pyimagej and jpype (:pr:`1842`)
+	- hooks: add librosa and lazy_loader hooks (:pr:`1856`)
+	- hooks: numpy can be used in conda-forge without mkl [windows] (:pr:`1867`)
+	- hooks: add pyreadstat (:pr:`1883`)
 
 #)  Linux:
-	- fix: use latest manylinux release to fix tkinter in Python 3.11 (:pull:`1830`)
-	- fix: setuptools is unbundled on Gentoo (:pull:`1864`)
+	- fix: use latest manylinux release to fix tkinter in Python 3.11 (:pr:`1830`)
+	- fix: setuptools is unbundled on Gentoo (:pr:`1864`)
 
 #)  Windows:
-	- windows: fix file version with four elements (:pull:`1772`)
-	- windows: fix error using CX_FREEZE_STAMP=pywin32 (:pull:`1773`)
-	- windows: put all msvcr dlls in build_exe top directory (:pull:`1780`)
-	- fix: copy all top dependencies [windows,conda] (:pull:`1799`)
-	- fix: copy all top dependencies [mingw] (:pull:`1859`)
+	- windows: fix file version with four elements (:pr:`1772`)
+	- windows: fix error using CX_FREEZE_STAMP=pywin32 (:pr:`1773`)
+	- windows: put all msvcr dlls in build_exe top directory (:pr:`1780`)
+	- fix: copy all top dependencies [windows,conda] (:pr:`1799`)
+	- fix: copy all top dependencies [mingw] (:pr:`1859`)
 
 #)  Documentation:
-	- docs: improve options documentation and fix typos (:pull:`1805`)
+	- docs: improve options documentation and fix typos (:pr:`1805`)
 
 #)  Improvements/Refactor/Bugfix:
-	- Revert "commands: accepts space-delimited string lists" (:pull:`1768`)
-	- freezer: fix importerror when using 'path' option (:pull:`1785`)
-	- Check that parent directory exists before writing to file (:pull:`1793`)
-	- fix: parse namespace packages as packages in zip options (:pull:`1820`)
-	- fix: restore build-exe option of build command (now deprecated) (:pull:`1823`)
-	- Fix code for year 2038 (:pull:`1860`)
-	- fix: ignore recursion into .git subdirectories (:pull:`1884`)
+	- Revert "commands: accepts space-delimited string lists" (:pr:`1768`)
+	- freezer: fix importerror when using 'path' option (:pr:`1785`)
+	- Check that parent directory exists before writing to file (:pr:`1793`)
+	- fix: parse namespace packages as packages in zip options (:pr:`1820`)
+	- fix: restore build-exe option of build command (now deprecated) (:pr:`1823`)
+	- Fix code for year 2038 (:pr:`1860`)
+	- fix: ignore recursion into .git subdirectories (:pr:`1884`)
 
 #)  Project:
-	- Declare support for setuptools 67.x (:pull:`1782`)
-	- Use CodeQL tools for scanning (:pull:`1766`)
-	- Use bump2version tag_name (:pull:`1769`)
-	- Upgrade pre-commit tools (:pull:`1774`)
-	- freezer: pylint ready (:pull:`1781`)
-	- dependabot: add package-ecosystem for pip (:pull:`1792`)
-	- chore: use ruff (:pull:`1798`, :pull:`1800`, :pull:`1801`, :pull:`1802`, :pull:`1803`, :pull:`1836`)
-	- chore: change Makefile to call pylint separated of others tools (:pull:`1807`)
-	- chore: update python dependencies (:pull:`1808`, :pull:`1822`)
-	- chore: add python version to dependabot (:pull:`1810`)
-	- chore: use code_object_replace_function if possible (:pull:`1816`)
-	- chore: normalize filename and use map (:pull:`1839`)
-	- chore: Generate coverage report (:pull:`1843`)
+	- Declare support for setuptools 67.x (:pr:`1782`)
+	- Use CodeQL tools for scanning (:pr:`1766`)
+	- Use bump2version tag_name (:pr:`1769`)
+	- Upgrade pre-commit tools (:pr:`1774`)
+	- freezer: pylint ready (:pr:`1781`)
+	- dependabot: add package-ecosystem for pip (:pr:`1792`)
+	- chore: use ruff (:pr:`1798`, :pr:`1800`, :pr:`1801`, :pr:`1802`, :pr:`1803`, :pr:`1836`)
+	- chore: change Makefile to call pylint separated of others tools (:pr:`1807`)
+	- chore: update python dependencies (:pr:`1808`, :pr:`1822`)
+	- chore: add python version to dependabot (:pr:`1810`)
+	- chore: use code_object_replace_function if possible (:pr:`1816`)
+	- chore: normalize filename and use map (:pr:`1839`)
+	- chore: Generate coverage report (:pr:`1843`)
 
 Version 6.14 (January 2023)
 ---------------------------
 
 #)  New or improved hooks for:
-	- hooks: Add charset_normalizer (:pull:`1758`)
-	- hooks: Add shapely (:pull:`1725`)
-	- hooks: Add sklearn hook (:pull:`1715`)
-	- hooks: Add pytorch (:pull:`1720`)
-	- hooks: Update scipy hook (:pull:`1716`)
-	- hooks: fix sqlite3 hook in python embed (:pull:`1707`)
+	- hooks: Add charset_normalizer (:pr:`1758`)
+	- hooks: Add shapely (:pr:`1725`)
+	- hooks: Add sklearn hook (:pr:`1715`)
+	- hooks: Add pytorch (:pr:`1720`)
+	- hooks: Update scipy hook (:pr:`1716`)
+	- hooks: fix sqlite3 hook in python embed (:pr:`1707`)
 
 #)  Linux:
-	- Support to build musllinux wheels (:pull:`1687`)
-	- project: Improve patchelf dependency specification (:pull:`1722`)
+	- Support to build musllinux wheels (:pr:`1687`)
+	- project: Improve patchelf dependency specification (:pr:`1722`)
 
 #)  Windows:
-	- startup: Do not limit PATH (revert #1659 partially), limit dll search path (:pull:`1675`)
-	- Ignore pylint error for deprecated module msilib (:pull:`1682`)
-	- Update to cx_Logging 3.1 and remove hacks for previous version (:pull:`1688`)
-	- [windows] Compile base executables with generic names depending on cache_tag (:pull:`1712`)
-	- [windows] build-wheel: maintain base executables on git (:pull:`1713`)
-	- [windows] build-wheel: fix git rm (use --ignore-unmatch instead) (:pull:`1714`)
-	- [windows] build-wheel: fix git branch (:pull:`1717`)
-	- [windows] setup: optional compilation in editable mode (:pull:`1718`)
+	- startup: Do not limit PATH (revert #1659 partially), limit dll search path (:pr:`1675`)
+	- Ignore pylint error for deprecated module msilib (:pr:`1682`)
+	- Update to cx_Logging 3.1 and remove hacks for previous version (:pr:`1688`)
+	- [windows] Compile base executables with generic names depending on cache_tag (:pr:`1712`)
+	- [windows] build-wheel: maintain base executables on git (:pr:`1713`)
+	- [windows] build-wheel: fix git rm (use --ignore-unmatch instead) (:pr:`1714`)
+	- [windows] build-wheel: fix git branch (:pr:`1717`)
+	- [windows] setup: optional compilation in editable mode (:pr:`1718`)
 
 #)  Documentation:
-	- pin sphinx to 5.3.0 (:pull:`1691`)
-	- docs: fix typo (:pull:`1697`)
-	- doc: Add keywords for setup() and reorganize read order (:pull:`1728`)
-	- Update copyright year (:pull:`1749`)
-	- docs: use 'furo' theme for sphinx (:pull:`1750`)
-	- doc: cleanup after use of furo theme (:pull:`1755`)
-	- doc: improve documentation about setup script (:pull:`1756`)
-	- project and doc: tweak formatting and ordering (:pull:`1762`)
-	- Small fixes in code and documentation (:pull:`1738`)
+	- pin sphinx to 5.3.0 (:pr:`1691`)
+	- docs: fix typo (:pr:`1697`)
+	- doc: Add keywords for setup() and reorganize read order (:pr:`1728`)
+	- Update copyright year (:pr:`1749`)
+	- docs: use 'furo' theme for sphinx (:pr:`1750`)
+	- doc: cleanup after use of furo theme (:pr:`1755`)
+	- doc: improve documentation about setup script (:pr:`1756`)
+	- project and doc: tweak formatting and ordering (:pr:`1762`)
+	- Small fixes in code and documentation (:pr:`1738`)
 
 #)  Improvements/Refactor/Bugfix:
-	- Include copy of cx_Freeze license with frozen applications (:pull:`1672`)
-	- license: move update_frozen_license to a pre-commit (:pull:`1676`)
-	- Move OS constants to _compat module (:pull:`1709`)
-	- install: run() method needs to exist (:pull:`1747`)
-	- Fix the subclassing of internal commands (regression introduced in #1746) (:pull:`1759`)
-	- commands: accepts space-delimited string lists (:pull:`1761`)
+	- Include copy of cx_Freeze license with frozen applications (:pr:`1672`)
+	- license: move update_frozen_license to a pre-commit (:pr:`1676`)
+	- Move OS constants to _compat module (:pr:`1709`)
+	- install: run() method needs to exist (:pr:`1747`)
+	- Fix the subclassing of internal commands (regression introduced in #1746) (:pr:`1759`)
+	- commands: accepts space-delimited string lists (:pr:`1761`)
 
 #)  Project:
-	- Support Python 3.11 and set it as default in CI (:pull:`1681`)
-	- Drop python 3.6 (:pull:`1670`)
-	- Drop the external dependency on importlib-metadata (:pull:`1692`)
-	- Drop the external dependency on packaging (:pull:`1730`)
-	- Python type hints - upgrade syntax (:pull:`1703`)
-	- Cleanup (:pull:`1760`)
-	- setup: move metadata to pyproject.toml (setuptools 61+) (:pull:`1677`)
-	- pre-commit: fix files that trigger the hook (:pull:`1690`)
-	- Update pre-commit dependencies (:pull:`1693`)
-	- update dev dependencies (:pull:`1701`)
-	- project: add/fix urls (:pull:`1708`)
-	- build-wheel: add missing sdist files (:pull:`1711`)
-	- dist: Use another approach to export DistributionMetadata (:pull:`1726`)
-	- build: setuptools has 'build' command since v62.4.0 (:pull:`1729`)
-	- dist: Use setuptools plugins to extend Distribution instead of subclassing (:pull:`1733`)
-	- Use setuptools Distribution directly (:pull:`1736`)
-	- Add build_exe as subcommand of setuptools build (plugin) (:pull:`1737`)
-	- Add/update commands (provisional) and minor tweaks (:pull:`1746`)
-	- Add dependabot (:pull:`1752`)
-	- Declare support for setuptools 66.0 (:pull:`1753`)
-	- Ignore build time error (:pull:`1754`)
+	- Support Python 3.11 and set it as default in CI (:pr:`1681`)
+	- Drop python 3.6 (:pr:`1670`)
+	- Drop the external dependency on importlib-metadata (:pr:`1692`)
+	- Drop the external dependency on packaging (:pr:`1730`)
+	- Python type hints - upgrade syntax (:pr:`1703`)
+	- Cleanup (:pr:`1760`)
+	- setup: move metadata to pyproject.toml (setuptools 61+) (:pr:`1677`)
+	- pre-commit: fix files that trigger the hook (:pr:`1690`)
+	- Update pre-commit dependencies (:pr:`1693`)
+	- update dev dependencies (:pr:`1701`)
+	- project: add/fix urls (:pr:`1708`)
+	- build-wheel: add missing sdist files (:pr:`1711`)
+	- dist: Use another approach to export DistributionMetadata (:pr:`1726`)
+	- build: setuptools has 'build' command since v62.4.0 (:pr:`1729`)
+	- dist: Use setuptools plugins to extend Distribution instead of subclassing (:pr:`1733`)
+	- Use setuptools Distribution directly (:pr:`1736`)
+	- Add build_exe as subcommand of setuptools build (plugin) (:pr:`1737`)
+	- Add/update commands (provisional) and minor tweaks (:pr:`1746`)
+	- Add dependabot (:pr:`1752`)
+	- Declare support for setuptools 66.0 (:pr:`1753`)
+	- Ignore build time error (:pr:`1754`)
 
 #)  Samples:
-	- samples: Add simple samples using pyproject.toml and setup.cfg (:pull:`1757`)
+	- samples: Add simple samples using pyproject.toml and setup.cfg (:pr:`1757`)
 
 Version 6.13 (October 2022)
 ---------------------------
 
 #)  New or improved hooks for:
-	- hooks: Add hooks for PyQt6 (6.3.1 and 6.4.0) (:pull:`1664`)
-	- hooks: support for new pyside6 6.4.0 (:pull:`1642`)
-	- hooks: support for PySide6 6.4.0 on MSYS2 (:pull:`1655`)
+	- hooks: Add hooks for PyQt6 (6.3.1 and 6.4.0) (:pr:`1664`)
+	- hooks: support for new pyside6 6.4.0 (:pr:`1642`)
+	- hooks: support for PySide6 6.4.0 on MSYS2 (:pr:`1655`)
 
 #)  Windows:
-	- Fix the filename of .msi file generated by bdist_msi. (:pull:`1591`)
-	- Improvements related to bdist_msi --target_name (:pull:`1648`)
-	- initscripts: Separate the code needed by windows and mingw and fix the path usage. (:pull:`1652`)
-	- Fix missing dlls in build root directory [mingw] (:pull:`1653`)
-	- Ensure python3.dll is loaded in some python versions (bpo-29778) (:pull:`1657`)
-	- Fix dependency target to work better with MSYS2 (:pull:`1658`)
-	- startup: limit the PATH in all windows environments (:pull:`1659`)
-	- setup: Fix python compatibility, especially on Windows (:pull:`1656`)
-	- parser: lief >= 0.12 is required [windows] (:pull:`1661`)
+	- Fix the filename of .msi file generated by bdist_msi. (:pr:`1591`)
+	- Improvements related to bdist_msi --target_name (:pr:`1648`)
+	- initscripts: Separate the code needed by windows and mingw and fix the path usage. (:pr:`1652`)
+	- Fix missing dlls in build root directory [mingw] (:pr:`1653`)
+	- Ensure python3.dll is loaded in some python versions (bpo-29778) (:pr:`1657`)
+	- Fix dependency target to work better with MSYS2 (:pr:`1658`)
+	- startup: limit the PATH in all windows environments (:pr:`1659`)
+	- setup: Fix python compatibility, especially on Windows (:pr:`1656`)
+	- parser: lief >= 0.12 is required [windows] (:pr:`1661`)
 
 #)  Samples:
-	- samples: fix demo scripts for pythonnet 3 (:pull:`1643`)
-	- samples: Add samples for PyQt6 and add readme to some qt samples (:pull:`1663`)
+	- samples: fix demo scripts for pythonnet 3 (:pr:`1643`)
+	- samples: Add samples for PyQt6 and add readme to some qt samples (:pr:`1663`)
 
 #)  Improvements/Refactor/Bugfix:
-	- Refactor ci/requirements.py (:pull:`1644`)
-	- tests: add mores tests for bdist_msi (:pull:`1646`)
-	- Do not translate newlines (generate identical file across OS) (:pull:`1645`)
-	- Fix warning and test docs. (:pull:`1647`)
-	- Monkey patch setuptools sandbox to get a better run_setup (:pull:`1649`)
-	- tests: cleanup files and directories created (:pull:`1650`)
-	- use os.fspath() instead of str() (:pull:`1660`)
+	- Refactor ci/requirements.py (:pr:`1644`)
+	- tests: add mores tests for bdist_msi (:pr:`1646`)
+	- Do not translate newlines (generate identical file across OS) (:pr:`1645`)
+	- Fix warning and test docs. (:pr:`1647`)
+	- Monkey patch setuptools sandbox to get a better run_setup (:pr:`1649`)
+	- tests: cleanup files and directories created (:pr:`1650`)
+	- use os.fspath() instead of str() (:pr:`1660`)
 
 Version 6.12 (October 2022)
 ---------------------------
 
 #)  Linux:
-	- Support Linux binary wheel for arm64 (:pull:`1539`)
+	- Support Linux binary wheel for arm64 (:pr:`1539`)
 
 #)  macOS:
-	- darwintools: fix bug in the processing of certain dynamic library references (:pull:`1521`)
-	- darwintools: Further clean-up of path resolver code. (:pull:`1529`)
-	- Make various errors in darwintools show a warning, rather than terminating freeze (:pull:`1593`)
+	- darwintools: fix bug in the processing of certain dynamic library references (:pr:`1521`)
+	- darwintools: Further clean-up of path resolver code. (:pr:`1529`)
+	- Make various errors in darwintools show a warning, rather than terminating freeze (:pr:`1593`)
 
 #)  Windows:
-	- freezer: Fix dependency target to avoid duplicates [windows] (:pull:`1623`)
-	- Call InitializePython from Service_Main instead of wmain. (:pull:`1572`)
-	- bdist_msi: sort options (:pull:`1519`)
-	- bdist_msi: Fix unnecessary 'running egg_info' (:pull:`1520`)
-	- bdist_msi: Fix target-name and target-version (:pull:`1524`)
+	- freezer: Fix dependency target to avoid duplicates [windows] (:pr:`1623`)
+	- Call InitializePython from Service_Main instead of wmain. (:pr:`1572`)
+	- bdist_msi: sort options (:pr:`1519`)
+	- bdist_msi: Fix unnecessary 'running egg_info' (:pr:`1520`)
+	- bdist_msi: Fix target-name and target-version (:pr:`1524`)
 
 #)  New or improved hooks for:
-	- Improve tkinter hook to work on all OS (:pull:`1526`)
-	- hooks: add hook for orjson (:pull:`1606`)
-	- hooks: Ensure include_files only if file exists. (:pull:`1627`)
-	- hooks: Add hook for tokenizers (:pull:`1628`)
-	- hooks: only bcrypt < 4.0 requires cffi (:pull:`1607`)
-	- hooks: update cryptography hook (:pull:`1608`)
-	- hooks: bcrypt and cryptography hooks must work with msys2 (:pull:`1609`)
-	- qt hooks: Put pyqt5 and pyside2 hooks in separate modules (:pull:`1531`)
-	- qt hooks: New pyside6 hooks (:pull:`1533`)
-	- qt hooks: fix qthooks imports/exports and add an optional debug mode (:pull:`1551`)
-	- qt hooks: Add PyQt5/Pyside2/PySide6 hooks for QtDesigner module (:pull:`1552`)
-	- qt hooks: Rewrite pyqt hooks to query Qt Library paths instead of guessing (:pull:`1555`)
-	- qt hooks: Restructures qt hooks into subpackages for easier troubleshooting. (:pull:`1561`)
-	- qt hooks: set some default paths and fix copies (:pull:`1565`)
-	- qt hooks: add resources to PySide2 hooks to work on more environments (:pull:`1566`)
-	- qt hooks: extend copy_qt_files to fix pyqtweb (:pull:`1568`)
-	- qt hooks: a fix for conda-forge linux (pyside2) (:pull:`1585`)
-	- qt hooks: fix the location of auxiliary files of webengine (pyqt5) (:pull:`1586`)
-	- Improve opencv-python hook (:pull:`1536`)
-	- Improve opencv-python hook on macos (:pull:`1538`)
-	- Improve opencv hook for conda linux (:pull:`1556`)
-	- Support msys2 in opencv-python hooks and use optimized mode (:pull:`1601`)
-	- Restore PyYaml hook (:pull:`1542`)
-	- Support for pythonnet 3.0 (:pull:`1600`)
-	- hooks: Refactor as a subpackage (:pull:`1528`)
-	- hooks: Put numpy hook in separate module (:pull:`1532`)
-	- hooks: split Crypto hook in a separate module (:pull:`1602`)
-	- hooks: split scipy hook in a separate module (:pull:`1603`)
+	- Improve tkinter hook to work on all OS (:pr:`1526`)
+	- hooks: add hook for orjson (:pr:`1606`)
+	- hooks: Ensure include_files only if file exists. (:pr:`1627`)
+	- hooks: Add hook for tokenizers (:pr:`1628`)
+	- hooks: only bcrypt < 4.0 requires cffi (:pr:`1607`)
+	- hooks: update cryptography hook (:pr:`1608`)
+	- hooks: bcrypt and cryptography hooks must work with msys2 (:pr:`1609`)
+	- qt hooks: Put pyqt5 and pyside2 hooks in separate modules (:pr:`1531`)
+	- qt hooks: New pyside6 hooks (:pr:`1533`)
+	- qt hooks: fix qthooks imports/exports and add an optional debug mode (:pr:`1551`)
+	- qt hooks: Add PyQt5/Pyside2/PySide6 hooks for QtDesigner module (:pr:`1552`)
+	- qt hooks: Rewrite pyqt hooks to query Qt Library paths instead of guessing (:pr:`1555`)
+	- qt hooks: Restructures qt hooks into subpackages for easier troubleshooting. (:pr:`1561`)
+	- qt hooks: set some default paths and fix copies (:pr:`1565`)
+	- qt hooks: add resources to PySide2 hooks to work on more environments (:pr:`1566`)
+	- qt hooks: extend copy_qt_files to fix pyqtweb (:pr:`1568`)
+	- qt hooks: a fix for conda-forge linux (pyside2) (:pr:`1585`)
+	- qt hooks: fix the location of auxiliary files of webengine (pyqt5) (:pr:`1586`)
+	- Improve opencv-python hook (:pr:`1536`)
+	- Improve opencv-python hook on macos (:pr:`1538`)
+	- Improve opencv hook for conda linux (:pr:`1556`)
+	- Support msys2 in opencv-python hooks and use optimized mode (:pr:`1601`)
+	- Restore PyYaml hook (:pr:`1542`)
+	- Support for pythonnet 3.0 (:pr:`1600`)
+	- hooks: Refactor as a subpackage (:pr:`1528`)
+	- hooks: Put numpy hook in separate module (:pr:`1532`)
+	- hooks: split Crypto hook in a separate module (:pr:`1602`)
+	- hooks: split scipy hook in a separate module (:pr:`1603`)
 
 #)  Samples:
-	- samples: Add orjson sample (:pull:`1605`)
-	- samples: pyqt5, pyside2 and pyside6 in optimized mode (:pull:`1587`)
-	- New pyqt5 simplebrowser sample (adapted from pyside2 sample) (:pull:`1567`)
-	- Use pyside6 example simplebrowser as sample (:pull:`1543`)
-	- New opencv-python sample (:pull:`1535`)
-	- Use the same tkinter sample as used in python (:pull:`1525`)
-	- samples: add PhotoImage to tkinter (:pull:`1581`)
-	- samples: adapt qt samples to use get_qt_plugins_paths (:pull:`1636`)
+	- samples: Add orjson sample (:pr:`1605`)
+	- samples: pyqt5, pyside2 and pyside6 in optimized mode (:pr:`1587`)
+	- New pyqt5 simplebrowser sample (adapted from pyside2 sample) (:pr:`1567`)
+	- Use pyside6 example simplebrowser as sample (:pr:`1543`)
+	- New opencv-python sample (:pr:`1535`)
+	- Use the same tkinter sample as used in python (:pr:`1525`)
+	- samples: add PhotoImage to tkinter (:pr:`1581`)
+	- samples: adapt qt samples to use get_qt_plugins_paths (:pr:`1636`)
 
 #)  Improvements/Refactor/Bugfix:
-	- fix setuptools 61+ package discovery and other fixes for 62+ (:pull:`1545`)
-	- fix setup to work with setuptools 64.x and 65.x (:pull:`1588`)
-	- importlib-metadata >= 4.12.0 raise ValueError instead of returning None (:pull:`1625`)
-	- Fixed ValueError / importlib_metadata problem (:pull:`1630`)
+	- fix setuptools 61+ package discovery and other fixes for 62+ (:pr:`1545`)
+	- fix setup to work with setuptools 64.x and 65.x (:pr:`1588`)
+	- importlib-metadata >= 4.12.0 raise ValueError instead of returning None (:pr:`1625`)
+	- Fixed ValueError / importlib_metadata problem (:pr:`1630`)
 	- Fix readthedocs for 6.11
-	- pin sphinx 5.0.1 and fix the support for it (:pull:`1512`)
-	- update issue template (:pull:`1515`)
-	- update dev dependencies (:pull:`1516`)
-	- module: Fix .dist-info with subdirectories (:pull:`1514`)
-	- Add parse as pylint-ready module (:pull:`1527`)
-	- Remove deprecated options in build_exe and bdist_mac (:pull:`1544`)
-	- Requires permanent use of lief package on windows (:pull:`1547`)
-	- Add a workaround to compile with --no-lto if LTO linking fails (:pull:`1549`)
-	- Fix a warning compiling with gcc 12.1 (:pull:`1550`)
-	- finder: extend _base_hooks to include hooks in directories (:pull:`1557`)
-	- update dev dependencies (:pull:`1558`)
-	- setup: use find_packages and include_package_data for simplicity (:pull:`1559`)
-	- samples: move to root (:pull:`1560`)
-	- finder: extend include_file_as_module to include submodule (:pull:`1562`)
-	- bases and initscripts: lowercase to remove pylint invalid-name (:pull:`1563`)
-	- Update dev dependencies (:pull:`1584`)
-	- tweak the bdist_rpm test (:pull:`1596`)
-	- Add test for cx_Freeze.command.bdist_msi (:pull:`1597`)
-	- freezer: copy package data using _copy_files to correctly parse dependencies (:pull:`1610`)
-	- Improve makefile (:pull:`1619`)
-	- Update dev dependencies (:pull:`1620`)
-	- Cleanup to support/test with python 3.11b3 (:pull:`1518`)
-	- freezer: use internal _create_directory (create the parents, verbose) (:pull:`1635`)
+	- pin sphinx 5.0.1 and fix the support for it (:pr:`1512`)
+	- update issue template (:pr:`1515`)
+	- update dev dependencies (:pr:`1516`)
+	- module: Fix .dist-info with subdirectories (:pr:`1514`)
+	- Add parse as pylint-ready module (:pr:`1527`)
+	- Remove deprecated options in build_exe and bdist_mac (:pr:`1544`)
+	- Requires permanent use of lief package on windows (:pr:`1547`)
+	- Add a workaround to compile with --no-lto if LTO linking fails (:pr:`1549`)
+	- Fix a warning compiling with gcc 12.1 (:pr:`1550`)
+	- finder: extend _base_hooks to include hooks in directories (:pr:`1557`)
+	- update dev dependencies (:pr:`1558`)
+	- setup: use find_packages and include_package_data for simplicity (:pr:`1559`)
+	- samples: move to root (:pr:`1560`)
+	- finder: extend include_file_as_module to include submodule (:pr:`1562`)
+	- bases and initscripts: lowercase to remove pylint invalid-name (:pr:`1563`)
+	- Update dev dependencies (:pr:`1584`)
+	- tweak the bdist_rpm test (:pr:`1596`)
+	- Add test for cx_Freeze.command.bdist_msi (:pr:`1597`)
+	- freezer: copy package data using _copy_files to correctly parse dependencies (:pr:`1610`)
+	- Improve makefile (:pr:`1619`)
+	- Update dev dependencies (:pr:`1620`)
+	- Cleanup to support/test with python 3.11b3 (:pr:`1518`)
+	- freezer: use internal _create_directory (create the parents, verbose) (:pr:`1635`)
 
 #)  Documentation:
-	- Fixed a broken link in documentation (:pull:`1618`)
-	- Improved documentation of initial_target_dir option on bdist_msi. (:pull:`1614`)
-	- Add FAQ item for big installations (:pull:`1583`)
+	- Fixed a broken link in documentation (:pr:`1618`)
+	- Improved documentation of initial_target_dir option on bdist_msi. (:pr:`1614`)
+	- Add FAQ item for big installations (:pr:`1583`)
 
 Version 6.11 (June 2022)
 ---------------------------
 
 #)  Main Improvements:
-	- First step to support static libpython (:pull:`1414`)
-	- Set the path to search for modules, and fix the path for built-in modules (:pull:`1419`)
-	- New release process relies on bump2version (:pull:`1365`)
-	- Improve code to cache dist-info files and convert egg-info to dist-info (:pull:`1367`)
-	- Compile base executables with generic names depending on SOABI (:pull:`1393`)
-	- Add CI with a pre-commit file (:pull:`1368`)
-	- Introduce tests in the GitHub CI (:pull:`1381`)
-	- Get rid of some calls to deprecated module distutils (:pull:`1445`)
-	- Borrow bdist_rpm from python 3.10 (:pull:`1446`)
-	- Borrow bdist_msi from python 3.8 (:pull:`1447`)
-	- pin setuptools to a range that works (:pull:`1453`)
+	- First step to support static libpython (:pr:`1414`)
+	- Set the path to search for modules, and fix the path for built-in modules (:pr:`1419`)
+	- New release process relies on bump2version (:pr:`1365`)
+	- Improve code to cache dist-info files and convert egg-info to dist-info (:pr:`1367`)
+	- Compile base executables with generic names depending on SOABI (:pr:`1393`)
+	- Add CI with a pre-commit file (:pr:`1368`)
+	- Introduce tests in the GitHub CI (:pr:`1381`)
+	- Get rid of some calls to deprecated module distutils (:pr:`1445`)
+	- Borrow bdist_rpm from python 3.10 (:pr:`1446`)
+	- Borrow bdist_msi from python 3.8 (:pr:`1447`)
+	- pin setuptools to a range that works (:pr:`1453`)
 
 #)  Linux:
-	- Support for using embedded manylinux static libraries (:pull:`1504`)
-	- Fix symlinks to avoid duplicate the target (:pull:`1424`)
-	- Fix incorrect default bin path includes (:pull:`1425`)
+	- Support for using embedded manylinux static libraries (:pr:`1504`)
+	- Fix symlinks to avoid duplicate the target (:pr:`1424`)
+	- Fix incorrect default bin path includes (:pr:`1425`)
 
 #)  macOS:
-	- Support for using macos static libraries (:pull:`1505`)
+	- Support for using macos static libraries (:pr:`1505`)
 
 #)  Windows:
-	- Convert PEP440 version scheme to windows scheme (:pull:`1392`)
-	- Lief 0.12 supports delay_imports (:pull:`1426`)
-	- LIEF 0.12 supports Python 3.10 (:pull:`1433`)
+	- Convert PEP440 version scheme to windows scheme (:pr:`1392`)
+	- Lief 0.12 supports delay_imports (:pr:`1426`)
+	- LIEF 0.12 supports Python 3.10 (:pr:`1433`)
 
 #)  New or improved hooks for:
-	- Added additional hooks for the Qt sqldrivers and styles plugins. (:pull:`1371`)
-	- Fix hooks for PySide2 5.15.2.1 (:pull:`1396`)
-	- Optimizing and adding some Qt hooks (:pull:`1398`)
-	- Use pathlib in qt hooks to always use posix paths as qt does (:pull:`1399`)
-	- Add hooks for Pyside2.QtWebEngine* (and pyqtwebengine) (:pull:`1479`)
+	- Added additional hooks for the Qt sqldrivers and styles plugins. (:pr:`1371`)
+	- Fix hooks for PySide2 5.15.2.1 (:pr:`1396`)
+	- Optimizing and adding some Qt hooks (:pr:`1398`)
+	- Use pathlib in qt hooks to always use posix paths as qt does (:pr:`1399`)
+	- Add hooks for Pyside2.QtWebEngine* (and pyqtwebengine) (:pr:`1479`)
 
 #)  Samples:
-	- Add PySide6 sample (:pull:`1442`)
-	- Use pyside2 example simplebrowser as sample (:pull:`1478`)
+	- Add PySide6 sample (:pr:`1442`)
+	- Use pyside2 example simplebrowser as sample (:pr:`1478`)
 
 #)  Improvements/Refactor/Bugfix:
-	- Minor tweaks with black (:pull:`1364`)
-	- Run isort over the code base (:pull:`1366`)
-	- Fixes some errors found by pylint (:pull:`1369`)
-	- Fix requirements (:pull:`1373`)
-	- Build in isolated mode for python 3.6-3.9 (:pull:`1374`)
-	- Fix pre-commit configuration (:pull:`1375`)
-	- Skip isort in imports_sample test to fix errors (:pull:`1383`)
-	- Update MANIFEST.in and Makefile (:pull:`1391`)
-	- Fix the default module name in IncludeFile (:pull:`1400`)
-	- pin sphinx to 4.4.0 and fix the support for it (:pull:`1401`)
-	- Fix some requirements and versions (:pull:`1402`)
-	- Use blacken-docs for python code blocks in the docs (:pull:`1403`)
-	- Fix a test after #1402 (:pull:`1404`)
-	- Use sphinx rdt theme and minor tweaks (:pull:`1405`)
-	- Use new build option in rdt to use py39 (:pull:`1406`)
-	- Add pre-commit-sphinx (:pull:`1407`)
-	- Add pip-tools pre-commit and enable setup-cfg-fmt (:pull:`1411`)
-	- Use Path in setup (:pull:`1412`)
-	- Use a self made requirements sync instead of piptools (:pull:`1413`)
-	- Add cached_property (and a compatible function) for planned use (:pull:`1417`)
-	- readme: To install the latest development build (:pull:`1418`)
-	- finder: refactor load_module (:pull:`1420`)
-	- The built-in modules are determined based on the cx_Freeze build (:pull:`1421`)
-	- Some changes to satisfy the linters (:pull:`1422`)
-	- Enable flake8 in pre-commit (:pull:`1423`)
-	- Enable flake8 in samples (:pull:`1427`)
-	- Bump black from 22.1.0 to 22.3.0 (:pull:`1428`)
-	- Enable flake8 in tests (:pull:`1429`)
-	- Enable pylint (limited to tests) (:pull:`1430`)
-	- Update python dependencies (:pull:`1432`)
-	- freezer: refactor to 'consider using with' (:pull:`1434`)
-	- finder: use pep8 names (and enable pylint for it) (:pull:`1435`)
-	- hooks: fixes docstrings and other lint warnings (:pull:`1436`)
-	- hooks: new utility function copy_qt_data (:pull:`1437`)
-	- hooks: use function attribute to avoid a pylint warning (:pull:`1438`)
-	- hooks and setup are ready to pylint (:pull:`1439`)
-	- More configuration to pylint (:pull:`1440`)
-	- Fix the main docstring for some modules (:pull:`1441`)
-	- Two more modules are ready for pylint. (:pull:`1443`)
-	- Add cli and dist as pylint-ready modules (:pull:`1444`)
-	- bdist_rpm: Make code style suitable for use in cx_Freeze (:pull:`1448`)
-	- bdist_rpm: merge the code to make a unique class (:pull:`1449`)
-	- bdist_msi: convert to utf8, apply pyupgrade, black and isort (:pull:`1452`)
-	- Declare the new subpackage cx_Freeze.command (:pull:`1451`)
-	- bdist_msi: get rid of distutils (:pull:`1454`)
-	- bdist_msi: Pass pylint and flake8 (:pull:`1455`)
-	- initscripts: pylint ready (:pull:`1456`)
-	- bdist_rpm: condicional import (:pull:`1457`)
-	- bdist_msi: move all the code to the command subpackage (:pull:`1458`)
-	- Document the new code layout (:pull:`1459`)
-	- Fix pylint configuration (:pull:`1460`)
-	- bdist_mac: move macdist to new name and fix lint errors (:pull:`1461`)
-	- bdist_*: fix some pylint invalid-name (:pull:`1462`)
-	- Tests: enable a test by platform (:pull:`1463`)
-	- build,install: move these commands to the command subpackage (:pull:`1464`)
-	- build_exe: move this command to the command subpackage (:pull:`1465`)
-	- install_exe: move this command to the command subpackage (:pull:`1466`)
-	- install: suppress known deprecation (:pull:`1467`)
-	- build: merge the code from distutils to the Build class (:pull:`1468`)
-	- The python used to compile and to build is always the same [conda] (:pull:`1469`)
-	- build: minor tweaks (:pull:`1471`)
-	- pre-commit autoupdate and minor tweaks with pylint (:pull:`1472`)
-	- Move setup() and refactor to avoid a future circular import in Freezer (:pull:`1473`)
-	- setup: more pylint (:pull:`1474`)
-	- Using a trick to get around a dependency on distutils. (:pull:`1475`)
-	- CI in one file and cache pip dependencies (:pull:`1476`)
-	- tests: Add test for build command (:pull:`1477`)
-	- build_exe: fix a bug in the build_exe option (:pull:`1480`)
-	- bdist_msi: move user_options to main code, excluding unused options (:pull:`1481`)
-	- tests: add find_spec test (and remove similar sample) (:pull:`1482`)
-	- Extend setuptools.sandbox.run_setup to work with cx_Freeze setup(). (:pull:`1484`)
-	- tests: support for tests using Path (:pull:`1485`)
-	- tests: add plist_items test (and remove similar sample) (:pull:`1486`)
-	- tests: remove a no longer supported method (:pull:`1487`)
-	- tests: add a test for bdist_rpm (:pull:`1488`)
-	- pre-commit: fix pyupgrade configuration (:pull:`1489`)
-	- doc: Enable text wrapping in table cells using rdt_theme (:pull:`1496`)
-	- Update issue templates (:pull:`1507`)
-	- update dev dependencies (:pull:`1508`)
+	- Minor tweaks with black (:pr:`1364`)
+	- Run isort over the code base (:pr:`1366`)
+	- Fixes some errors found by pylint (:pr:`1369`)
+	- Fix requirements (:pr:`1373`)
+	- Build in isolated mode for python 3.6-3.9 (:pr:`1374`)
+	- Fix pre-commit configuration (:pr:`1375`)
+	- Skip isort in imports_sample test to fix errors (:pr:`1383`)
+	- Update MANIFEST.in and Makefile (:pr:`1391`)
+	- Fix the default module name in IncludeFile (:pr:`1400`)
+	- pin sphinx to 4.4.0 and fix the support for it (:pr:`1401`)
+	- Fix some requirements and versions (:pr:`1402`)
+	- Use blacken-docs for python code blocks in the docs (:pr:`1403`)
+	- Fix a test after #1402 (:pr:`1404`)
+	- Use sphinx rdt theme and minor tweaks (:pr:`1405`)
+	- Use new build option in rdt to use py39 (:pr:`1406`)
+	- Add pre-commit-sphinx (:pr:`1407`)
+	- Add pip-tools pre-commit and enable setup-cfg-fmt (:pr:`1411`)
+	- Use Path in setup (:pr:`1412`)
+	- Use a self made requirements sync instead of piptools (:pr:`1413`)
+	- Add cached_property (and a compatible function) for planned use (:pr:`1417`)
+	- readme: To install the latest development build (:pr:`1418`)
+	- finder: refactor load_module (:pr:`1420`)
+	- The built-in modules are determined based on the cx_Freeze build (:pr:`1421`)
+	- Some changes to satisfy the linters (:pr:`1422`)
+	- Enable flake8 in pre-commit (:pr:`1423`)
+	- Enable flake8 in samples (:pr:`1427`)
+	- Bump black from 22.1.0 to 22.3.0 (:pr:`1428`)
+	- Enable flake8 in tests (:pr:`1429`)
+	- Enable pylint (limited to tests) (:pr:`1430`)
+	- Update python dependencies (:pr:`1432`)
+	- freezer: refactor to 'consider using with' (:pr:`1434`)
+	- finder: use pep8 names (and enable pylint for it) (:pr:`1435`)
+	- hooks: fixes docstrings and other lint warnings (:pr:`1436`)
+	- hooks: new utility function copy_qt_data (:pr:`1437`)
+	- hooks: use function attribute to avoid a pylint warning (:pr:`1438`)
+	- hooks and setup are ready to pylint (:pr:`1439`)
+	- More configuration to pylint (:pr:`1440`)
+	- Fix the main docstring for some modules (:pr:`1441`)
+	- Two more modules are ready for pylint. (:pr:`1443`)
+	- Add cli and dist as pylint-ready modules (:pr:`1444`)
+	- bdist_rpm: Make code style suitable for use in cx_Freeze (:pr:`1448`)
+	- bdist_rpm: merge the code to make a unique class (:pr:`1449`)
+	- bdist_msi: convert to utf8, apply pyupgrade, black and isort (:pr:`1452`)
+	- Declare the new subpackage cx_Freeze.command (:pr:`1451`)
+	- bdist_msi: get rid of distutils (:pr:`1454`)
+	- bdist_msi: Pass pylint and flake8 (:pr:`1455`)
+	- initscripts: pylint ready (:pr:`1456`)
+	- bdist_rpm: condicional import (:pr:`1457`)
+	- bdist_msi: move all the code to the command subpackage (:pr:`1458`)
+	- Document the new code layout (:pr:`1459`)
+	- Fix pylint configuration (:pr:`1460`)
+	- bdist_mac: move macdist to new name and fix lint errors (:pr:`1461`)
+	- bdist_*: fix some pylint invalid-name (:pr:`1462`)
+	- Tests: enable a test by platform (:pr:`1463`)
+	- build,install: move these commands to the command subpackage (:pr:`1464`)
+	- build_exe: move this command to the command subpackage (:pr:`1465`)
+	- install_exe: move this command to the command subpackage (:pr:`1466`)
+	- install: suppress known deprecation (:pr:`1467`)
+	- build: merge the code from distutils to the Build class (:pr:`1468`)
+	- The python used to compile and to build is always the same [conda] (:pr:`1469`)
+	- build: minor tweaks (:pr:`1471`)
+	- pre-commit autoupdate and minor tweaks with pylint (:pr:`1472`)
+	- Move setup() and refactor to avoid a future circular import in Freezer (:pr:`1473`)
+	- setup: more pylint (:pr:`1474`)
+	- Using a trick to get around a dependency on distutils. (:pr:`1475`)
+	- CI in one file and cache pip dependencies (:pr:`1476`)
+	- tests: Add test for build command (:pr:`1477`)
+	- build_exe: fix a bug in the build_exe option (:pr:`1480`)
+	- bdist_msi: move user_options to main code, excluding unused options (:pr:`1481`)
+	- tests: add find_spec test (and remove similar sample) (:pr:`1482`)
+	- Extend setuptools.sandbox.run_setup to work with cx_Freeze setup(). (:pr:`1484`)
+	- tests: support for tests using Path (:pr:`1485`)
+	- tests: add plist_items test (and remove similar sample) (:pr:`1486`)
+	- tests: remove a no longer supported method (:pr:`1487`)
+	- tests: add a test for bdist_rpm (:pr:`1488`)
+	- pre-commit: fix pyupgrade configuration (:pr:`1489`)
+	- doc: Enable text wrapping in table cells using rdt_theme (:pr:`1496`)
+	- Update issue templates (:pr:`1507`)
+	- update dev dependencies (:pr:`1508`)
 
 
 Version 6.10 (January 2022)
@@ -386,617 +386,617 @@ Version 6.10 (January 2022)
 
 #)  Improvements:
 	- Implements Parser interface to create an abstraction to parse binary
-	  files (:pull:`1313`)
-	- Implements basic PEParser interface (:pull:`1314`)
+	  files (:pr:`1313`)
+	- Implements basic PEParser interface (:pr:`1314`)
 	- Helper to create and return a Path-like temporary directory
-	  (:pull:`1338`)
-	- Use build and tweak requirements (:pull:`1343`)
-	- Add a basic pyproject.toml for build and tools (:pull:`1355`)
+	  (:pr:`1338`)
+	- Use build and tweak requirements (:pr:`1343`)
+	- Add a basic pyproject.toml for build and tools (:pr:`1355`)
 
 #)  Refactor and bugfix for all systems:
-	- importlib.metadata is no longer provisional in Python 3.10 (:pull:`1316`)
-	- Add a new _compat module (:pull:`1317`)
-	- Prioritize importlib_metadata in versions lower than 3.10 (:pull:`1353`)
-	- Fix an overwrite of silent variable in parser (:pull:`1322`)
-	- Copy top dependencies only once (:pull:`1336`, :issue:`1304`,
+	- importlib.metadata is no longer provisional in Python 3.10 (:pr:`1316`)
+	- Add a new _compat module (:pr:`1317`)
+	- Prioritize importlib_metadata in versions lower than 3.10 (:pr:`1353`)
+	- Fix an overwrite of silent variable in parser (:pr:`1322`)
+	- Copy top dependencies only once (:pr:`1336`, :issue:`1304`,
 	  :issue:`1333`)
-	- Change the place to set version and set new year (:pull:`1350`)
-	- Add more files to the source distribution (:pull:`1349`)
-	- Minor tweaks in setup.cfg and add a missing version.py (:pull:`1351`)
-	- Avoid error when cx_Freeze.util is not build yet (:pull:`1352`)
-	- Use helper TemporaryPath in module (:pull:`1354`)
+	- Change the place to set version and set new year (:pr:`1350`)
+	- Add more files to the source distribution (:pr:`1349`)
+	- Minor tweaks in setup.cfg and add a missing version.py (:pr:`1351`)
+	- Avoid error when cx_Freeze.util is not build yet (:pr:`1352`)
+	- Use helper TemporaryPath in module (:pr:`1354`)
 
 #)  Linux:
-	- Implements ELFParser interface merging patchelf (:pull:`1315`)
-	- Use PyPI patchelf rather than installed by OS (:pull:`1341`)
+	- Implements ELFParser interface merging patchelf (:pr:`1315`)
+	- Use PyPI patchelf rather than installed by OS (:pr:`1341`)
 
 #)  Windows:
 	- Drop references to shlwapi.dll on Windows to improve performance
-	  (:pull:`1318`)
-	- Use the dlltool provided in the same directory as gendef (:pull:`1319`)
-	- Update manifest.txt to match python.manifest (:pull:`1320`)
-	- Search dlls in sys.path, then in the path [windows] (:pull:`1323`)
-	- Use PySys_SetArgvEx in windows too. (:pull:`1324`)
-	- Add lief as dependency for windows (:pull:`1325`)
-	- Support Application Manifests in Windows (:pull:`1326`, :issue:`385`,
+	  (:pr:`1318`)
+	- Use the dlltool provided in the same directory as gendef (:pr:`1319`)
+	- Update manifest.txt to match python.manifest (:pr:`1320`)
+	- Search dlls in sys.path, then in the path [windows] (:pr:`1323`)
+	- Use PySys_SetArgvEx in windows too. (:pr:`1324`)
+	- Add lief as dependency for windows (:pr:`1325`)
+	- Support Application Manifests in Windows (:pr:`1326`, :issue:`385`,
 	  :issue:`997`, :issue:`1305`)
 	- Creates a manifest for an application that will request elevation
-	  (:pull:`1327`, :issue:`1188`)
-	- Ignore when lief is not available/installed, like in MSYS2 (:pull:`1328`)
-	- util: style changes (:pull:`1329`)
-	- Support Path in BeginUpdateResource and fix UpdateResource (:pull:`1330`)
-	- Move version stamp to winversioninfo module (:pull:`1331`)
-	- Add a simple test to winversioninfo (:pull:`1332`)
-	- Implement version stamp [windows][experimental] (:pull:`1334`)
-	- Workaround a bug in lief with utf-8 filenames [windows] (:pull:`1339`)
-	- Use lief to detect dependencies [windows][experimental] (:pull:`1344`,
+	  (:pr:`1327`, :issue:`1188`)
+	- Ignore when lief is not available/installed, like in MSYS2 (:pr:`1328`)
+	- util: style changes (:pr:`1329`)
+	- Support Path in BeginUpdateResource and fix UpdateResource (:pr:`1330`)
+	- Move version stamp to winversioninfo module (:pr:`1331`)
+	- Add a simple test to winversioninfo (:pr:`1332`)
+	- Implement version stamp [windows][experimental] (:pr:`1334`)
+	- Workaround a bug in lief with utf-8 filenames [windows] (:pr:`1339`)
+	- Use lief to detect dependencies [windows][experimental] (:pr:`1344`,
 	  :issue:`665`)
 
 #)  Samples:
-	- Extend the 'icon' sample to use an admin manifest (:pull:`1340`)
+	- Extend the 'icon' sample to use an admin manifest (:pr:`1340`)
 
 #)  Documentation:
-	- Documentation for manifest and uac-admin options (:pull:`1337`)
-	- Update docs for patchelf (:pull:`1342`)
+	- Documentation for manifest and uac-admin options (:pr:`1337`)
+	- Update docs for patchelf (:pr:`1342`)
 
 
 Version 6.9 (December 2021)
 ---------------------------
 
 #)  Improvements:
-	- Extend Module.in_file_system to support an optimized mode (:pull:`1301`)
+	- Extend Module.in_file_system to support an optimized mode (:pr:`1301`)
 
 #)  Refactor and bugfix for all systems:
-	- Fix Implicit Namespace Packages (:pull:`1290`, :issue:`1276`)
-	- Extend the support for vendored subpackages (:pull:`1294`)
-	- Common: Prevent memory leaks on fail (:pull:`1245`)
+	- Fix Implicit Namespace Packages (:pr:`1290`, :issue:`1276`)
+	- Extend the support for vendored subpackages (:pr:`1294`)
+	- Common: Prevent memory leaks on fail (:pr:`1245`)
 	- Merge dis._unpack_opargs into scan_code to be able to fix a bug in py310
-	  (:pull:`1306`)
-	- Fix some print and f-string (:pull:`1246`)
-	- fixing enumerations (:pull:`1263`)
-	- Fixes for the existing nose tests (:pull:`1234`)
+	  (:pr:`1306`)
+	- Fix some print and f-string (:pr:`1246`)
+	- fixing enumerations (:pr:`1263`)
+	- Fixes for the existing nose tests (:pr:`1234`)
 	- Generate `dev-requirements.txt` + improve readme for contributors wanting
-	  to run tests (:pull:`1224`)
-	- Convert existing tests to pytest + increase coverage (:pull:`1255`)
+	  to run tests (:pr:`1224`)
+	- Convert existing tests to pytest + increase coverage (:pr:`1255`)
 
 #)  Linux:
 	- Fix relative path in dependencies, detected in miniconda linux
-	  (:pull:`1258`)
-	- Create symlinks in the target (:pull:`1292`, :issue:`750`)
+	  (:pr:`1258`)
+	- Create symlinks in the target (:pr:`1292`, :issue:`750`)
 
 #)  macOS:
-	- fix bugs in certain subprocess calls (:pull:`1260`)
-	- Apply ad-hoc signature to modified libraries (:pull:`1251`)
+	- fix bugs in certain subprocess calls (:pr:`1260`)
+	- Apply ad-hoc signature to modified libraries (:pr:`1251`)
 
 #)  Windows:
 	- Set REINSTALLMODE to force installing same-version executables
-	  (:pull:`1252`, :issue:`1250`)
+	  (:pr:`1252`, :issue:`1250`)
 
 #)  New or improved hooks for:
-	- ctypes/libffi (:pull:`1279`)
-	- flask-compress (:pull:`1295`, :issue:`1273`)
-	- opencv-python (:pull:`1278`, :issue:`1275`)
-	- PyQt5 hooks (:pull:`1302`, :issue:`1261`)
-	- PySide2 - Linux only (:pull:`1302`)
-	- sentry-sdk modules (:pull:`1282`)
+	- ctypes/libffi (:pr:`1279`)
+	- flask-compress (:pr:`1295`, :issue:`1273`)
+	- opencv-python (:pr:`1278`, :issue:`1275`)
+	- PyQt5 hooks (:pr:`1302`, :issue:`1261`)
+	- PySide2 - Linux only (:pr:`1302`)
+	- sentry-sdk modules (:pr:`1282`)
 
 #)  Samples:
-	- Update PyQt5 sample (:pull:`1307`)
+	- Update PyQt5 sample (:pr:`1307`)
 
 #)  Documentation:
-	- Update the FAQ (:pull:`1247`)
-	- Update msi doc (:pull:`1248`)
-	- fade to black (:pull:`1291`)
-	- docs: new item in faq (:pull:`1298`)
-	- docs: open external links in a tab (:pull:`1299`)
-	- prepare to release with python 3.10 support (:pull:`1308`)
+	- Update the FAQ (:pr:`1247`)
+	- Update msi doc (:pr:`1248`)
+	- fade to black (:pr:`1291`)
+	- docs: new item in faq (:pr:`1298`)
+	- docs: open external links in a tab (:pr:`1299`)
+	- prepare to release with python 3.10 support (:pr:`1308`)
 
 
 Version 6.8 (September 2021)
 ----------------------------
 
 #)  Improvements:
-	- Support pathlib in ModuleFinder (:pull:`1153`)
-	- Use Path in Module.file (:pull:`1158`)
-	- Use Path in _replace_paths_in_code (:pull:`1159`)
-	- Use Path in Module.path (:pull:`1160`)
-	- Convert code in hooks to use Path (:pull:`1161`)
-	- Use path.iterdir to simplify a code block (:pull:`1162`)
-	- Use Path in executable module (:pull:`1163`)
-	- Use Path in ModuleFinder.zip_includes (:pull:`1164`)
-	- Use Path in process_path_specs (:pull:`1167`)
-	- Use Path in Freezer include_files and zip_includes (:pull:`1168`)
-	- Use Path in Freezer.targetdir and some related code (:pull:`1169`)
+	- Support pathlib in ModuleFinder (:pr:`1153`)
+	- Use Path in Module.file (:pr:`1158`)
+	- Use Path in _replace_paths_in_code (:pr:`1159`)
+	- Use Path in Module.path (:pr:`1160`)
+	- Convert code in hooks to use Path (:pr:`1161`)
+	- Use path.iterdir to simplify a code block (:pr:`1162`)
+	- Use Path in executable module (:pr:`1163`)
+	- Use Path in ModuleFinder.zip_includes (:pr:`1164`)
+	- Use Path in process_path_specs (:pr:`1167`)
+	- Use Path in Freezer include_files and zip_includes (:pr:`1168`)
+	- Use Path in Freezer.targetdir and some related code (:pr:`1169`)
 	- Use Path in Freezer._copy_file and almost remaining related code
-	  (:pull:`1172`)
-	- Use Path in Executable icon and shortcut_dir (:pull:`1173`)
-	- Use Set[Path] in dependent_files (:pull:`1215`)
-	- Use subprocess (:pull:`1214`)
-	- Add more options to cxfreeze script and tweak the docs (:pull:`1174`)
+	  (:pr:`1172`)
+	- Use Path in Executable icon and shortcut_dir (:pr:`1173`)
+	- Use Set[Path] in dependent_files (:pr:`1215`)
+	- Use subprocess (:pr:`1214`)
+	- Add more options to cxfreeze script and tweak the docs (:pr:`1174`)
 
 #)  Refactor and bugfix for all systems:
-	- Remove unused and unnecessary code (:pull:`1142`)
-	- Add some old modules to exclude list (:pull:`1149`)
-	- Fix a last minute change and tweak docstrings (:pull:`1154`)
+	- Remove unused and unnecessary code (:pr:`1142`)
+	- Add some old modules to exclude list (:pr:`1149`)
+	- Fix a last minute change and tweak docstrings (:pr:`1154`)
 	- Include files (from a directory) is ignoring the exclude dependencies
-	  option (:pull:`1216`)
-	- Add more typing to freeze (:pull:`1218`)
-	- Create permanent cx_Freeze/bases (:pull:`1227`)
-	- Make Freezer.targetdir a property to improve a bit (:pull:`1170`)
-	- Code analysis, pep8, f-string (:pull:`1177`)
-	- Complementary fixes (:pull:`1179`)
-	- Use setuptools instead distutils a bit more (:pull:`1195`)
+	  option (:pr:`1216`)
+	- Add more typing to freeze (:pr:`1218`)
+	- Create permanent cx_Freeze/bases (:pr:`1227`)
+	- Make Freezer.targetdir a property to improve a bit (:pr:`1170`)
+	- Code analysis, pep8, f-string (:pr:`1177`)
+	- Complementary fixes (:pr:`1179`)
+	- Use setuptools instead distutils a bit more (:pr:`1195`)
 
 #)  Linux:
 	- Fix py39 in ArchLinux using lto (in a different way than mac)
-	  (:pull:`1146`, :issue:`1132`)
-	- Patchelf calls supports Path type (:pull:`1178`)
-	- Use Path (relative_to and parts) to rewrite the fix rpaths (:pull:`1181`)
-	- Complementary patch to #1181 (:pull:`1201`)
-	- Fix for Miniconda python in linux (:pull:`1219`)
-	- Implement Patchelf.get_needed (still based on ldd) (:pull:`1220`)
-	- Implement Patchelf.is_elf to optimize get_needed (:pull:`1221`)
-	- Fix dependency target and rpath settings (:pull:`1223`)
+	  (:pr:`1146`, :issue:`1132`)
+	- Patchelf calls supports Path type (:pr:`1178`)
+	- Use Path (relative_to and parts) to rewrite the fix rpaths (:pr:`1181`)
+	- Complementary patch to #1181 (:pr:`1201`)
+	- Fix for Miniconda python in linux (:pr:`1219`)
+	- Implement Patchelf.get_needed (still based on ldd) (:pr:`1220`)
+	- Implement Patchelf.is_elf to optimize get_needed (:pr:`1221`)
+	- Fix dependency target and rpath settings (:pr:`1223`)
 	- Patchelf needs permission to write
-	  (:pull:`1232`, :issue:`1171`, :issue:`1197`)
-	- Disable strip with build --debug [linux] (:pull:`1235`, :issue:`1194`)
+	  (:pr:`1232`, :issue:`1171`, :issue:`1197`)
+	- Disable strip with build --debug [linux] (:pr:`1235`, :issue:`1194`)
 
 #)  macOS:
-	- Use Path in darwintools and some pep8 (:pull:`1222`)
-	- Fix MachORef in macdist and add-on tweaks to #1222 (:pull:`1229`)
+	- Use Path in darwintools and some pep8 (:pr:`1222`)
+	- Fix MachORef in macdist and add-on tweaks to #1222 (:pr:`1229`)
 
 #)  Windows:
-	- Fix compatibility with msys2 python 3.9.6 (:pull:`1182`)
-	- LLVM dlltool only supports generating an import library (:pull:`1187`)
-	- Normalize paths at startup for MSYS2 python (:pull:`1193`)
+	- Fix compatibility with msys2 python 3.9.6 (:pr:`1182`)
+	- LLVM dlltool only supports generating an import library (:pr:`1187`)
+	- Normalize paths at startup for MSYS2 python (:pr:`1193`)
 	- Disable delay load to avoid 'Segmentation fault' in mingw 32 bits
-	  (:pull:`1217`)
-	- Support Path as parameter for some functions in C (:pull:`1225`)
-	- Add a stub interface for util module (:pull:`1226`)
-	- Recursing into directories to search for load order files (:pull:`1200`)
+	  (:pr:`1217`)
+	- Support Path as parameter for some functions in C (:pr:`1225`)
+	- Add a stub interface for util module (:pr:`1226`)
+	- Recursing into directories to search for load order files (:pr:`1200`)
 	- Fix program files folder for msi using mingw and some tweaks
-	  (:pull:`1236`)
+	  (:pr:`1236`)
 
 #)  New or improved hooks for:
-	- _cffi_backend (cffi) (:pull:`1150`)
-	- googleapiclient (:pull:`1151`, :issue:`1147`)
-	- PyQt5 hooks (:pull:`1148`, :pull:`1155`, :pull:`1156`, :issue:`631`,
+	- _cffi_backend (cffi) (:pr:`1150`)
+	- googleapiclient (:pr:`1151`, :issue:`1147`)
+	- PyQt5 hooks (:pr:`1148`, :pr:`1155`, :pr:`1156`, :issue:`631`,
 	  :issue:`846`, :issue:`972`, :issue:`1119`)
-	- PySide2 (:pull:`1183`)
+	- PySide2 (:pr:`1183`)
 	- tzdata, zoneinfo and backports.zoneinfo
-	  (:pull:`1198`, :pull:`1204`, :pull:`1208`)
-	- pyzmq (:pull:`1199`)
-	- numpy+mkl in conda (:pull:`1205`)
+	  (:pr:`1198`, :pr:`1204`, :pr:`1208`)
+	- pyzmq (:pr:`1199`)
+	- numpy+mkl in conda (:pr:`1205`)
 
 #)  Samples:
-	- Fix code of some samples (:pull:`1145`)
-	- Remove outdated sample (:pull:`1157`)
-	- Improve sample to support pyzmq < 20 and timeout (:pull:`1190`)
-	- Tweak pyqt5 and pyside2 samples (:pull:`1180`)
-	- Improve PyQt5 and PySide2 samples (:pull:`1192`)
+	- Fix code of some samples (:pr:`1145`)
+	- Remove outdated sample (:pr:`1157`)
+	- Improve sample to support pyzmq < 20 and timeout (:pr:`1190`)
+	- Tweak pyqt5 and pyside2 samples (:pr:`1180`)
+	- Improve PyQt5 and PySide2 samples (:pr:`1192`)
 
 #)  Documentation:
 	- Make distutils help and documentation more in line with cxfreeze script
-	  (:pull:`1175`)
-	- Update distutils build_exe help in docs (:pull:`1176`)
-	- Remove distutils references in main docs (:pull:`1196`)
-	- Better explain the miniconda installation (:pull:`1209`)
-	- Minor updates to docs (:pull:`1230`)
+	  (:pr:`1175`)
+	- Update distutils build_exe help in docs (:pr:`1176`)
+	- Remove distutils references in main docs (:pr:`1196`)
+	- Better explain the miniconda installation (:pr:`1209`)
+	- Minor updates to docs (:pr:`1230`)
 
 
 Version 6.7 (July 2021)
 -----------------------
 
 #)  Improvements, refactor and bugfix for all systems:
-	- Implemented multi levels for build_exe silent option (:pull:`883`)
-	- Corrected silent_level to default to 0 (to agree with documentation) (:pull:`1046`)
-	- Split up Freezer object (:pull:`1035`)
-	- Ignores nonexistent files in dist-info (:pull:`1038`, :issue:`1034`)
-	- Use setuptools build_ext to compile base executables and with names that dependes on python version and platform (:pull:`1054`)
-	- Use sysconfig and others instead of some distutils modules (:pull:`1055`)
-	- Handle the pre-copy task with the _pre_copy_hook method in the freezer (:pull:`1069`)
-	- New method to handle platform dependent resources in the freezer (:pull:`1070`)
-	- Minor tweaks to tidy up the code (:pull:`1079`)
-	- Use wchar if possible. (:pull:`1080`)
-	- Create cx_Freeze/bases if it doesn't exist (:pull:`1082`)
-	- Use option blocks in the docs and add command line help from commands (:pull:`1097`)
-	- Use a valid example in docs (:pull:`1098`)
-	- Cleanup versionchanged; limit to 6.0+ (:pull:`1099`)
-	- Improve the text of build_exe bin_* (:pull:`1100`)
-	- Use of some Sphinx features to organize a bit (:pull:`1102`, :pull:`1138`, :pull:`1139`)
-	- Implement Freeze._default_bin_path_includes for all platforms (:pull:`1108`)
-	- Move some code to startup to unify the use of environ (:pull:`1112`)
-	- Small changes to resolve code warnings (:pull:`1122`)
-	- New method Module.update_distribution to update the cached distribution for the frozen executable (:pull:`1123`)
-	- Implement DistributionCache.from_name (:pull:`1135`)
-	- Use of black and pyupgrade (:pull:`1056`, :pull:`1085`, :pull:`1086`, :pull:`1086`, :pull:`1057`)
-	- Use pep8 names in private functions in freezer (:pull:`1068`)
+	- Implemented multi levels for build_exe silent option (:pr:`883`)
+	- Corrected silent_level to default to 0 (to agree with documentation) (:pr:`1046`)
+	- Split up Freezer object (:pr:`1035`)
+	- Ignores nonexistent files in dist-info (:pr:`1038`, :issue:`1034`)
+	- Use setuptools build_ext to compile base executables and with names that dependes on python version and platform (:pr:`1054`)
+	- Use sysconfig and others instead of some distutils modules (:pr:`1055`)
+	- Handle the pre-copy task with the _pre_copy_hook method in the freezer (:pr:`1069`)
+	- New method to handle platform dependent resources in the freezer (:pr:`1070`)
+	- Minor tweaks to tidy up the code (:pr:`1079`)
+	- Use wchar if possible. (:pr:`1080`)
+	- Create cx_Freeze/bases if it doesn't exist (:pr:`1082`)
+	- Use option blocks in the docs and add command line help from commands (:pr:`1097`)
+	- Use a valid example in docs (:pr:`1098`)
+	- Cleanup versionchanged; limit to 6.0+ (:pr:`1099`)
+	- Improve the text of build_exe bin_* (:pr:`1100`)
+	- Use of some Sphinx features to organize a bit (:pr:`1102`, :pr:`1138`, :pr:`1139`)
+	- Implement Freeze._default_bin_path_includes for all platforms (:pr:`1108`)
+	- Move some code to startup to unify the use of environ (:pr:`1112`)
+	- Small changes to resolve code warnings (:pr:`1122`)
+	- New method Module.update_distribution to update the cached distribution for the frozen executable (:pr:`1123`)
+	- Implement DistributionCache.from_name (:pr:`1135`)
+	- Use of black and pyupgrade (:pr:`1056`, :pr:`1085`, :pr:`1086`, :pr:`1086`, :pr:`1057`)
+	- Use pep8 names in private functions in freezer (:pr:`1068`)
 #)  Linux:
-	- Fix the support for unix-like systems (:pull:`1067`, :issue:`1061`)
-	- check in advance whether the dependency should be copied to avoid changing the rpath unnecessarily. (:pull:`1091`, :issue:`1048`)
-	- Fix issue with strip in bdist_rpm (:pull:`1092`, :issue:`1048`)
-	- Improve installation docs for linux (:pull:`1095`)
-	- Fix a buffer overflow introduced in :pull:`872` (:pull:`1047`)
-	- Fix another flaw introduced in :pull:`872` (:pull:`1111`)
-	- Fix regression introduced in :pull:`995` (and (:pull:`985`)) (:pull:`1090`, :issue:`1029`)
+	- Fix the support for unix-like systems (:pr:`1067`, :issue:`1061`)
+	- check in advance whether the dependency should be copied to avoid changing the rpath unnecessarily. (:pr:`1091`, :issue:`1048`)
+	- Fix issue with strip in bdist_rpm (:pr:`1092`, :issue:`1048`)
+	- Improve installation docs for linux (:pr:`1095`)
+	- Fix a buffer overflow introduced in :pr:`872` (:pr:`1047`)
+	- Fix another flaw introduced in :pr:`872` (:pr:`1111`)
+	- Fix regression introduced in :pr:`995` (and (:pr:`985`)) (:pr:`1090`, :issue:`1029`)
 #)  macOS:
-	- Added CFBundlePackageType and NSHighResolutionCapable by default to Info.plist of Darwin bundles (:pull:`1031`, :issue:`239`)
+	- Added CFBundlePackageType and NSHighResolutionCapable by default to Info.plist of Darwin bundles (:pr:`1031`, :issue:`239`)
 #)  Windows:
-	- Transform filename to msilib.Binary for binary data (:pull:`1024`, :issue:`1019`)
-	- Add extension registration on Windows (:pull:`1032`)
-	- Support for icons with non-ascii names (:pull:`1066`)
-	- New C function to update the PE checksum (or fix it in case it is zero) (:pull:`1071`, :issue:`315`, :issue:`1059`)
-	- Use setuptools command to install a include file (:pull:`1072`)
-	- Fix the support for non-ascii names in windows (:pull:`1077`, :issue:`835`)
-	- PyEval_InitThreads is unnecessary in py37+ and is deprecated in py39 (:pull:`1081`)
-	- Set working directory in the Desktop shortcut (:pull:`1083`, :issue:`48`, :issue:`623`)
-	- Improve documentation about bdist_msi (:pull:`1084`, :issue:`48`)
+	- Transform filename to msilib.Binary for binary data (:pr:`1024`, :issue:`1019`)
+	- Add extension registration on Windows (:pr:`1032`)
+	- Support for icons with non-ascii names (:pr:`1066`)
+	- New C function to update the PE checksum (or fix it in case it is zero) (:pr:`1071`, :issue:`315`, :issue:`1059`)
+	- Use setuptools command to install a include file (:pr:`1072`)
+	- Fix the support for non-ascii names in windows (:pr:`1077`, :issue:`835`)
+	- PyEval_InitThreads is unnecessary in py37+ and is deprecated in py39 (:pr:`1081`)
+	- Set working directory in the Desktop shortcut (:pr:`1083`, :issue:`48`, :issue:`623`)
+	- Improve documentation about bdist_msi (:pr:`1084`, :issue:`48`)
 #)  New or improved hooks for:
-	- pydantic (:pull:`1074`, :issue:`1052`)
-	- scikit-image (skimage) (:pull:`1104`, :issue:`1101`)
-	- plotly (:pull:`1105`, :issue:`1101`)
-	- scipy (versions 1.6.3 to 1.7.0) (:pull:`1106`, :pull:`1134`, :issue:`1101`, :issue:`1129`)
-	- numpy and numpy+mkl (versions 1.19.5 to 1.21.0) (:pull:`1113`, :pull:`1125`, :issue:`739`, :issue:`1110`)
-	- six (:pull:`1115`)
-	- hdfdict, h5py_wrapper and pytest-runner (:pull:`1116`, :pull:`1124`, :issue:`1118`)
+	- pydantic (:pr:`1074`, :issue:`1052`)
+	- scikit-image (skimage) (:pr:`1104`, :issue:`1101`)
+	- plotly (:pr:`1105`, :issue:`1101`)
+	- scipy (versions 1.6.3 to 1.7.0) (:pr:`1106`, :pr:`1134`, :issue:`1101`, :issue:`1129`)
+	- numpy and numpy+mkl (versions 1.19.5 to 1.21.0) (:pr:`1113`, :pr:`1125`, :issue:`739`, :issue:`1110`)
+	- six (:pr:`1115`)
+	- hdfdict, h5py_wrapper and pytest-runner (:pr:`1116`, :pr:`1124`, :issue:`1118`)
 #)  Samples:
-	- pydantic (:pull:`1074`)
-	- pythonnet-demo (python.NET sample based on it's demo) (:pull:`1088`, :issue:`1049`)
+	- pydantic (:pr:`1074`)
+	- pythonnet-demo (python.NET sample based on it's demo) (:pr:`1088`, :issue:`1049`)
 
 Version 6.6 (April 2021)
 ------------------------
 
 #)  Improvements:
-	- Enable python -m cx_Freeze syntax (:pull:`899`)
-	- Standardize InitializePython on all platforms. (:pull:`872`)
-	- Store a copy of cached dist-info (:pull:`958`)
-	- Suppress additional output if --silent has been set. (:pull:`830`)
-	- Only copy a file if should copy a file (:pull:`995`, :issue:`256`)
-	- Refactor cache dist-info files to be extended (:pull:`957`)
-	- Remove subfolders belonging to excluded modules (:pull:`922`)
+	- Enable python -m cx_Freeze syntax (:pr:`899`)
+	- Standardize InitializePython on all platforms. (:pr:`872`)
+	- Store a copy of cached dist-info (:pr:`958`)
+	- Suppress additional output if --silent has been set. (:pr:`830`)
+	- Only copy a file if should copy a file (:pr:`995`, :issue:`256`)
+	- Refactor cache dist-info files to be extended (:pr:`957`)
+	- Remove subfolders belonging to excluded modules (:pr:`922`)
 #)  Linux:
-	- Implements a new Patchelf interface for patching ELF files (:pull:`966`)
-	- Improve the resolution of dependencies [Linux] (:pull:`967`)
-	- Use -rpath explicitly (:pull:`940`)
+	- Implements a new Patchelf interface for patching ELF files (:pr:`966`)
+	- Improve the resolution of dependencies [Linux] (:pr:`967`)
+	- Use -rpath explicitly (:pr:`940`)
 #)  macOS:
-	- Another way to detected the use of LTO (:pull:`895`)
-	- Failed to create DMG file (applications_shortcut=True`) (:pull:`927`, :issue:`925`)
-	- Fix plistlib.load call in macdist [py39] (:pull:`926`, :issue:`924`)
-	- Improvements to dependency resolution on Darwin (:pull:`887`)
-	- Tweak to only print warning if attempting to copy two mach-o files to the same location.  Only the first file used. (:pull:`915`, :issue:`913`)
+	- Another way to detected the use of LTO (:pr:`895`)
+	- Failed to create DMG file (applications_shortcut=True`) (:pr:`927`, :issue:`925`)
+	- Fix plistlib.load call in macdist [py39] (:pr:`926`, :issue:`924`)
+	- Improvements to dependency resolution on Darwin (:pr:`887`)
+	- Tweak to only print warning if attempting to copy two mach-o files to the same location.  Only the first file used. (:pr:`915`, :issue:`913`)
 #)  Windows:
-	- Avoid duplicates of libpythonXX.so and pythonXX.ddl (:pull:`978`)
-	- Rebirth of --include-msvcr - real support for vcruntime dlls [windows] (:pull:`973`, :issue:`367`)
-	- Set lib directory as default for dll search [windows] (:pull:`1000`)
-	- Speedup compiling on windows (:pull:`993`)
-	- Support for delay load [mingw] (:pull:`1002`)
-	- Support for delay load [windows] (:pull:`1001`)
-	- Update to cx_Logging 3.0 (:pull:`909`, :pull:`994`, :pull:`996`, :pull:`998`, :pull:`1012`)
-	- Use the delay load to compile Win32Service (:pull:`1003`)
+	- Avoid duplicates of libpythonXX.so and pythonXX.ddl (:pr:`978`)
+	- Rebirth of --include-msvcr - real support for vcruntime dlls [windows] (:pr:`973`, :issue:`367`)
+	- Set lib directory as default for dll search [windows] (:pr:`1000`)
+	- Speedup compiling on windows (:pr:`993`)
+	- Support for delay load [mingw] (:pr:`1002`)
+	- Support for delay load [windows] (:pr:`1001`)
+	- Update to cx_Logging 3.0 (:pr:`909`, :pr:`994`, :pr:`996`, :pr:`998`, :pr:`1012`)
+	- Use the delay load to compile Win32Service (:pr:`1003`)
 #)  New or improved hooks for:
-	- llvmlite (:pull:`1016`)
-	- matplotlib (:pull:`971`)
-	- mkl-service (:pull:`975`)
-	- numpy (:pull:`970`, :pull:`968`)
-	- pandas (:pull:`969`)
-	- pycountry (:pull:`956`)
-	- pyodbc (:pull:`1018`)
-	- pyqtgraph (:pull:`1015`)
-	- pyzmq 22 (:pull:`953`)
+	- llvmlite (:pr:`1016`)
+	- matplotlib (:pr:`971`)
+	- mkl-service (:pr:`975`)
+	- numpy (:pr:`970`, :pr:`968`)
+	- pandas (:pr:`969`)
+	- pycountry (:pr:`956`)
+	- pyodbc (:pr:`1018`)
+	- pyqtgraph (:pr:`1015`)
+	- pyzmq 22 (:pr:`953`)
 #)  Samples:
-	- Add sample for pycountry (:pull:`955`)
-	- Add sample for pyzmq (:pull:`954`)
-	- Update the service sample and build (:pull:`886`)
-	- Update PySide2 sample (:pull:`1011`)
-	- Tweak samples (:pull:`888`)
+	- Add sample for pycountry (:pr:`955`)
+	- Add sample for pyzmq (:pr:`954`)
+	- Update the service sample and build (:pr:`886`)
+	- Update PySide2 sample (:pr:`1011`)
+	- Tweak samples (:pr:`888`)
 #)  Bugfixes:
-	- Force encoding of generated files to utf-8 (:pull:`1005`, :issue:`989`)
-	- cx_Logging as submodule (:pull:`874`, :issue:`866`)
-	- Avoid the __main__ module from pip wheel (:pull:`894`, :issue:`891`)
-	- Fix regression introduced in PR #857 (:pull:`878`, :issue:`875`)
-	- Fix typo (:pull:`877`, :issue:`866`)
-	- Fix the pillow sample (:pull:`876`)
-	- Fix the docs (:pull:`870`)
-	- Fix regression introduced in #978 (:pull:`1010`)
-	- Standardizes the target directory Freezer (and cxfreeze`) (:pull:`999`)
-	- Fix regression introduced in PR #973 (:pull:`976`)
-	- Fix PATH for anaconda/miniconda (:pull:`974`)
-	- Starts freezing in a clean directory (:pull:`965`)
-	- Fix a regression introduced in #798 (:pull:`945`, :issue:`932`)
-	- fix regressions introduced in #843 (:pull:`920`, :issue:`919`)
-	- Some packages use a directory with vendored modules (:pull:`906`, :issue:`900`)
-	- IncludeModule has priority over ExcludeModule (:pull:`904`)
-	- Better error checks (:pull:`902`)
-	- Support for executable names that may not be valid identifiers (:pull:`889`, :issue:`884`)
-	- Accept file without extension as source file to be backwards compatible (:pull:`893`)
+	- Force encoding of generated files to utf-8 (:pr:`1005`, :issue:`989`)
+	- cx_Logging as submodule (:pr:`874`, :issue:`866`)
+	- Avoid the __main__ module from pip wheel (:pr:`894`, :issue:`891`)
+	- Fix regression introduced in PR #857 (:pr:`878`, :issue:`875`)
+	- Fix typo (:pr:`877`, :issue:`866`)
+	- Fix the pillow sample (:pr:`876`)
+	- Fix the docs (:pr:`870`)
+	- Fix regression introduced in #978 (:pr:`1010`)
+	- Standardizes the target directory Freezer (and cxfreeze`) (:pr:`999`)
+	- Fix regression introduced in PR #973 (:pr:`976`)
+	- Fix PATH for anaconda/miniconda (:pr:`974`)
+	- Starts freezing in a clean directory (:pr:`965`)
+	- Fix a regression introduced in #798 (:pr:`945`, :issue:`932`)
+	- fix regressions introduced in #843 (:pr:`920`, :issue:`919`)
+	- Some packages use a directory with vendored modules (:pr:`906`, :issue:`900`)
+	- IncludeModule has priority over ExcludeModule (:pr:`904`)
+	- Better error checks (:pr:`902`)
+	- Support for executable names that may not be valid identifiers (:pr:`889`, :issue:`884`)
+	- Accept file without extension as source file to be backwards compatible (:pr:`893`)
 #)  Refactor:
-	- Update readme (:pull:`1022`)
-	- Update installation docs (:pull:`1021`)
-	- Modify cxfreeze script a bit (:pull:`1009`)
-	- Restructure ConstantModule (:pull:`1004`)
-	- Invert the assignment to create a new list (:pull:`987`)
-	- Refactor Freezer init (:pull:`985`)
-	- New module exception (:pull:`984`)
-	- Separates the freezer module classes (:pull:`983`)
-	- Update code style in Modules (:pull:`982`)
-	- build docs in build dir at project's root (:pull:`981`)
-	- Minor update to code style (:pull:`980`)
-	- update faq a bit (:pull:`977`)
-	- Cleanup freezer copy file method (:pull:`964`)
-	- Typo (:pull:`962`)
-	- Change detection order and tweak formatting (:pull:`961`)
-	- Refactor Module class attributes (:pull:`960`)
-	- Fade to black (:pull:`946`, :pull:`1020`)
-	- Distribute samples only with source code (:pull:`941`)
-	- Add badges (:pull:`944`)
-	- Revise docs a bit  (:pull:`943`)
-	- Update in the docs the use of main branch (:pull:`942`)
-	- remove unused files (:pull:`910`)
-	- Update build-wheel (:pull:`903`)
-	- Revert previous commit and fix the ident only (:pull:`882`)
-	- Fix potential errors (:pull:`881`)
-	- Code analysis (:pull:`880`)
+	- Update readme (:pr:`1022`)
+	- Update installation docs (:pr:`1021`)
+	- Modify cxfreeze script a bit (:pr:`1009`)
+	- Restructure ConstantModule (:pr:`1004`)
+	- Invert the assignment to create a new list (:pr:`987`)
+	- Refactor Freezer init (:pr:`985`)
+	- New module exception (:pr:`984`)
+	- Separates the freezer module classes (:pr:`983`)
+	- Update code style in Modules (:pr:`982`)
+	- build docs in build dir at project's root (:pr:`981`)
+	- Minor update to code style (:pr:`980`)
+	- update faq a bit (:pr:`977`)
+	- Cleanup freezer copy file method (:pr:`964`)
+	- Typo (:pr:`962`)
+	- Change detection order and tweak formatting (:pr:`961`)
+	- Refactor Module class attributes (:pr:`960`)
+	- Fade to black (:pr:`946`, :pr:`1020`)
+	- Distribute samples only with source code (:pr:`941`)
+	- Add badges (:pr:`944`)
+	- Revise docs a bit  (:pr:`943`)
+	- Update in the docs the use of main branch (:pr:`942`)
+	- remove unused files (:pr:`910`)
+	- Update build-wheel (:pr:`903`)
+	- Revert previous commit and fix the ident only (:pr:`882`)
+	- Fix potential errors (:pr:`881`)
+	- Code analysis (:pr:`880`)
 
 Version 6.5 (January 2021)
 ---------------------------
 
 #)  Improvements:
-	- Refactor ModuleFinder to use importlib.machinery (:pull:`811`)
-	- Executable target_name now has support for names with version (:pull:`857`)
+	- Refactor ModuleFinder to use importlib.machinery (:pr:`811`)
+	- Executable target_name now has support for names with version (:pr:`857`)
 	- The name of the target executable can be modified after the build
-	  (:pull:`858`, :issue:`703`)
-	- Use codeType.replace when in py38+ (optimized) (:pull:`836`)
-	- Use a configuration file for Read the Docs (:pull:`818`)
+	  (:pr:`858`, :issue:`703`)
+	- Use codeType.replace when in py38+ (optimized) (:pr:`836`)
+	- Use a configuration file for Read the Docs (:pr:`818`)
 	- Modernize code (Type annotation, PEP8, black, refactor)
-	  (:pull:`815`, :pull:`832`, :pull:`837`, :pull:`838`, :pull:`839`,
-	  :pull:`840`, :pull:`841`, :pull:`842`, :pull:`843`, :pull:`859`,
-	  :pull:`860`, :pull:`861`, :pull:`864`, :pull:`865`, :pull:`868`)
+	  (:pr:`815`, :pr:`832`, :pr:`837`, :pr:`838`, :pr:`839`,
+	  :pr:`840`, :pr:`841`, :pr:`842`, :pr:`843`, :pr:`859`,
+	  :pr:`860`, :pr:`861`, :pr:`864`, :pr:`865`, :pr:`868`)
 #)  Windows:
 	- Check if icon is valid
-	  (:issue:`856`, :pull:`851`, :issue:`824`, :issue:`379`)
-	- Warning about python from Windows Store (:pull:`867`, :issue:`856`)
+	  (:issue:`856`, :pr:`851`, :issue:`824`, :issue:`379`)
+	- Warning about python from Windows Store (:pr:`867`, :issue:`856`)
 #)  macOS:
-	- Implemented a "plist_items" option on bdist_mac command (:pull:`827`)
-	- Remove deprecated methods in macdist (:pull:`810`)
-	- Fix a regression for macOS (:pull:`816`, :issue:`809`)
-	- Fix a bug using macOS on Github Actions (:pull:`812`)
-	- Marked rpath-lib-folder option as depreciated. (:pull:`834`)
+	- Implemented a "plist_items" option on bdist_mac command (:pr:`827`)
+	- Remove deprecated methods in macdist (:pr:`810`)
+	- Fix a regression for macOS (:pr:`816`, :issue:`809`)
+	- Fix a bug using macOS on Github Actions (:pr:`812`)
+	- Marked rpath-lib-folder option as depreciated. (:pr:`834`)
 #)  New or improved hooks for:
-	- cryptography (:pull:`817`, :issue:`814`)
-	- google.cloud.storage (:pull:`821`)
-	- matplotlib (:pull:`807`, :issue:`805`)
-	- pygments (:pull:`863`, :issue:`862`)
-	- zoneinfo/tzdata (and backports.zoneinfo) (:pull:`854`)
+	- cryptography (:pr:`817`, :issue:`814`)
+	- google.cloud.storage (:pr:`821`)
+	- matplotlib (:pr:`807`, :issue:`805`)
+	- pygments (:pr:`863`, :issue:`862`)
+	- zoneinfo/tzdata (and backports.zoneinfo) (:pr:`854`)
 #)  Samples:
-	- Better pytz sample (:pull:`852`)
-	- Sample for new library zoneinfo (py39) (:pull:`853`)
-	- Sample to demonstrate the use a valid and an invalid icon (:pull:`850`)
+	- Better pytz sample (:pr:`852`)
+	- Sample for new library zoneinfo (py39) (:pr:`853`)
+	- Sample to demonstrate the use a valid and an invalid icon (:pr:`850`)
 #)  Bugfixes:
 	- cx_Freeze.__version__ should be the package version
-	  (:pull:`806`, :issue:`804`)
-	- pin importlib_metadata to >=3.1.1 (:pull:`819`, :pull:`820`, :pull:`822`)
-	- Correct test failures when initializing ModuleFinder (:pull:`833`)
+	  (:pr:`806`, :issue:`804`)
+	- pin importlib_metadata to >=3.1.1 (:pr:`819`, :pr:`820`, :pr:`822`)
+	- Correct test failures when initializing ModuleFinder (:pr:`833`)
 
 
 Version 6.4 (November 2020)
 ---------------------------
 
 #)  Improvements:
-	- Improved the resolution of dependencies in darwin MachO files (:pull:`590`)
-	- Documentation (:pull:`783`, :pull:`796`)
-	- Release using GitHub Actions CI/CD workflows (:pull:`797`)
-	- Apply pyupgrade (:pull:`801`)
+	- Improved the resolution of dependencies in darwin MachO files (:pr:`590`)
+	- Documentation (:pr:`783`, :pr:`796`)
+	- Release using GitHub Actions CI/CD workflows (:pr:`797`)
+	- Apply pyupgrade (:pr:`801`)
 	- Modernize code (Type annotation, PEP8, black, refactor, cleanup)
-	  (:pull:`785`, :pull:`776`, :pull:`314`, :pull:`787`, :pull:`784`,
-	  :pull:`786`, :pull:`788`, :pull:`789`, :pull:`793`, :pull:`794`,
-	  :pull:`780`, :pull:`795`, :pull:`799`, :pull:`800`, :pull:`790`,
-	  :pull:`798`)
+	  (:pr:`785`, :pr:`776`, :pr:`314`, :pr:`787`, :pr:`784`,
+	  :pr:`786`, :pr:`788`, :pr:`789`, :pr:`793`, :pr:`794`,
+	  :pr:`780`, :pr:`795`, :pr:`799`, :pr:`800`, :pr:`790`,
+	  :pr:`798`)
 #)  New or improved hooks for:
-	- PyQt5 (:pull:`718`, :pull:`791`)
+	- PyQt5 (:pr:`718`, :pr:`791`)
 #)  Samples:
 	- Added a sample to illustrate problem with importlib.util.find_spec
-	  (:pull:`735`)
-	- Sample for bdist_msi, summary_data option (:pull:`775`)
+	  (:pr:`735`)
+	- Sample for bdist_msi, summary_data option (:pr:`775`)
 	- README for some samples; remove requirements.txt to avoid to be
-	  interpreted by some sites as the requirements of cx_Freeze (:pull:`802`)
+	  interpreted by some sites as the requirements of cx_Freeze (:pr:`802`)
 #)  Bugfixes:
-	- Cause MSI file to be released at the end of bdist_msi command (:pull:`781`)
+	- Cause MSI file to be released at the end of bdist_msi command (:pr:`781`)
 
 
 Version 6.3 (October 2020)
 --------------------------
 
 #)  Improvements:
-	- Improve metadata using importlib.metadata (:pull:`697`)
-	- New options in ``cxfreeze`` script; documentation updated (:pull:`742`)
+	- Improve metadata using importlib.metadata (:pr:`697`)
+	- New options in ``cxfreeze`` script; documentation updated (:pr:`742`)
 	- The command line parser was rewritten and modernised using argparse
-	  (:pull:`741`)
-	- Documentation (:pull:`740`, :pull:`722`, :pull:`720`)
-	- Cleanups (:pull:`766`, :pull:`746`, :pull:`744`, :pull:`743`,
-	  :pull:`736`, :pull:`726`, :pull:`724`, :pull:`721`, :pull:`712`)
+	  (:pr:`741`)
+	- Documentation (:pr:`740`, :pr:`722`, :pr:`720`)
+	- Cleanups (:pr:`766`, :pr:`746`, :pr:`744`, :pr:`743`,
+	  :pr:`736`, :pr:`726`, :pr:`724`, :pr:`721`, :pr:`712`)
 #)  New or improved hooks for:
-	- google.cloud.storage (:pull:`708`)
-	- google.crc32c (:pull:`737`)
-	- matplotlib and numpy (:pull:`695`, :issue:`692`)
-	- scipy (:pull:`725`)
-	- sysconfig (:pull:`727`, :pull:`715`)
-	- tensorflow (:pull:`710`)
+	- google.cloud.storage (:pr:`708`)
+	- google.crc32c (:pr:`737`)
+	- matplotlib and numpy (:pr:`695`, :issue:`692`)
+	- scipy (:pr:`725`)
+	- sysconfig (:pr:`727`, :pr:`715`)
+	- tensorflow (:pr:`710`)
 #)  Linux:
-	- Improve copy dependent files relative to source module file (:pull:`704`)
+	- Improve copy dependent files relative to source module file (:pr:`704`)
 #)  Windows:
 	- Check if upgrade-code is valid and document the valid format
-	  (:pull:`711`, :issue:`585`)
-	- Improve Windows GUID documentation (:pull:`749`)
+	  (:pr:`711`, :issue:`585`)
+	- Improve Windows GUID documentation (:pr:`749`)
 	- Added option to bdist_msi to specify information for msi summary
-	  information stream (:pull:`760`)
+	  information stream (:pr:`760`)
 #)  macOS:
 	- Fix the syspath for some version of python on macOS
-	  (:pull:`719`, :issue:`667`)
+	  (:pr:`719`, :issue:`667`)
 #)  Samples:
-	- Add pyside2 sample (:pull:`664`)
-	- A sample for testing PyQt5 included in zip package (:pull:`717`)
-	- Add pandas sample (:pull:`709`)
+	- Add pyside2 sample (:pr:`664`)
+	- A sample for testing PyQt5 included in zip package (:pr:`717`)
+	- Add pandas sample (:pr:`709`)
 	- Added sample code to show the use of ConstantsModule / BUILD_CONSTANTS
-	  (:pull:`729`)
+	  (:pr:`729`)
 #)  Bugfixes:
 	- Ensure the copy of default python libraries in all platforms
-	  (:pull:`706`, :issue:`701`)
+	  (:pr:`706`, :issue:`701`)
 	- Remove warning 'Distutils was imported before Setuptools'
-	  (:pull:`694`, :issue:`693`)
-	- Fix the use of compress and desambiguate the use of stat (:pull:`738`)
+	  (:pr:`694`, :issue:`693`)
+	- Fix the use of compress and desambiguate the use of stat (:pr:`738`)
 	- Small fix to handle a build constant that includes a "=" symbol
-	  (:pull:`728`)
-	- Fix issue when module.file is None (:pull:`707`)
-	- Fix detect namespaces in py35 (:pull:`700`)
+	  (:pr:`728`)
+	- Fix issue when module.file is None (:pr:`707`)
+	- Fix detect namespaces in py35 (:pr:`700`)
 	- Set python initialization flags prior to Py_SetPath call to avoid
-	  warnings (:pull:`751`)
+	  warnings (:pr:`751`)
 
 
 Version 6.2 (July 2020)
 -----------------------
 
 #)  New or improved hooks for:
-	- aiofiles (:pull:`600`)
-	- babel (:pull:`577`)
-	- bcrypt (:pull:`583`, :issue:`581`)
-	- certifi (:pull:`690`)
-	- cffi.cparser (:pull:`603`)
-	- ctypes (for MSYS2 mingw) (:pull:`565`)
-	- matplotlib (:pull:`574`, :issue:`569`)
-	- pikepdf (:pull:`604`)
-	- lxml (:pull:`604`)
-	- pycryptodome (:pull:`602`)
-	- pygments (:pull:`604`)
-	- pkg_resources (:pull:`584`, :issue:`579`)
-	- pytest (:pull:`617`)
-	- setuptools (:pull:`608`)
-	- uvloop (:pull:`689`)
+	- aiofiles (:pr:`600`)
+	- babel (:pr:`577`)
+	- bcrypt (:pr:`583`, :issue:`581`)
+	- certifi (:pr:`690`)
+	- cffi.cparser (:pr:`603`)
+	- ctypes (for MSYS2 mingw) (:pr:`565`)
+	- matplotlib (:pr:`574`, :issue:`569`)
+	- pikepdf (:pr:`604`)
+	- lxml (:pr:`604`)
+	- pycryptodome (:pr:`602`)
+	- pygments (:pr:`604`)
+	- pkg_resources (:pr:`584`, :issue:`579`)
+	- pytest (:pr:`617`)
+	- setuptools (:pr:`608`)
+	- uvloop (:pr:`689`)
 #)  Linux:
-	- Pass command line arguments in current locale (:pull:`645`, :issue:`611`)
+	- Pass command line arguments in current locale (:pr:`645`, :issue:`611`)
 #)  Windows:
-	- Fixed multiprocessing pickling errors (:pull:`622`, :issue:`539`, :issue:`402`, :issue:`403`, :issue:`231`, :issue:`536`)
-	- Ensure the copy of default python libraries (:pull:`640`)
-	- Replace deprecated functions that will be removed in py4 - win32gui (:pull:`649`)
-	- Exclude Tkinter from loaded modules (:pull:`576`, :issue:`567`)
-	- Fixed "no module named 'scipy.spatial.cKDTree'" (:pull:`626`, :issue:`233`)
-	- Fixed "no module named 'multiprocessing.pool'" (:pull:`627`, :issue:`353`)
-	- Download cx_Logging to build Win32Service.exe when building from sources (:pull:`650`, :issue:`519`)
+	- Fixed multiprocessing pickling errors (:pr:`622`, :issue:`539`, :issue:`402`, :issue:`403`, :issue:`231`, :issue:`536`)
+	- Ensure the copy of default python libraries (:pr:`640`)
+	- Replace deprecated functions that will be removed in py4 - win32gui (:pr:`649`)
+	- Exclude Tkinter from loaded modules (:pr:`576`, :issue:`567`)
+	- Fixed "no module named 'scipy.spatial.cKDTree'" (:pr:`626`, :issue:`233`)
+	- Fixed "no module named 'multiprocessing.pool'" (:pr:`627`, :issue:`353`)
+	- Download cx_Logging to build Win32Service.exe when building from sources (:pr:`650`, :issue:`519`)
 #)  macOS:
-	- Fixing modification of PATH for single user install (:pull:`614`, :issue:`613`)
-	- Make needed dirs when using include_resources (:pull:`633`)
-	- Check for Mach-O using byte strings to allow case of non unicode chars (:pull:`635`)
-	- Copy references from /usr/local (:pull:`648`)
+	- Fixing modification of PATH for single user install (:pr:`614`, :issue:`613`)
+	- Make needed dirs when using include_resources (:pr:`633`)
+	- Check for Mach-O using byte strings to allow case of non unicode chars (:pr:`635`)
+	- Copy references from /usr/local (:pr:`648`)
 #)  Documentation
-	- Update doc and faq (:pull:`564`, :pull:`663`, :pull:`688`)
-	- Initial work to be pep8 compliant (:pull:`572`, :pull:`582`)
+	- Update doc and faq (:pr:`564`, :pr:`663`, :pr:`688`)
+	- Initial work to be pep8 compliant (:pr:`572`, :pr:`582`)
 #)  Misc
 	- Fixed bug in ``cxfreeze`` script introduced in 6.1 (:issue:`560`).
-	- Remove old packages/modules names, do not report as missing (:pull:`605`)
-	- Better support for MSYS2 and Anaconda3 (:pull:`642`)
-	- Support python 3.5.2 and up (:pull:`606`)
-	- Support metadata to use by pkg_resources (:pull:`608`)
-	- New common function rebuild_code_object to be reusable (:pull:`629`)
-	- Fix optimize option in python 3.8 (:pull:`641`)
-	- Add --include-files option to ``cxfreeze`` script (:pull:`647`)
-	- Replace the value of __package__ directly in the code (:pull:`651`)
-	- Eliminate exclusion of ``dbm`` module since it is in Python 3 (:pull:`662`, :issue:`660`)
-	- Detect namespace packages (:pull:`669`, :pull:`668`)
-	- Installing from source requires setuptools (:pull:`687`)
-	- Remove PyUnicode_FromUnicode (:pull:`673`)
+	- Remove old packages/modules names, do not report as missing (:pr:`605`)
+	- Better support for MSYS2 and Anaconda3 (:pr:`642`)
+	- Support python 3.5.2 and up (:pr:`606`)
+	- Support metadata to use by pkg_resources (:pr:`608`)
+	- New common function rebuild_code_object to be reusable (:pr:`629`)
+	- Fix optimize option in python 3.8 (:pr:`641`)
+	- Add --include-files option to ``cxfreeze`` script (:pr:`647`)
+	- Replace the value of __package__ directly in the code (:pr:`651`)
+	- Eliminate exclusion of ``dbm`` module since it is in Python 3 (:pr:`662`, :issue:`660`)
+	- Detect namespace packages (:pr:`669`, :pr:`668`)
+	- Installing from source requires setuptools (:pr:`687`)
+	- Remove PyUnicode_FromUnicode (:pr:`673`)
 
 Version 6.1 (January 2020)
 --------------------------
 
-#)  Added support for Python 3.8 (:pull:`545`, :pull:`556`).
-#)  Added support for ``python setup.py develop`` (:pull:`502`).
+#)  Added support for Python 3.8 (:pr:`545`, :pr:`556`).
+#)  Added support for ``python setup.py develop`` (:pr:`502`).
 #)  Use ``console_scripts`` in ``entry_points`` so that the commands
     ``cxfreeze`` and ``cxfreeze-quickstart`` run on Windows without the need
-    for running a postinstall script (:pull:`511`).
+    for running a postinstall script (:pr:`511`).
 #)  Added support for switching from per-user to per-machine installations on
-    Windows (:pull:`507`).
+    Windows (:pr:`507`).
 #)  Fix installation if ``AlwaysInstallElevated`` policy is set on Windows
-    (:pull:`533`).
-#)  Updated default dependencies for Python 3 on Windows (:pull:`505`).
-#)  Removed unused code (:pull:`549`).
+    (:pr:`533`).
+#)  Updated default dependencies for Python 3 on Windows (:pr:`505`).
+#)  Removed unused code (:pr:`549`).
 #)  The default dependencies are now always copied into the lib folder instead
     of into the directory where the executable resides on Linux
-    (:pull:`518`).
+    (:pr:`518`).
 #)  Dependent files are now copied to the same relative directory as their
-    location in the source on Linux (:pull:`494`).
+    location in the source on Linux (:pr:`494`).
 #)  Added tests for commonly used packages like ``cryptography``, ``pillow``,
     ``sqlite``, ``pytz``, ``ctypes`` and ``distutils``
-    (:pull:`508`, :pull:`537`, :pull:`546`, :pull:`555`, :pull:`557`).
-#)  Fix regression with DLL dependencies introduced in 6.0 by :pull:`492`
-    due to case differences (:pull:`512`).
-#)  Fix regression with dependent files introduced in 6.0 by :pull:`297`
-    for platforms other than macOS (:pull:`516`).
-#)  The version of cx_Freeze is now defined in one place (:pull:`552`).
+    (:pr:`508`, :pr:`537`, :pr:`546`, :pr:`555`, :pr:`557`).
+#)  Fix regression with DLL dependencies introduced in 6.0 by :pr:`492`
+    due to case differences (:pr:`512`).
+#)  Fix regression with dependent files introduced in 6.0 by :pr:`297`
+    for platforms other than macOS (:pr:`516`).
+#)  The version of cx_Freeze is now defined in one place (:pr:`552`).
 #)  Eliminate exclusion of ``gestalt`` module on platforms other than macOS
     since it exists outside of macOS.
-#)  Improved hooks for ``sqlite3`` (:pull:`509`), ``cryptography``, and
-    ``tkinter`` (:pull:`559`).
-#)  Added hook for ``pytz`` (:pull:`554`).
+#)  Improved hooks for ``sqlite3`` (:pr:`509`), ``cryptography``, and
+    ``tkinter`` (:pr:`559`).
+#)  Added hook for ``pytz`` (:pr:`554`).
 #)  Improved hook infrastructure, permitting hooks to add constants that can
     be examined at runtime, determine whether a module is going to be stored in
     the file system and include files in the zip file.
-#)  Improved documentation (:pull:`510`).
+#)  Improved documentation (:pr:`510`).
 
 
 Version 6.0 (August 2019)
 -------------------------
 
-#)  Corrected support for Python 3.7 (:pull:`395`).
+#)  Corrected support for Python 3.7 (:pr:`395`).
 #)  Use importlib and other Python 3 improvements
-    (:pull:`484`, :pull:`485`, :pull:`486`, :pull:`490`).
-#)  Fixed issue with @rpath causing file copy errors on macOS (:pull:`307`).
+    (:pr:`484`, :pr:`485`, :pr:`486`, :pr:`490`).
+#)  Fixed issue with @rpath causing file copy errors on macOS (:pr:`307`).
 #)  Replaced file() with open() and use context manager to ensure the file
-    handle is closed and deleted (:pull:`348`).
-#)  Corrected invalid version handling in bdist_msi (:pull:`349`, :issue:`340`).
-#)  Corrected hook for clr module (:pull:`397`, :pull:`444`).
-#)  Corrected documentation for compress option (:pull:`358`).
+    handle is closed and deleted (:pr:`348`).
+#)  Corrected invalid version handling in bdist_msi (:pr:`349`, :issue:`340`).
+#)  Corrected hook for clr module (:pr:`397`, :pr:`444`).
+#)  Corrected documentation for compress option (:pr:`358`).
 #)  Ensure that the pythoncom and pywintypes DLLs are found in the lib
     directory and not in the base directory (:issue:`332`).
-#)  Always copy dependent files to root directory on macOS (:pull:`365`).
-#)  Skip self referencing archive on macOS (:pull:`364`, :issue:`304`).
-#)  Include doc directory in source distribution (:pull:`394`, :issue:`376`).
+#)  Always copy dependent files to root directory on macOS (:pr:`365`).
+#)  Skip self referencing archive on macOS (:pr:`364`, :issue:`304`).
+#)  Include doc directory in source distribution (:pr:`394`, :issue:`376`).
 #)  Force msilib module to be reloaded in order to allow for the generation of
-    multiple MSI packages in a single session (:pull:`419`).
-#)  Added hook for PyQt5.QtPrintSupport module (:pull:`401`).
+    multiple MSI packages in a single session (:pr:`419`).
+#)  Added hook for PyQt5.QtPrintSupport module (:pr:`401`).
 #)  Added ability to include an icon on the add/remove program window that pops
-    up during installation (:pull:`387`).
+    up during installation (:pr:`387`).
 #)  Prevent spurious errors from being printed during building on macOS by
     checking to see that a file is a Mach-O binary before adding it to the list
-    of files it is checking the reference of (:pull:`342`, :issue:`268`).
-#)  Avoid otool bug on macOS Yosemite (:pull:`297`, :issue:`292`).
+    of files it is checking the reference of (:pr:`342`, :issue:`268`).
+#)  Avoid otool bug on macOS Yosemite (:pr:`297`, :issue:`292`).
 #)  Added ability to specify environment variables that should be created when
-    an MSI package is installed (:pull:`266`).
+    an MSI package is installed (:pr:`266`).
 #)  Added support for including resources in an app bundle for macOS
-    (:pull:`423`).
-#)  Added absolute reference path option for macOS packages (:pull:`424`).
-#)  Added CFBundle identifier for macOS packages (:pull:`427`, :issue:`426`).
-#)  Added hook for copying SSL DLLs for Python 3.7+ on Windows (:pull:`470`).
-#)  Added -municode flag when building on Windows with mingw32 (:pull:`468`).
-#)  Added hook for pycparser (:pull:`446`).
+    (:pr:`423`).
+#)  Added absolute reference path option for macOS packages (:pr:`424`).
+#)  Added CFBundle identifier for macOS packages (:pr:`427`, :issue:`426`).
+#)  Added hook for copying SSL DLLs for Python 3.7+ on Windows (:pr:`470`).
+#)  Added -municode flag when building on Windows with mingw32 (:pr:`468`).
+#)  Added hook for pycparser (:pr:`446`).
 #)  Fixed hook for zmq so it doesn't fail when there is no bundled libzmq
-    library in the installed pyzmq package (:pull:`442`).
-#)  Print error when fetching dependent files fails (:pull:`435`).
+    library in the installed pyzmq package (:pr:`442`).
+#)  Print error when fetching dependent files fails (:pr:`435`).
 #)  Make executable writable before adding the icon
-    (:pull:`430`, :issue:`368`).
+    (:pr:`430`, :issue:`368`).
 #)  Dropped support for RPM and MSI packages for cx_Freeze itself since these
     are no longer supported by PyPI.
-#)  Fix building console app with mingw32 (:pull:`475`).
+#)  Fix building console app with mingw32 (:pr:`475`).
 #)  Force inclusion of the unicodedata module which is used by the socket
-    module, and possibly others (:pull:`476`).
-#)  Added hook for asyncio package (:pull:`477`).
-#)  Added hook for idna package (:pull:`478`).
-#)  Added hook for pkg_resources package (:pull:`481`).
-#)  Added hook for gevent (:pull:`495`).
+    module, and possibly others (:pr:`476`).
+#)  Added hook for asyncio package (:pr:`477`).
+#)  Added hook for idna package (:pr:`478`).
+#)  Added hook for pkg_resources package (:pr:`481`).
+#)  Added hook for gevent (:pr:`495`).
 #)  Force .exe extension to be included on Windows, so that the same setup code
-    can be used on both Linux and Windows (:pull:`489`).
-#)  Added hook for Pillow (:pull:`491`).
-#)  Improved hook for tkinter (:pull:`493`).
+    can be used on both Linux and Windows (:pr:`489`).
+#)  Added hook for Pillow (:pr:`491`).
+#)  Improved hook for tkinter (:pr:`493`).
 #)  Avoid attempting to check for dependent files on Windows when the file is
-    not an executable or DLL (:pull:`492`).
+    not an executable or DLL (:pr:`492`).
 #)  Ensure that only executable files are checked for dependencies in order to
     avoid spurious errors when checking for dependent files.
 #)  Improved hook for matplotlib.
@@ -1010,6 +1010,6 @@ Version 6.0b1 (November 2017)
     file that looks like pythonxx.zip (which is disabled on some platforms like
     Ubuntu), set the Python path to include a subdirectory called "lib" and a
     zip file "lib/library.zip" on all platforms.
-#)  Do not create version resource when version is omitted (:pull:`279`).
+#)  Do not create version resource when version is omitted (:pr:`279`).
 #)  Ensure the sqlite3 DLL is loaded in the same directory as the module which
     depends on it (:issue:`296`).

--- a/doc/src/releasenotes-7x.rst
+++ b/doc/src/releasenotes-7x.rst
@@ -4,459 +4,459 @@
 Version 7.2 (Jul 16)
 ----------------------
 
-#)  hooks: the optimized mode is the default for pip installations (:pull:`2500`) :user:`marcelotduarte`
-#)  bdist_rpm: drop rpm2_mode and refactor spec_file (:pull:`2488`) :user:`marcelotduarte`
-#)  bdist_appimage: remove zip file, propagate options, fixes docs (:pull:`2463`) :user:`marcelotduarte`
-#)  build(deps): bump coverage from 7.5.4 to 7.6.0 (:pull:`2498`) :user:`dependabot`
-#)  bdist_msi: add license for msi (:pull:`2472`) :user:`nick`
-#)  bdist_dmg: add dmgbuild as a dependency to improve mac dmg (:pull:`2442`) :user:`nick`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2494`) :user:`pre-commit-ci`
-#)  build(deps-dev): bump bump-my-version from 0.24.1 to 0.24.2 (:pull:`2492`) :user:`dependabot`
-#)  build(deps-dev): bump cibuildwheel from 2.19.1 to 2.19.2 (:pull:`2491`) :user:`dependabot`
-#)  tests: make test pass in conda-forge [osx, linux] (:pull:`2490`) :user:`marcelotduarte`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2487`) :user:`pre-commit-ci`
-#)  build(deps): bump sphinx-new-tab-link from 0.4.0 to 0.5.0 (:pull:`2486`) :user:`dependabot`
-#)  exception: Only re-export setuptools errors to avoid exceptions not handled correctly (:pull:`2485`) :user:`marcelotduarte`
-#)  build(deps-dev): bump bump-my-version from 0.24.0 to 0.24.1 (:pull:`2484`) :user:`dependabot`
-#)  hooks: add multiprocess (a multiprocessing fork) (:pull:`2475`) :user:`marcelotduarte`
-#)  build(deps-dev): bump bump-my-version from 0.23.0 to 0.24.0 (:pull:`2481`) :user:`dependabot`
-#)  sample: add sample for Gtk (:pull:`2364`) :user:`cedk`
-#)  chore: use setup-python-uv-action to cache uv packages (:pull:`2482`) :user:`marcelotduarte`
-#)  tests: make tests pass on mingw (:pull:`2476 regression) (#2480`) :user:`marcelotduarte`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2479`) :user:`pre-commit-ci`
-#)  build(deps): bump coverage from 7.5.3 to 7.5.4 (:pull:`2477`) :user:`dependabot`
-#)  tests: improve _compat to use in tests (:pull:`2476`) :user:`marcelotduarte`
-#)  tests: fix test_cli in archlinux (:pull:`2470`) :user:`marcelotduarte`
-#)  build(deps): bump update setuptools requirement to >=65.6.3,<71 (:pull:`2468`) :user:`marcelotduarte`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2464`) :user:`pre-commit-ci`
-#)  build(deps-dev): bump bump-my-version from 0.22.0 to 0.23.0 (:pull:`2462`) :user:`dependabot`
-#)  hooks: support numpy 2.0 (:pull:`2466`) :user:`marcelotduarte`
-#)  Bump version: 7.1.0-post0 → 7.1.1 [ci skip] (:pull:`2461`) :user:`marcelotduarte`
-#)  hooks: improve scikit-image (:pull:`2460`) :user:`marcelotduarte`
-#)  build(deps-dev): bump cibuildwheel from 2.19.0 to 2.19.1 (:pull:`2458`) :user:`dependabot`
-#)  hooks: add rasterio (:pull:`2455`) :user:`marcelotduarte`
-#)  hooks: fix #2382 regression / improve tests and docs (:pull:`2443`) :user:`marcelotduarte`
-#)  hooks: avoid exception when distribution is none (:pull:`2452`) :user:`marcelotduarte`
-#)  build(deps-dev): bump bump-my-version from 0.21.1 to 0.22.0 (:pull:`2450`) :user:`dependabot`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2448`) :user:`pre-commit-ci`
-#)  build(deps-dev): bump cibuildwheel from 2.18.1 to 2.19.0 (:pull:`2447`) :user:`dependabot`
-#)  doc: small revision of development/index [ci skip] (:pull:`2446`) :user:`marcelotduarte`
-#)  bdist_rpm: Fix string concat error due to order of op for + and or in RPM (:pull:`2444`) :user:`nicktindle`
-#)  cli: fix sys.path for cxfreeze command line (:pull:`2439`) :user:`marcelotduarte`
-#)  build(deps): bump pytest from 8.2.1 to 8.2.2 (:pull:`2437`) :user:`dependabot`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2434`) :user:`pre-commit-ci`
-#)  Bump version: 7.1.0 → 7.1.0-post0 [ci skip] (:pull:`2432`) :user:`marcelotduarte`
-#)  doc: msvc faq revision [ci skip] (:pull:`2429`) :user:`marcelotduarte`
-#)  build(deps): bump coverage from 7.5.2 to 7.5.3 (:pull:`2428`) :user:`dependabot`
-#)  hooks: fix pygobject hook for Linux (:pull:`2425`) :user:`marcelotduarte`
+#)  hooks: the optimized mode is the default for pip installations (:pr:`2500`) :user:`marcelotduarte`
+#)  bdist_rpm: drop rpm2_mode and refactor spec_file (:pr:`2488`) :user:`marcelotduarte`
+#)  bdist_appimage: remove zip file, propagate options, fixes docs (:pr:`2463`) :user:`marcelotduarte`
+#)  build(deps): bump coverage from 7.5.4 to 7.6.0 (:pr:`2498`) :user:`dependabot`
+#)  bdist_msi: add license for msi (:pr:`2472`) :user:`nick`
+#)  bdist_dmg: add dmgbuild as a dependency to improve mac dmg (:pr:`2442`) :user:`nick`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2494`) :user:`pre-commit-ci`
+#)  build(deps-dev): bump bump-my-version from 0.24.1 to 0.24.2 (:pr:`2492`) :user:`dependabot`
+#)  build(deps-dev): bump cibuildwheel from 2.19.1 to 2.19.2 (:pr:`2491`) :user:`dependabot`
+#)  tests: make test pass in conda-forge [osx, linux] (:pr:`2490`) :user:`marcelotduarte`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2487`) :user:`pre-commit-ci`
+#)  build(deps): bump sphinx-new-tab-link from 0.4.0 to 0.5.0 (:pr:`2486`) :user:`dependabot`
+#)  exception: Only re-export setuptools errors to avoid exceptions not handled correctly (:pr:`2485`) :user:`marcelotduarte`
+#)  build(deps-dev): bump bump-my-version from 0.24.0 to 0.24.1 (:pr:`2484`) :user:`dependabot`
+#)  hooks: add multiprocess (a multiprocessing fork) (:pr:`2475`) :user:`marcelotduarte`
+#)  build(deps-dev): bump bump-my-version from 0.23.0 to 0.24.0 (:pr:`2481`) :user:`dependabot`
+#)  sample: add sample for Gtk (:pr:`2364`) :user:`cedk`
+#)  chore: use setup-python-uv-action to cache uv packages (:pr:`2482`) :user:`marcelotduarte`
+#)  tests: make tests pass on mingw (:pr:`2476 regression) (#2480`) :user:`marcelotduarte`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2479`) :user:`pre-commit-ci`
+#)  build(deps): bump coverage from 7.5.3 to 7.5.4 (:pr:`2477`) :user:`dependabot`
+#)  tests: improve _compat to use in tests (:pr:`2476`) :user:`marcelotduarte`
+#)  tests: fix test_cli in archlinux (:pr:`2470`) :user:`marcelotduarte`
+#)  build(deps): bump update setuptools requirement to >=65.6.3,<71 (:pr:`2468`) :user:`marcelotduarte`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2464`) :user:`pre-commit-ci`
+#)  build(deps-dev): bump bump-my-version from 0.22.0 to 0.23.0 (:pr:`2462`) :user:`dependabot`
+#)  hooks: support numpy 2.0 (:pr:`2466`) :user:`marcelotduarte`
+#)  Bump version: 7.1.0-post0 → 7.1.1 [ci skip] (:pr:`2461`) :user:`marcelotduarte`
+#)  hooks: improve scikit-image (:pr:`2460`) :user:`marcelotduarte`
+#)  build(deps-dev): bump cibuildwheel from 2.19.0 to 2.19.1 (:pr:`2458`) :user:`dependabot`
+#)  hooks: add rasterio (:pr:`2455`) :user:`marcelotduarte`
+#)  hooks: fix #2382 regression / improve tests and docs (:pr:`2443`) :user:`marcelotduarte`
+#)  hooks: avoid exception when distribution is none (:pr:`2452`) :user:`marcelotduarte`
+#)  build(deps-dev): bump bump-my-version from 0.21.1 to 0.22.0 (:pr:`2450`) :user:`dependabot`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2448`) :user:`pre-commit-ci`
+#)  build(deps-dev): bump cibuildwheel from 2.18.1 to 2.19.0 (:pr:`2447`) :user:`dependabot`
+#)  doc: small revision of development/index [ci skip] (:pr:`2446`) :user:`marcelotduarte`
+#)  bdist_rpm: Fix string concat error due to order of op for + and or in RPM (:pr:`2444`) :user:`nicktindle`
+#)  cli: fix sys.path for cxfreeze command line (:pr:`2439`) :user:`marcelotduarte`
+#)  build(deps): bump pytest from 8.2.1 to 8.2.2 (:pr:`2437`) :user:`dependabot`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2434`) :user:`pre-commit-ci`
+#)  Bump version: 7.1.0 → 7.1.0-post0 [ci skip] (:pr:`2432`) :user:`marcelotduarte`
+#)  doc: msvc faq revision [ci skip] (:pr:`2429`) :user:`marcelotduarte`
+#)  build(deps): bump coverage from 7.5.2 to 7.5.3 (:pr:`2428`) :user:`dependabot`
+#)  hooks: fix pygobject hook for Linux (:pr:`2425`) :user:`marcelotduarte`
 
 Version 7.1 (May 26)
 ----------------------
 
-#)  hooks: add mkl (:pull:`2420`) :user:`marcelotduarte`
-#)  hooks: resolve dependencies to avoid symlink in numpy/mkl/blas conda linux (:pull:`2419`) :user:`marcelotduarte`
-#)  module: fix distribution installer multiline (:pull:`2418`) :user:`marcelotduarte`
-#)  ci: add test to do more 'parser' and 'module' coverage (:pull:`2416`) :user:`marcelotduarte`
-#)  freezer: resolve symlinks to always copy the source (:pull:`2415`) :user:`marcelotduarte`
-#)  build(deps): update setuptools requirement from <70,>=62.6 to >=62.6,<71 (:pull:`2413`) :user:`dependabot`
-#)  freezer: resolve dependencies to avoid symlink [linux] (:pull:`2410`) :user:`marcelotduarte`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2409`) :user:`pre-commit-ci`
-#)  build(deps-dev): bump cibuildwheel from 2.18.0 to 2.18.1 (:pull:`2408`) :user:`dependabot`
-#)  build(deps): bump pytest from 8.2.0 to 8.2.1 (:pull:`2407`) :user:`dependabot`
-#)  hooks: support for numpy + oneMKL using pip windows (:pull:`2405`) :user:`marcelotduarte`
-#)  hooks: support for numpy+mkl on conda linux (:pull:`2404`) :user:`marcelotduarte`
-#)  module: improve version method and add new methods (:pull:`2403`) :user:`marcelotduarte`
-#)  build(deps-dev): bump bump-my-version from 0.21.0 to 0.21.1 (:pull:`2399`) :user:`dependabot`
-#)  bdist_deb: catch a cpio 2.13 bug (:pull:`2402`) :user:`marcelotduarte`
-#)  chore: use uv pip to make installing packages faster (:pull:`2397`) :user:`marcelotduarte`
-#)  tests: xfail bdist_dmg when "Resource busy" [macOS] (:pull:`2396`) :user:`marcelotduarte`
-#)  doc: use uv pip (:pull:`2395`) :user:`marcelotduarte`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2394`) :user:`pre-commit-ci`
-#)  build(deps-dev): bump cibuildwheel from 2.17.0 to 2.18.0 (:pull:`2393`) :user:`dependabot`
-#)  hooks: add wayland Qt plugins automatically (:pull:`2391`) :user:`marcelotduarte`
-#)  hooks: add missing Qt plugins and translations (:pull:`2390`) :user:`marcelotduarte`
-#)  hooks: update plugins and translations for qt 6.7 (:pull:`2389`) :user:`marcelotduarte`
-#)  doc: add faq 'Removing the MAX_PATH Limitation' (:pull:`2388`) :user:`marcelotduarte`
-#)  chore: use compile() with dont_inherit and optimize (:pull:`2387`) :user:`marcelotduarte`
-#)  hooks: additional translations to qt hooks (:pull:`2386`) :user:`marcelotduarte`
-#)  fix: global of main module to work better with multiprocessing (:pull:`2385`) :user:`marcelotduarte`
-#)  hooks: improve multiprocessing hook to work with pytorch (:pull:`2382`) :user:`marcelotduarte`
-#)  build_exe: add new option --zip-filename (:pull:`2379`) :user:`marcelotduarte`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2381`) :user:`pre-commit-ci`
-#)  build(deps): bump coverage from 7.5.0 to 7.5.1 (:pull:`2380`) :user:`dependabot`
-#)  build-wheel: reactivate universal2 wheels for macOS (:pull:`2378`) :user:`marcelotduarte`
-#)  hooks: add pygobject (:pull:`2375`) :user:`marcelotduarte`
-#)  build(deps-dev): bump bump-my-version from 0.20.3 to 0.21.0 (:pull:`2377`) :user:`dependabot`
-#)  build(deps): bump pytest-xdist[psutil] from 3.5.0 to 3.6.1 (:pull:`2370`) :user:`dependabot`
-#)  build(deps): bump pytest from 8.1.2 to 8.2.0 (:pull:`2372`) :user:`dependabot`
-#)  build(deps): bump myst-parser from 3.0.0 to 3.0.1 (:pull:`2371`) :user:`dependabot`
-#)  samples: adapt code to support ruff rules (:pull:`2369`) :user:`marcelotduarte`
-#)  build(deps-dev): update pytest to 8.1.2, revert pyetst-xdist to 3.5.0 (:pull:`2368`) :user:`marcelotduarte`
-#)  tests: make msys2/mingw tests pass (:pull:`2367`) :user:`marcelotduarte`
-#)  bdist_msi: ignore warning 'msilib' is deprecated (:pull:`2366`) :user:`marcelotduarte`
-#)  build(deps-dev): bump bump-my-version from 0.20.2 to 0.20.3 (:pull:`2365`) :user:`dependabot`
-#)  hooks: fix unbound variable in load_subprocess under MINGW (:pull:`2363`) :user:`cedk`
-#)  ci: try to catch a issue with macos (:pull:`2360`) :user:`marcelotduarte`
-#)  hooks: Recompile the numpy.core.overrides module to limit optimization (:pull:`2358`) :user:`marcelotduarte`
-#)  hooks: fix regression in msys2 (:pull:`2357`) :user:`marcelotduarte`
-#)  build(deps): bump coverage from 7.4.4 to 7.5.0 (:pull:`2355`) :user:`dependabot`
-#)  ci: CI tests fails using macos-latest (:pull:`2359`) :user:`marcelotduarte`
-#)  tests: add command line tests for build_exe (:pull:`2353`) :user:`marcelotduarte`
-#)  build(deps): bump myst-parser from 2.0.0 to 3.0.0 (:pull:`2351`) :user:`dependabot`
-#)  build(deps-dev): bump bump-my-version from 0.20.1 to 0.20.2 (:pull:`2350`) :user:`dependabot`
-#)  tests: xfail bdist_dmg if resource is busy (:pull:`2352`) :user:`marcelotduarte`
-#)  build(deps): bump pluggy from 1.4.0 to 1.5.0 (:pull:`2348`) :user:`dependabot`
-#)  Bump version: 7.0.0 → 7.1.0-dev0 [ci skip] (:pull:`2349`) :user:`marcelotduarte`
+#)  hooks: add mkl (:pr:`2420`) :user:`marcelotduarte`
+#)  hooks: resolve dependencies to avoid symlink in numpy/mkl/blas conda linux (:pr:`2419`) :user:`marcelotduarte`
+#)  module: fix distribution installer multiline (:pr:`2418`) :user:`marcelotduarte`
+#)  ci: add test to do more 'parser' and 'module' coverage (:pr:`2416`) :user:`marcelotduarte`
+#)  freezer: resolve symlinks to always copy the source (:pr:`2415`) :user:`marcelotduarte`
+#)  build(deps): update setuptools requirement from <70,>=62.6 to >=62.6,<71 (:pr:`2413`) :user:`dependabot`
+#)  freezer: resolve dependencies to avoid symlink [linux] (:pr:`2410`) :user:`marcelotduarte`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2409`) :user:`pre-commit-ci`
+#)  build(deps-dev): bump cibuildwheel from 2.18.0 to 2.18.1 (:pr:`2408`) :user:`dependabot`
+#)  build(deps): bump pytest from 8.2.0 to 8.2.1 (:pr:`2407`) :user:`dependabot`
+#)  hooks: support for numpy + oneMKL using pip windows (:pr:`2405`) :user:`marcelotduarte`
+#)  hooks: support for numpy+mkl on conda linux (:pr:`2404`) :user:`marcelotduarte`
+#)  module: improve version method and add new methods (:pr:`2403`) :user:`marcelotduarte`
+#)  build(deps-dev): bump bump-my-version from 0.21.0 to 0.21.1 (:pr:`2399`) :user:`dependabot`
+#)  bdist_deb: catch a cpio 2.13 bug (:pr:`2402`) :user:`marcelotduarte`
+#)  chore: use uv pip to make installing packages faster (:pr:`2397`) :user:`marcelotduarte`
+#)  tests: xfail bdist_dmg when "Resource busy" [macOS] (:pr:`2396`) :user:`marcelotduarte`
+#)  doc: use uv pip (:pr:`2395`) :user:`marcelotduarte`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2394`) :user:`pre-commit-ci`
+#)  build(deps-dev): bump cibuildwheel from 2.17.0 to 2.18.0 (:pr:`2393`) :user:`dependabot`
+#)  hooks: add wayland Qt plugins automatically (:pr:`2391`) :user:`marcelotduarte`
+#)  hooks: add missing Qt plugins and translations (:pr:`2390`) :user:`marcelotduarte`
+#)  hooks: update plugins and translations for qt 6.7 (:pr:`2389`) :user:`marcelotduarte`
+#)  doc: add faq 'Removing the MAX_PATH Limitation' (:pr:`2388`) :user:`marcelotduarte`
+#)  chore: use compile() with dont_inherit and optimize (:pr:`2387`) :user:`marcelotduarte`
+#)  hooks: additional translations to qt hooks (:pr:`2386`) :user:`marcelotduarte`
+#)  fix: global of main module to work better with multiprocessing (:pr:`2385`) :user:`marcelotduarte`
+#)  hooks: improve multiprocessing hook to work with pytorch (:pr:`2382`) :user:`marcelotduarte`
+#)  build_exe: add new option --zip-filename (:pr:`2379`) :user:`marcelotduarte`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2381`) :user:`pre-commit-ci`
+#)  build(deps): bump coverage from 7.5.0 to 7.5.1 (:pr:`2380`) :user:`dependabot`
+#)  build-wheel: reactivate universal2 wheels for macOS (:pr:`2378`) :user:`marcelotduarte`
+#)  hooks: add pygobject (:pr:`2375`) :user:`marcelotduarte`
+#)  build(deps-dev): bump bump-my-version from 0.20.3 to 0.21.0 (:pr:`2377`) :user:`dependabot`
+#)  build(deps): bump pytest-xdist[psutil] from 3.5.0 to 3.6.1 (:pr:`2370`) :user:`dependabot`
+#)  build(deps): bump pytest from 8.1.2 to 8.2.0 (:pr:`2372`) :user:`dependabot`
+#)  build(deps): bump myst-parser from 3.0.0 to 3.0.1 (:pr:`2371`) :user:`dependabot`
+#)  samples: adapt code to support ruff rules (:pr:`2369`) :user:`marcelotduarte`
+#)  build(deps-dev): update pytest to 8.1.2, revert pyetst-xdist to 3.5.0 (:pr:`2368`) :user:`marcelotduarte`
+#)  tests: make msys2/mingw tests pass (:pr:`2367`) :user:`marcelotduarte`
+#)  bdist_msi: ignore warning 'msilib' is deprecated (:pr:`2366`) :user:`marcelotduarte`
+#)  build(deps-dev): bump bump-my-version from 0.20.2 to 0.20.3 (:pr:`2365`) :user:`dependabot`
+#)  hooks: fix unbound variable in load_subprocess under MINGW (:pr:`2363`) :user:`cedk`
+#)  ci: try to catch a issue with macos (:pr:`2360`) :user:`marcelotduarte`
+#)  hooks: Recompile the numpy.core.overrides module to limit optimization (:pr:`2358`) :user:`marcelotduarte`
+#)  hooks: fix regression in msys2 (:pr:`2357`) :user:`marcelotduarte`
+#)  build(deps): bump coverage from 7.4.4 to 7.5.0 (:pr:`2355`) :user:`dependabot`
+#)  ci: CI tests fails using macos-latest (:pr:`2359`) :user:`marcelotduarte`
+#)  tests: add command line tests for build_exe (:pr:`2353`) :user:`marcelotduarte`
+#)  build(deps): bump myst-parser from 2.0.0 to 3.0.0 (:pr:`2351`) :user:`dependabot`
+#)  build(deps-dev): bump bump-my-version from 0.20.1 to 0.20.2 (:pr:`2350`) :user:`dependabot`
+#)  tests: xfail bdist_dmg if resource is busy (:pr:`2352`) :user:`marcelotduarte`
+#)  build(deps): bump pluggy from 1.4.0 to 1.5.0 (:pr:`2348`) :user:`dependabot`
+#)  Bump version: 7.0.0 → 7.1.0-dev0 [ci skip] (:pr:`2349`) :user:`marcelotduarte`
 
 Version 7.0 (April 21)
 ----------------------
 
-#)  hooks: support numpy in python 3.12 (:pull:`2345`) :user:`marcelotduarte`
-#)  test: add simple test for bdist_mac (:pull:`2343`) :user:`marcelotduarte`
-#)  fix: regression in _pre_copy_hook (Linux) (:pull:`2342`) :user:`marcelotduarte`
-#)  build(deps): update dev dependencies (:pull:`2341`) :user:`marcelotduarte`
-#)  parser: show what patchelf is doing if silent is off (:pull:`2340`) :user:`marcelotduarte`
-#)  initscripts: use of __loader__ is deprecated (:pull:`2338`) :user:`marcelotduarte`
-#)  tests: add test_hooks_pandas.py (:pull:`2336`) :user:`marcelotduarte`
-#)  build(deps-dev): bump bump-my-version from 0.20.0 to 0.20.1 (:pull:`2337`) :user:`dependabot`
-#)  test: an expected exception should not be treated as an expected failure (:pull:`2334`) :user:`marcelotduarte`
-#)  fix: coverage report usage and omit option (:pull:`2333`) :user:`marcelotduarte`
-#)  test: add a linux binary wheel test in ci (:pull:`2332`) :user:`marcelotduarte`
-#)  chore: generate multiple files for requirements (:pull:`2330`) :user:`marcelotduarte`
-#)  doc: Correct some typographical errors and grammar errors (:pull:`2328`) :user:`marcelotduarte`
-#)  doc: show builtdist command as toctree and clickable in the table (:pull:`2327`) :user:`marcelotduarte`
-#)  doc: separates bdist commands to nest them in builtdist (:pull:`2325`) :user:`marcelotduarte`
-#)  doc: show pyproject.toml as first example (:pull:`2326`) :user:`marcelotduarte`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2324`) :user:`pre-commit-ci`
-#)  chore: move License to the project root dir (:pull:`2323`) :user:`marcelotduarte`
-#)  doc: fix furo edit button [ci skip] (:pull:`2322`) :user:`marcelotduarte`
-#)  docs: add 'Creating Built Distributions' (:pull:`2321`) :user:`marcelotduarte`
-#)  build(deps-dev): bump bump-my-version from 0.19.3 to 0.20.0 (:pull:`2320`) :user:`dependabot`
-#)  chore: refactor internal modules (:pull:`2319`) :user:`marcelotduarte`
-#)  build(deps): pin dev dependencies (:pull:`2318`) :user:`marcelotduarte`
-#)  bases: update base executables and util module [ci skip] (:pull:`2317`) :user:`marcelotduarte`
-#)  chore: remove deprecated option in 'build' command (:pull:`2316`) :user:`marcelotduarte`
-#)  Bump version: 6.16.0-dev12 → 7.0.0-rc0 [ci skip] (:pull:`2315`) :user:`marcelotduarte`
-#)  chore: remove unused class (:pull:`2314`) :user:`marcelotduarte`
-#)  build(deps-dev): bump pytest-mock from 3.12.0 to 3.14.0 (:pull:`2311`) :user:`dependabot`
-#)  tests: add TYPE_CHECKING to coverage excludes (:pull:`2310`) :user:`marcelotduarte`
-#)  chore: improve annotation (using ruff to check) (:pull:`2309`) :user:`marcelotduarte`
-#)  chore: adapt code to support ruff 'S' rules (:pull:`2308`) :user:`marcelotduarte`
-#)  chore: improve type checking (w/ help of ruff) (:pull:`2307`) :user:`marcelotduarte`
-#)  build(deps-dev): bump sphinx-new-tab-link from 0.3.1 to 0.4.0 (:pull:`2306`) :user:`dependabot`
-#)  chore: use more ruff lint rules (:pull:`2305`) :user:`marcelotduarte`
-#)  chore: enable ruff 'EM' ruleset (:pull:`2304`) :user:`marcelotduarte`
-#)  build: fix for Python 3.12 Ubuntu Linux 24.04 (Noble Nimbat) (:pull:`2303`) :user:`marcelotduarte`
-#)  hooks: support tensorflow plugins (:pull:`2302`) :user:`marcelotduarte`
-#)  hooks: add easyocr and torchvision (also update skickit-image and pytorch) (:pull:`2286`) :user:`marcelotduarte`
-#)  build(deps-dev): bump coverage from 7.4.3 to 7.4.4 (:pull:`2301`) :user:`dependabot`
-#)  build-wheel: use macos-14 (native arm) with cibuildwheel (:pull:`2299`) :user:`marcelotduarte`
-#)  build(deps): update wheel requirement from <=0.42.0,>=0.38.4 to >=0.38.4,<=0.43.0 (:pull:`2298`) :user:`dependabot`
-#)  build(deps-dev): bump cibuildwheel from 2.16.5 to 2.17.0 (:pull:`2297`) :user:`dependabot`
-#)  build(deps-dev): bump bump-my-version from 0.18.3 to 0.19.0 (:pull:`2296`) :user:`dependabot`
-#)  cli: restore more deprecated options (:pull:`2295`) :user:`marcelotduarte`
-#)  build(deps-dev): bump ruff-pre-commit 0.3.2 [ci skip] (:pull:`2294`) :user:`marcelotduarte`
-#)  build(deps-dev): bump sphinx-new-tab-link from 0.3.0 to 0.3.1 (:pull:`2292`) :user:`dependabot`
-#)  build(deps-dev): bump pytest from 8.0.2 to 8.1.1 (:pull:`2291`) :user:`dependabot`
-#)  build(deps-dev): bump pytest-timeout from 2.2.0 to 2.3.1 (:pull:`2289`) :user:`dependabot`
-#)  doc: improve the code_layout a bit (:pull:`2288`) :user:`marcelotduarte`
-#)  hooks: support pytorch 2.2 (:pull:`2281`) :user:`marcelotduarte`
-#)  docs: update msvcr links (:pull:`2284`) :user:`marcelotduarte`
-#)  build(deps-dev): bump sphinx-new-tab-link from 0.2.3 to 0.3.0 (:pull:`2282`) :user:`dependabot`
-#)  build(deps-dev): bump sphinx-new-tab-link from 0.2.2 to 0.2.3 (:pull:`2279`) :user:`dependabot`
-#)  build(deps-dev): bump coverage from 7.4.2 to 7.4.3 (:pull:`2278`) :user:`dependabot`
-#)  build(deps-dev): bump pytest from 8.0.1 to 8.0.2 (:pull:`2277`) :user:`dependabot`
-#)  build(deps-dev): bump bump-my-version from 0.17.4 to 0.18.3 (:pull:`2276`) :user:`dependabot`
-#)  bdist_msi: remove unused code (:pull:`2270`) :user:`marcelotduarte`
-#)  build(deps-dev): bump coverage from 7.4.1 to 7.4.2 (:pull:`2271`) :user:`dependabot`
-#)  tests: improve bdist_msi tests and samples (:pull:`2269`) :user:`marcelotduarte`
-#)  chore: use only 'ruff' as a linter and formatter (:pull:`2268`) :user:`marcelotduarte`
-#)  build(deps): support lief 0.14.x (:pull:`2267`) :user:`marcelotduarte`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2266`) :user:`pre-commit-ci`
-#)  build(deps-dev): bump pytest from 8.0.0 to 8.0.1 (:pull:`2265`) :user:`dependabot`
-#)  freezer: remove dead code (not used in py38+) (:pull:`2263`) :user:`marcelotduarte`
-#)  tests: improve a bit build_exe and freezer tests (:pull:`2262`) :user:`marcelotduarte`
-#)  bdist_deb: fix call to bdist_rpm, improve tests (:pull:`2260`) :user:`marcelotduarte`
-#)  pre-commit: use validate-pyproject-schema-store (:pull:`2258`) :user:`marcelotduarte`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2257`) :user:`pre-commit-ci`
-#)  build(deps-dev): bump furo from 2023.9.10 to 2024.1.29 (:pull:`2256`) :user:`marcelotduarte`
-#)  build(deps-dev): bump bump-my-version from 0.17.3 to 0.17.4 (:pull:`2255`) :user:`dependabot`
-#)  tests: add more tests for freezer (:pull:`2254`) :user:`marcelotduarte`
-#)  build-exe: adds include_path option (formerly in cli) (:pull:`2253`) :user:`marcelotduarte`
-#)  fix: #2242 introduced a regression in install_exe (:pull:`2250`) :user:`marcelotduarte`
-#)  fix: remove misuse of packages in setuptools.setup (:pull:`2249`) :user:`marcelotduarte`
-#)  tests: add more tests for bdist_msi (:pull:`2248`) :user:`marcelotduarte`
-#)  chore: add support for pyproject.toml (tool.cxfreeze) (:pull:`2244`) :user:`marcelotduarte`
-#)  build(deps): bump codecov/codecov-action from 3 to 4 (:pull:`2238`) :user:`dependabot`
-#)  build(deps-dev): bump sphinx-new-tab-link from 0.2.1 to 0.2.2 (:pull:`2245`) :user:`dependabot`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2243`) :user:`pre-commit-ci`
-#)  fix: incorrect metadata usage in install/install_exe (:pull:`2242`) :user:`marcelotduarte`
-#)  tests: improve coverage tests for linux (:pull:`2241`) :user:`marcelotduarte`
-#)  build(deps-dev): bump cibuildwheel from 2.16.4 to 2.16.5 (:pull:`2237`) :user:`dependabot`
-#)  ci: add specific coverage test for linux (:pull:`2239`) :user:`marcelotduarte`
-#)  fix: coverage report extra tests (:pull:`2236`) :user:`marcelotduarte`
-#)  chore: rearranges and sort some settings (:pull:`2235`) :user:`marcelotduarte`
-#)  chore: improve the use of coverage (:pull:`2233`) :user:`marcelotduarte`
-#)  build(deps-dev): bump black 2024 (:pull:`2230`) :user:`marcelotduarte`
-#)  build(deps-dev): bump cibuildwheel from 2.16.2 to 2.16.4 (:pull:`2229`) :user:`dependabot`
-#)  build(deps-dev): bump bump-my-version from 0.17.1 to 0.17.3 (:pull:`2228`) :user:`dependabot`
-#)  build(deps-dev): bump pytest from 7.4.4 to 8.0.0 (:pull:`2227`) :user:`dependabot`
-#)  tests: add some freezer tests (:pull:`2226`) :user:`marcelotduarte`
-#)  executable: new option --uac-uiaccess (:pull:`2135`) :user:`marcelotduarte`
-#)  chore: add options to pre-commit (:pull:`2225`) :user:`marcelotduarte`
-#)  tests: test build_exe options silent,silent-level and build_exe (:pull:`2224`) :user:`marcelotduarte`
-#)  tests: target_dir "starts in a clean directory" (:pull:`2223`) :user:`marcelotduarte`
-#)  build(deps-dev): bump bump-my-version from 0.17.0 to 0.17.1 (:pull:`2222`) :user:`dependabot`
-#)  winversioninfo: comments length must be limited to fit WORD (:pull:`2220`) :user:`marcelotduarte`
-#)  tests: add tests for __main__ and cli (:pull:`2219`) :user:`marcelotduarte`
-#)  build(deps-dev): bump pluggy from 1.3.0 to 1.4.0 (:pull:`2217`) :user:`dependabot`
-#)  parser: minor fix to support lief 0.14 (:pull:`2216`) :user:`marcelotduarte`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2215`) :user:`pre-commit-ci`
-#)  build(deps-dev): bump sphinx-tabs from 3.4.4 to 3.4.5 (:pull:`2214`) :user:`dependabot`
-#)  build(deps-dev): bump bump-my-version from 0.16.2 to 0.17.0 (:pull:`2213`) :user:`dependabot`
-#)  winversioninfo: fix version string and improve coverage/tests (:pull:`2211`) :user:`marcelotduarte`
-#)  chore: Update copyright year and license (:pull:`2209`) :user:`marcelotduarte`
-#)  docs: open external links in new tab (:pull:`2208`) :user:`marcelotduarte`
-#)  hooks: add pyproj (:pull:`2207`) :user:`marcelotduarte`
-#)  winmsvcr: extend support for VS 2022 (:pull:`2204`) :user:`marcelotduarte`
-#)  hooks: opencv-python - minor fixes (:pull:`2206`) :user:`marcelotduarte`
-#)  freezer: improve/fixes validate_executable (:pull:`2205`) :user:`marcelotduarte`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2202`) :user:`pre-commit-ci`
-#)  build(deps-dev): bump bump-my-version from 0.16.1 to 0.16.2 (:pull:`2201`) :user:`dependabot`
-#)  tests: minor tweaks - part 2 (:pull:`2198`) :user:`marcelotduarte`
-#)  tests: minor tweaks - part 1 (:pull:`2197`) :user:`marcelotduarte`
-#)  build(deps-dev): bump pre-commit up to 3.6.0 and sphinx up to 7.2.6 (:pull:`2196`) :user:`marcelotduarte`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2195`) :user:`pre-commit-ci`
-#)  build(deps-dev): bump bump-my-version from 0.16.0 to 0.16.1 (:pull:`2194`) :user:`dependabot`
-#)  build(deps-dev): bump bump-my-version from 0.15.4 to 0.16.0 (:pull:`2191`) :user:`dependabot`
-#)  tests: simplify more tests using run_command (:pull:`2189`) :user:`marcelotduarte`
-#)  tests: simplify test using a run_command (:pull:`2187`) :user:`marcelotduarte`
-#)  build(deps-dev): bump pytest from 7.4.3 to 7.4.4 (:pull:`2188`) :user:`dependabot`
-#)  build(deps-dev): bump bump-my-version from 0.15.3 to 0.15.4 (:pull:`2186`) :user:`dependabot`
-#)  setup script: add an extension to executable icon that is valid across OS (:pull:`2185`) :user:`marcelotduarte`
-#)  setup script: pre-defined values for base are valid in all OS (:pull:`2184`) :user:`marcelotduarte`
-#)  setup script: extend executables keyword to support more types (:pull:`2182`) :user:`marcelotduarte`
-#)  bdist_appimage: build Linux AppImage format [new feature] (:pull:`2050`) :user:`marcelotduarte`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2181`) :user:`pre-commit-ci`
-#)  build(deps-dev): bump bump-my-version from 0.15.1 to 0.15.3 (:pull:`2178`) :user:`dependabot`
-#)  build-wheel: fix update_bases' ref and cleanup publish (:pull:`2176`) :user:`marcelotduarte`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2175`) :user:`pre-commit-ci`
-#)  build(deps-dev): bump bump-my-version from 0.12.0 to 0.15.1 (:pull:`2174`) :user:`dependabot`
-#)  Bump version: 6.16.0-dev11 → 6.16.0-dev12 [ci skip] (:pull:`2173`) :user:`marcelotduarte`
-#)  bdist_mac: create symlink between folders specified by user under Resources (:pull:`2169`) :user:`admin`
-#)  fix: #2139 introduced a regression [macos] (:pull:`2172`) :user:`marcelotduarte`
-#)  hooks: add AV and PyAV (:pull:`2165`) :user:`marcelotduarte`
-#)  build: fix build_wheel (after #2162 and #2163) (:pull:`2170`) :user:`marcelotduarte`
-#)  build(deps): bump actions/download-artifact from 3 to 4 (:pull:`2163`) :user:`dependabot`
-#)  build(deps): bump actions/upload-artifact from 3 to 4 (:pull:`2162`) :user:`dependabot`
-#)  build(deps): bump github/codeql-action from 2 to 3 (:pull:`2160`) :user:`dependabot`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2157`) :user:`pre-commit-ci`
-#)  build(deps-dev): bump pylint from 3.0.2 to 3.0.3 (:pull:`2156`) :user:`dependabot`
-#)  build(deps): bump actions/setup-python from 4 to 5 (:pull:`2155`) :user:`dependabot`
-#)  Replace SetDllDirectory by AddDllDirectory (:pull:`2144`) :user:`dev`
-#)  Bump version: 6.16.0-dev10 → 6.16.0-dev11 [ci skip] (:pull:`2151`) :user:`marcelotduarte`
-#)  fix: pthread missing for building in FreeBSD (:pull:`2150`) :user:`marcelotduarte`
-#)  build(deps): bump wheel from 0.41.3 to 0.42.0 (:pull:`2148`) :user:`dependabot`
-#)  build(deps-dev): bump bump-my-version from 0.11.0 to 0.12.0 (:pull:`2147`) :user:`dependabot`
-#)  chore: switch to bump-my-version (:pull:`2146`) :user:`marcelotduarte`
-#)  bdist_mac: apply the style of other bdist modules (:pull:`2139`) :user:`marcelotduarte`
-#)  hooks: add yt_dlp (:pull:`2145`) :user:`marcelotduarte`
-#)  build(deps-dev): bump pytest-xdist[psutil] from 3.4.0 to 3.5.0 (:pull:`2143`) :user:`dependabot`
-#)  build(deps): update setuptools requirement from <69,>=62.6 to >=62.6,<70 (:pull:`2141`) :user:`dependabot`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2142`) :user:`pre-commit-ci`
-#)  freezer: Improve symlink support to work w/ macOS (:pull:`2138`) :user:`marcelotduarte`
-#)  hooks: adds anyio, pyarrow and tiktoken (:pull:`2134`) :user:`marcelotduarte`
-#)  chore: cosmetic and minor tweaks (:pull:`2137`) :user:`marcelotduarte`
-#)  build_exe: raise exception on invalid build_exe option (:pull:`2132`) :user:`marcelotduarte`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2130`) :user:`pre-commit-ci`
-#)  build(deps-dev): bump pytest-xdist[psutil] from 3.3.1 to 3.4.0 (:pull:`2129`) :user:`dependabot`
-#)  samples: improve qt samples (:pull:`2128`) :user:`marcelotduarte`
-#)  hooks: Support for PyQt5/PySide2 QtWebEngine in macOS (:pull:`2127`) :user:`marcelotduarte`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2125`) :user:`pre-commit-ci`
-#)  hooks: Support for PyQt6/PySide6 QtWebEngine in macOS (:pull:`2124`) :user:`marcelotduarte`
-#)  hooks: use a different approach for pyqt6 in bdist_mac (:pull:`2123`) :user:`marcelotduarte`
-#)  hooks: fix pyqt6 in bdist_mac (.app) (:pull:`2122`) :user:`marcelotduarte`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2120`) :user:`pre-commit-ci`
-#)  build(deps): bump wheel from 0.41.2 to 0.41.3 (:pull:`2119`) :user:`dependabot`
-#)  build(deps-dev): bump pytest from 7.4.2 to 7.4.3 (:pull:`2115`) :user:`dependabot`
-#)  "Bump version: 6.16.0-dev9 → 6.16.0-dev10 [ci skip]" (:pull:`2114`) :user:`marcelotduarte`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2113`) :user:`pre-commit-ci`
-#)  build(deps-dev): bump sphinx-tabs from 3.4.1 to 3.4.4 (:pull:`2112`) :user:`dependabot`
-#)  build(deps-dev): bump pylint from 3.0.1 to 3.0.2 (:pull:`2111`) :user:`dependabot`
-#)  hooks: fix qtwebengine in conda-forge (:pull:`2110`) :user:`marcelotduarte`
-#)  hooks: fix qt.conf for pyqt [macos] (:pull:`2109`) :user:`marcelotduarte`
-#)  hooks: tweaks to the debugging of qt hooks (:pull:`2108`) :user:`marcelotduarte`
-#)  bdist_mac: move set_relative_reference_paths to build_exe (:pull:`2106`) :user:`marcelotduarte`
-#)  darwintools: fix adhocsignature for universal2 machine (:pull:`2107`) :user:`marcelotduarte`
-#)  bdist_mac: make symlink between Resources/share and Contents/MacOS (:pull:`2105`) :user:`marcelotduarte`
-#)  parse: regression fix in get_dependent_files [windows] (:pull:`2104`) :user:`marcelotduarte`
-#)  bdist_mac: skip text files in set_relative_reference_paths (:pull:`2102`) :user:`micah`
-#)  build(deps-dev): bump pytest-mock from 3.11.1 to 3.12.0 (:pull:`2103`) :user:`dependabot`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2101`) :user:`pre-commit-ci`
-#)  bases: update base executables and util module [ci skip] (:pull:`2100`) :user:`marcelotduarte`
-#)  chore: update base executables and util module [ci skip] (:pull:`2099`) :user:`marcelotduarte`
-#)  "Bump version: 6.16.0-dev8 → 6.16.0-dev9 [ci skip]" (:pull:`2098`) :user:`marcelotduarte`
-#)  fix: issues with manifest and windows version (:pull:`2097`) :user:`marcelotduarte`
-#)  build(deps-dev): bump pre-commit from 3.4.0 to 3.5.0 (:pull:`2096`) :user:`dependabot`
-#)  hooks: add triton and support for pytorch 2.1 (:pull:`2090`) :user:`marcelotduarte`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2092`) :user:`pre-commit-ci`
-#)  build(deps-dev): bump pytest-timeout from 2.1.0 to 2.2.0 (:pull:`2091`) :user:`dependabot`
-#)  build(deps-dev): bump pylint from 3.0.0 to 3.0.1 (:pull:`2089`) :user:`dependabot`
-#)  build(deps-dev): bump cibuildwheel from 2.16.1 to 2.16.2 (:pull:`2085`) :user:`dependabot`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2082`) :user:`pre-commit-ci`
-#)  build(deps-dev): bump pylint from 2.17.6 to 3.0.0 (:pull:`2081`) :user:`dependabot`
-#)  tests: use importorskip/skip at module level to skip early (:pull:`2084`) :user:`marcelotduarte`
-#)  chore: rewrite some imports as absolute (:pull:`2083`) :user:`marcelotduarte`
-#)  bdist_deb: add doc and tests (:pull:`2080`) :user:`marcelotduarte`
-#)  doc: minor fixes (:pull:`2079`) :user:`marcelotduarte`
-#)  bdist_deb: create an DEB distribution [new feature] (:pull:`2078`) :user:`marcelotduarte`
-#)  bdist_rpm: remove unused options (:pull:`2077`) :user:`marcelotduarte`
-#)  "Bump version: 6.16.0-dev7 → 6.16.0-dev8 [ci skip]" (:pull:`2076`) :user:`marcelotduarte`
-#)  bdist_rpm: fix issue with install prefix (:pull:`2075`) :user:`marcelotduarte`
-#)  hooks: initialize blas [numpy conda-forge] (:pull:`2074`) :user:`49456524+IperGiove`
-#)  parser: exclude LD_PRELOAD to not include triggered dependencies (:pull:`2073`) :user:`marcelotduarte`
-#)  hooks: add tidylib (:pull:`2072`) :user:`marcelotduarte`
-#)  parser: use the internal path instead of sys.path (:pull:`2071`) :user:`marcelotduarte`
-#)  fix: avoid false builtin modules developing in multi-environment (:pull:`2070`) :user:`marcelotduarte`
-#)  build(deps-dev): bump cibuildwheel from 2.16.0 to 2.16.1 (:pull:`2069`) :user:`dependabot`
-#)  hooks: move tkinter and tz data to share folder (:pull:`2067`) :user:`marcelotduarte`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2066`) :user:`pre-commit-ci`
-#)  build(deps-dev): bump pylint from 2.17.5 to 2.17.6 (:pull:`2065`) :user:`dependabot`
-#)  tests: minor tweaks (:pull:`2063`) :user:`marcelotduarte`
-#)  build_exe: fix typo in command line boolean option 'include-msvcr' (:pull:`2062`) :user:`marcelotduarte`
-#)  hooks: fix scipy windows (:pull:`2060`) :user:`marcelotduarte`
-#)  doc: improve documentation for 'binary wheels' (:pull:`2059`) :user:`marcelotduarte`
-#)  hooks: add numpy 1.26 (:pull:`2058`) :user:`marcelotduarte`
-#)  hooks: fix numpy/scipy regression [mingw] (:pull:`2057`) :user:`marcelotduarte`
-#)  build(deps-dev): bump cibuildwheel from 2.15.0 to 2.16.0 (:pull:`2056`) :user:`dependabot`
-#)  hooks: add RNS (Reticulum) (:pull:`2053`) :user:`marcelotduarte`
-#)  bdist_mac: Copy build_exe to Resources and move executables to MacOS (:pull:`2048`) :user:`marcelotduarte`
-#)  hooks: fix numpy/scipy dylibs are included twice (:pull:`2038`) :user:`marcelotduarte`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2055`) :user:`pre-commit-ci`
-#)  "Bump version: 6.16.0-dev6 → 6.16.0-dev7 [ci skip]" (:pull:`2052`) :user:`marcelotduarte`
-#)  icons: add Python icons (:pull:`2051`) :user:`marcelotduarte`
-#)  Revert "build(deps): bump codecov/codecov-action from 3 to 4" (:pull:`2049`) :user:`marcelotduarte`
-#)  build(deps): bump codecov/codecov-action from 3 to 4 (:pull:`2047`) :user:`dependabot`
-#)  samples: small tweaks to demonstrate independent options (:pull:`2045`) :user:`marcelotduarte`
-#)  build(deps): bump docker/setup-qemu-action from 2 to 3 (:pull:`2044`) :user:`dependabot`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2043`) :user:`pre-commit-ci`
-#)  bdist_mac: small optimization on copy tree (:pull:`2040`) :user:`marcelotduarte`
-#)  bdist_mac: fix duplicate lib in bdist_dmg [regression] (:pull:`2037`) :user:`marcelotduarte`
-#)  hooks: improve numpy and pandas hooks (:pull:`2036`) :user:`marcelotduarte`
-#)  build(deps-dev): bump pytest from 7.4.1 to 7.4.2 (:pull:`2035`) :user:`dependabot`
-#)  "Bump version: 6.16.0-dev5 → 6.16.0-dev6 [ci skip]" (:pull:`2034`) :user:`marcelotduarte`
-#)  doc: Building binary wheels (:pull:`2033`) :user:`marcelotduarte`
-#)  hooks: add support for pandas 2.1.0 (:pull:`2032`) :user:`marcelotduarte`
-#)  build-wheel: fix build and compatibility w/ build 1.0 (:pull:`2030`) :user:`marcelotduarte`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2031`) :user:`pre-commit-ci`
-#)  build(deps): bump actions/checkout from 3 to 4 (:pull:`2029`) :user:`dependabot`
-#)  build(deps-dev): bump pytest from 7.4.0 to 7.4.1 (:pull:`2028`) :user:`dependabot`
-#)  build(deps-dev): bump pre-commit from 3.3.3 to 3.4.0 (:pull:`2027`) :user:`dependabot`
-#)  bdis_mac: Builds pass macOS notarization (:pull:`2025`) :user:`johan.ronnkvist`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2024`) :user:`pre-commit-ci`
-#)  build(deps-dev): bump pluggy from 1.2.0 to 1.3.0 (:pull:`2023`) :user:`dependabot`
-#)  hooks: add pycryptodomex and update pycryptodome (:pull:`2022`) :user:`marcelotduarte`
-#)  build-wheel: add support for ppc64le binary wheels for py310+ (:pull:`2020`) :user:`marcelotduarte`
-#)  hooks: use module.exclude_names to filter missing modules (:pull:`2019`) :user:`marcelotduarte`
-#)  hooks: improve tzdata/zoneinfo/pytz hooks a bit for use in zip (:pull:`2018`) :user:`marcelotduarte`
-#)  build(deps-dev): bump wheel from 0.41.1 to 0.41.2 (:pull:`2017`) :user:`dependabot`
-#)  doc: furo can be used only on html build (:pull:`2015`) :user:`marcelotduarte`
-#)  build(deps-dev): update pre-commit and doc dependencies (:pull:`2014`) :user:`marcelotduarte`
-#)  module: search for the stub file already parsed in the distribution (:pull:`2013`) :user:`marcelotduarte`
-#)  hooks: qt extension modules are detected using stubs (:pull:`2009`) :user:`marcelotduarte`
-#)  module: add a importshed for parsed stubs (:pull:`2008`) :user:`marcelotduarte`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2007`) :user:`pre-commit-ci`
-#)  module: get the implicit imports of extensions in a stub file (:pull:`2006`) :user:`marcelotduarte`
-#)  module: propagate cache_path from the finder (:pull:`2005`) :user:`marcelotduarte`
-#)  chore: new internal _typing module (:pull:`2004`) :user:`marcelotduarte`
-#)  finder: cache_path holds where distribution data is saved (:pull:`2003`) :user:`marcelotduarte`
-#)  build(deps-dev): bump cibuildwheel from 2.14.1 to 2.15.0 (:pull:`2002`) :user:`dependabot`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2000`) :user:`pre-commit-ci`
-#)  build(deps-dev): bump wheel from 0.41.0 to 0.41.1 (:pull:`1999`) :user:`dependabot`
-#)  hooks: add markdown (:pull:`1997`) :user:`marcelotduarte`
-#)  finder: improve scan code to detect packages using import call (:pull:`1966`) :user:`marcelotduarte`
-#)  build(deps-dev): bump sphinx from 7.1.1 to 7.1.2 (:pull:`1995`) :user:`dependabot`
-#)  module: ModuleHook class to support inheritance (:pull:`1998`) :user:`marcelotduarte`
-#)  Bump version: 6.16.0-dev5 (:pull:`1994`) :user:`marcelotduarte`
-#)  hooks: fix pyqt5 webengine [conda linux] (:pull:`1993`) :user:`marcelotduarte`
-#)  hooks: fix pyside2 webengine [conda linux] (:pull:`1992`) :user:`marcelotduarte`
-#)  samples: document the use of qt samples in conda-forge (:pull:`1991`) :user:`marcelotduarte`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`1990`) :user:`pre-commit-ci`
-#)  build(deps-dev): bump sphinx from 7.1.0 to 7.1.1 (:pull:`1989`) :user:`dependabot`
-#)  hooks: move ssl hook to a submodule (:pull:`1988`) :user:`marcelotduarte`
-#)  build(deps-dev): bump pylint from 2.17.4 to 2.17.5 (:pull:`1987`) :user:`dependabot`
-#)  build(deps-dev): bump sphinx from 7.0.1 to 7.1.0 (:pull:`1985`) :user:`dependabot`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`1983`) :user:`pre-commit-ci`
-#)  build(deps-dev): bump wheel from 0.40.0 to 0.41.0 (:pull:`1982`) :user:`dependabot`
-#)  hooks: Disable sandbox in PySide2 WebEngine [Linux and Windows] (:pull:`1981`) :user:`marcelotduarte`
-#)  hooks: Disable sandbox in PyQt5 WebEngine [Linux and Windows] (:pull:`1980`) :user:`marcelotduarte`
-#)  hooks: support opencv-python 4.8.0 [msys2] (:pull:`1975`) :user:`marcelotduarte`
-#)  hooks: support pyside6 6.5.1 [conda] (:pull:`1979`) :user:`marcelotduarte`
-#)  hooks: support for pyqt6 6.5.1 [msys2] (:pull:`1977`) :user:`marcelotduarte`
-#)  hooks: support pyside2 5.15.8 [msys2] (:pull:`1978`) :user:`marcelotduarte`
-#)  hooks: fix for pyqt [conda linux] (:pull:`1976`) :user:`marcelotduarte`
-#)  finder: add base modules at the end to simplify tests (:pull:`1974`) :user:`marcelotduarte`
-#)  hooks: PySide2/6 - shiboken2/6 in zip_include_packages (:pull:`1970`) :user:`marcelotduarte`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`1973`) :user:`pre-commit-ci`
-#)  build-wheel: put jobs in concurrency for speedup [skip ci] (:pull:`1971`) :user:`marcelotduarte`
-#)  build(deps-dev): bump cibuildwheel from 2.14.0 to 2.14.1 (:pull:`1972`) :user:`dependabot`
-#)  startup: get rid of sysconfig at startup (:pull:`1968`) :user:`marcelotduarte`
-#)  hooks: update sysconfig hook (:pull:`1967`) :user:`marcelotduarte`
-#)  samples: update samples using wxPython (:pull:`1965`) :user:`marcelotduarte`
-#)  hooks: multiprocessing support for forkserver and spawn (:pull:`1956`) :user:`marcelotduarte`
-#)  hooks: add py-cord (fork of discord) (:pull:`1964`) :user:`marcelotduarte`
-#)  tests: rewrite create_package to support dedent (:pull:`1960`) :user:`marcelotduarte`
-#)  fix: bdist_rpm to pass tests in python 3.12b4 (:pull:`1963`) :user:`marcelotduarte`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`1959`) :user:`pre-commit-ci`
+#)  hooks: support numpy in python 3.12 (:pr:`2345`) :user:`marcelotduarte`
+#)  test: add simple test for bdist_mac (:pr:`2343`) :user:`marcelotduarte`
+#)  fix: regression in _pre_copy_hook (Linux) (:pr:`2342`) :user:`marcelotduarte`
+#)  build(deps): update dev dependencies (:pr:`2341`) :user:`marcelotduarte`
+#)  parser: show what patchelf is doing if silent is off (:pr:`2340`) :user:`marcelotduarte`
+#)  initscripts: use of __loader__ is deprecated (:pr:`2338`) :user:`marcelotduarte`
+#)  tests: add test_hooks_pandas.py (:pr:`2336`) :user:`marcelotduarte`
+#)  build(deps-dev): bump bump-my-version from 0.20.0 to 0.20.1 (:pr:`2337`) :user:`dependabot`
+#)  test: an expected exception should not be treated as an expected failure (:pr:`2334`) :user:`marcelotduarte`
+#)  fix: coverage report usage and omit option (:pr:`2333`) :user:`marcelotduarte`
+#)  test: add a linux binary wheel test in ci (:pr:`2332`) :user:`marcelotduarte`
+#)  chore: generate multiple files for requirements (:pr:`2330`) :user:`marcelotduarte`
+#)  doc: Correct some typographical errors and grammar errors (:pr:`2328`) :user:`marcelotduarte`
+#)  doc: show builtdist command as toctree and clickable in the table (:pr:`2327`) :user:`marcelotduarte`
+#)  doc: separates bdist commands to nest them in builtdist (:pr:`2325`) :user:`marcelotduarte`
+#)  doc: show pyproject.toml as first example (:pr:`2326`) :user:`marcelotduarte`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2324`) :user:`pre-commit-ci`
+#)  chore: move License to the project root dir (:pr:`2323`) :user:`marcelotduarte`
+#)  doc: fix furo edit button [ci skip] (:pr:`2322`) :user:`marcelotduarte`
+#)  docs: add 'Creating Built Distributions' (:pr:`2321`) :user:`marcelotduarte`
+#)  build(deps-dev): bump bump-my-version from 0.19.3 to 0.20.0 (:pr:`2320`) :user:`dependabot`
+#)  chore: refactor internal modules (:pr:`2319`) :user:`marcelotduarte`
+#)  build(deps): pin dev dependencies (:pr:`2318`) :user:`marcelotduarte`
+#)  bases: update base executables and util module [ci skip] (:pr:`2317`) :user:`marcelotduarte`
+#)  chore: remove deprecated option in 'build' command (:pr:`2316`) :user:`marcelotduarte`
+#)  Bump version: 6.16.0-dev12 → 7.0.0-rc0 [ci skip] (:pr:`2315`) :user:`marcelotduarte`
+#)  chore: remove unused class (:pr:`2314`) :user:`marcelotduarte`
+#)  build(deps-dev): bump pytest-mock from 3.12.0 to 3.14.0 (:pr:`2311`) :user:`dependabot`
+#)  tests: add TYPE_CHECKING to coverage excludes (:pr:`2310`) :user:`marcelotduarte`
+#)  chore: improve annotation (using ruff to check) (:pr:`2309`) :user:`marcelotduarte`
+#)  chore: adapt code to support ruff 'S' rules (:pr:`2308`) :user:`marcelotduarte`
+#)  chore: improve type checking (w/ help of ruff) (:pr:`2307`) :user:`marcelotduarte`
+#)  build(deps-dev): bump sphinx-new-tab-link from 0.3.1 to 0.4.0 (:pr:`2306`) :user:`dependabot`
+#)  chore: use more ruff lint rules (:pr:`2305`) :user:`marcelotduarte`
+#)  chore: enable ruff 'EM' ruleset (:pr:`2304`) :user:`marcelotduarte`
+#)  build: fix for Python 3.12 Ubuntu Linux 24.04 (Noble Nimbat) (:pr:`2303`) :user:`marcelotduarte`
+#)  hooks: support tensorflow plugins (:pr:`2302`) :user:`marcelotduarte`
+#)  hooks: add easyocr and torchvision (also update skickit-image and pytorch) (:pr:`2286`) :user:`marcelotduarte`
+#)  build(deps-dev): bump coverage from 7.4.3 to 7.4.4 (:pr:`2301`) :user:`dependabot`
+#)  build-wheel: use macos-14 (native arm) with cibuildwheel (:pr:`2299`) :user:`marcelotduarte`
+#)  build(deps): update wheel requirement from <=0.42.0,>=0.38.4 to >=0.38.4,<=0.43.0 (:pr:`2298`) :user:`dependabot`
+#)  build(deps-dev): bump cibuildwheel from 2.16.5 to 2.17.0 (:pr:`2297`) :user:`dependabot`
+#)  build(deps-dev): bump bump-my-version from 0.18.3 to 0.19.0 (:pr:`2296`) :user:`dependabot`
+#)  cli: restore more deprecated options (:pr:`2295`) :user:`marcelotduarte`
+#)  build(deps-dev): bump ruff-pre-commit 0.3.2 [ci skip] (:pr:`2294`) :user:`marcelotduarte`
+#)  build(deps-dev): bump sphinx-new-tab-link from 0.3.0 to 0.3.1 (:pr:`2292`) :user:`dependabot`
+#)  build(deps-dev): bump pytest from 8.0.2 to 8.1.1 (:pr:`2291`) :user:`dependabot`
+#)  build(deps-dev): bump pytest-timeout from 2.2.0 to 2.3.1 (:pr:`2289`) :user:`dependabot`
+#)  doc: improve the code_layout a bit (:pr:`2288`) :user:`marcelotduarte`
+#)  hooks: support pytorch 2.2 (:pr:`2281`) :user:`marcelotduarte`
+#)  docs: update msvcr links (:pr:`2284`) :user:`marcelotduarte`
+#)  build(deps-dev): bump sphinx-new-tab-link from 0.2.3 to 0.3.0 (:pr:`2282`) :user:`dependabot`
+#)  build(deps-dev): bump sphinx-new-tab-link from 0.2.2 to 0.2.3 (:pr:`2279`) :user:`dependabot`
+#)  build(deps-dev): bump coverage from 7.4.2 to 7.4.3 (:pr:`2278`) :user:`dependabot`
+#)  build(deps-dev): bump pytest from 8.0.1 to 8.0.2 (:pr:`2277`) :user:`dependabot`
+#)  build(deps-dev): bump bump-my-version from 0.17.4 to 0.18.3 (:pr:`2276`) :user:`dependabot`
+#)  bdist_msi: remove unused code (:pr:`2270`) :user:`marcelotduarte`
+#)  build(deps-dev): bump coverage from 7.4.1 to 7.4.2 (:pr:`2271`) :user:`dependabot`
+#)  tests: improve bdist_msi tests and samples (:pr:`2269`) :user:`marcelotduarte`
+#)  chore: use only 'ruff' as a linter and formatter (:pr:`2268`) :user:`marcelotduarte`
+#)  build(deps): support lief 0.14.x (:pr:`2267`) :user:`marcelotduarte`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2266`) :user:`pre-commit-ci`
+#)  build(deps-dev): bump pytest from 8.0.0 to 8.0.1 (:pr:`2265`) :user:`dependabot`
+#)  freezer: remove dead code (not used in py38+) (:pr:`2263`) :user:`marcelotduarte`
+#)  tests: improve a bit build_exe and freezer tests (:pr:`2262`) :user:`marcelotduarte`
+#)  bdist_deb: fix call to bdist_rpm, improve tests (:pr:`2260`) :user:`marcelotduarte`
+#)  pre-commit: use validate-pyproject-schema-store (:pr:`2258`) :user:`marcelotduarte`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2257`) :user:`pre-commit-ci`
+#)  build(deps-dev): bump furo from 2023.9.10 to 2024.1.29 (:pr:`2256`) :user:`marcelotduarte`
+#)  build(deps-dev): bump bump-my-version from 0.17.3 to 0.17.4 (:pr:`2255`) :user:`dependabot`
+#)  tests: add more tests for freezer (:pr:`2254`) :user:`marcelotduarte`
+#)  build-exe: adds include_path option (formerly in cli) (:pr:`2253`) :user:`marcelotduarte`
+#)  fix: #2242 introduced a regression in install_exe (:pr:`2250`) :user:`marcelotduarte`
+#)  fix: remove misuse of packages in setuptools.setup (:pr:`2249`) :user:`marcelotduarte`
+#)  tests: add more tests for bdist_msi (:pr:`2248`) :user:`marcelotduarte`
+#)  chore: add support for pyproject.toml (tool.cxfreeze) (:pr:`2244`) :user:`marcelotduarte`
+#)  build(deps): bump codecov/codecov-action from 3 to 4 (:pr:`2238`) :user:`dependabot`
+#)  build(deps-dev): bump sphinx-new-tab-link from 0.2.1 to 0.2.2 (:pr:`2245`) :user:`dependabot`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2243`) :user:`pre-commit-ci`
+#)  fix: incorrect metadata usage in install/install_exe (:pr:`2242`) :user:`marcelotduarte`
+#)  tests: improve coverage tests for linux (:pr:`2241`) :user:`marcelotduarte`
+#)  build(deps-dev): bump cibuildwheel from 2.16.4 to 2.16.5 (:pr:`2237`) :user:`dependabot`
+#)  ci: add specific coverage test for linux (:pr:`2239`) :user:`marcelotduarte`
+#)  fix: coverage report extra tests (:pr:`2236`) :user:`marcelotduarte`
+#)  chore: rearranges and sort some settings (:pr:`2235`) :user:`marcelotduarte`
+#)  chore: improve the use of coverage (:pr:`2233`) :user:`marcelotduarte`
+#)  build(deps-dev): bump black 2024 (:pr:`2230`) :user:`marcelotduarte`
+#)  build(deps-dev): bump cibuildwheel from 2.16.2 to 2.16.4 (:pr:`2229`) :user:`dependabot`
+#)  build(deps-dev): bump bump-my-version from 0.17.1 to 0.17.3 (:pr:`2228`) :user:`dependabot`
+#)  build(deps-dev): bump pytest from 7.4.4 to 8.0.0 (:pr:`2227`) :user:`dependabot`
+#)  tests: add some freezer tests (:pr:`2226`) :user:`marcelotduarte`
+#)  executable: new option --uac-uiaccess (:pr:`2135`) :user:`marcelotduarte`
+#)  chore: add options to pre-commit (:pr:`2225`) :user:`marcelotduarte`
+#)  tests: test build_exe options silent,silent-level and build_exe (:pr:`2224`) :user:`marcelotduarte`
+#)  tests: target_dir "starts in a clean directory" (:pr:`2223`) :user:`marcelotduarte`
+#)  build(deps-dev): bump bump-my-version from 0.17.0 to 0.17.1 (:pr:`2222`) :user:`dependabot`
+#)  winversioninfo: comments length must be limited to fit WORD (:pr:`2220`) :user:`marcelotduarte`
+#)  tests: add tests for __main__ and cli (:pr:`2219`) :user:`marcelotduarte`
+#)  build(deps-dev): bump pluggy from 1.3.0 to 1.4.0 (:pr:`2217`) :user:`dependabot`
+#)  parser: minor fix to support lief 0.14 (:pr:`2216`) :user:`marcelotduarte`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2215`) :user:`pre-commit-ci`
+#)  build(deps-dev): bump sphinx-tabs from 3.4.4 to 3.4.5 (:pr:`2214`) :user:`dependabot`
+#)  build(deps-dev): bump bump-my-version from 0.16.2 to 0.17.0 (:pr:`2213`) :user:`dependabot`
+#)  winversioninfo: fix version string and improve coverage/tests (:pr:`2211`) :user:`marcelotduarte`
+#)  chore: Update copyright year and license (:pr:`2209`) :user:`marcelotduarte`
+#)  docs: open external links in new tab (:pr:`2208`) :user:`marcelotduarte`
+#)  hooks: add pyproj (:pr:`2207`) :user:`marcelotduarte`
+#)  winmsvcr: extend support for VS 2022 (:pr:`2204`) :user:`marcelotduarte`
+#)  hooks: opencv-python - minor fixes (:pr:`2206`) :user:`marcelotduarte`
+#)  freezer: improve/fixes validate_executable (:pr:`2205`) :user:`marcelotduarte`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2202`) :user:`pre-commit-ci`
+#)  build(deps-dev): bump bump-my-version from 0.16.1 to 0.16.2 (:pr:`2201`) :user:`dependabot`
+#)  tests: minor tweaks - part 2 (:pr:`2198`) :user:`marcelotduarte`
+#)  tests: minor tweaks - part 1 (:pr:`2197`) :user:`marcelotduarte`
+#)  build(deps-dev): bump pre-commit up to 3.6.0 and sphinx up to 7.2.6 (:pr:`2196`) :user:`marcelotduarte`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2195`) :user:`pre-commit-ci`
+#)  build(deps-dev): bump bump-my-version from 0.16.0 to 0.16.1 (:pr:`2194`) :user:`dependabot`
+#)  build(deps-dev): bump bump-my-version from 0.15.4 to 0.16.0 (:pr:`2191`) :user:`dependabot`
+#)  tests: simplify more tests using run_command (:pr:`2189`) :user:`marcelotduarte`
+#)  tests: simplify test using a run_command (:pr:`2187`) :user:`marcelotduarte`
+#)  build(deps-dev): bump pytest from 7.4.3 to 7.4.4 (:pr:`2188`) :user:`dependabot`
+#)  build(deps-dev): bump bump-my-version from 0.15.3 to 0.15.4 (:pr:`2186`) :user:`dependabot`
+#)  setup script: add an extension to executable icon that is valid across OS (:pr:`2185`) :user:`marcelotduarte`
+#)  setup script: pre-defined values for base are valid in all OS (:pr:`2184`) :user:`marcelotduarte`
+#)  setup script: extend executables keyword to support more types (:pr:`2182`) :user:`marcelotduarte`
+#)  bdist_appimage: build Linux AppImage format [new feature] (:pr:`2050`) :user:`marcelotduarte`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2181`) :user:`pre-commit-ci`
+#)  build(deps-dev): bump bump-my-version from 0.15.1 to 0.15.3 (:pr:`2178`) :user:`dependabot`
+#)  build-wheel: fix update_bases' ref and cleanup publish (:pr:`2176`) :user:`marcelotduarte`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2175`) :user:`pre-commit-ci`
+#)  build(deps-dev): bump bump-my-version from 0.12.0 to 0.15.1 (:pr:`2174`) :user:`dependabot`
+#)  Bump version: 6.16.0-dev11 → 6.16.0-dev12 [ci skip] (:pr:`2173`) :user:`marcelotduarte`
+#)  bdist_mac: create symlink between folders specified by user under Resources (:pr:`2169`) :user:`admin`
+#)  fix: #2139 introduced a regression [macos] (:pr:`2172`) :user:`marcelotduarte`
+#)  hooks: add AV and PyAV (:pr:`2165`) :user:`marcelotduarte`
+#)  build: fix build_wheel (after #2162 and #2163) (:pr:`2170`) :user:`marcelotduarte`
+#)  build(deps): bump actions/download-artifact from 3 to 4 (:pr:`2163`) :user:`dependabot`
+#)  build(deps): bump actions/upload-artifact from 3 to 4 (:pr:`2162`) :user:`dependabot`
+#)  build(deps): bump github/codeql-action from 2 to 3 (:pr:`2160`) :user:`dependabot`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2157`) :user:`pre-commit-ci`
+#)  build(deps-dev): bump pylint from 3.0.2 to 3.0.3 (:pr:`2156`) :user:`dependabot`
+#)  build(deps): bump actions/setup-python from 4 to 5 (:pr:`2155`) :user:`dependabot`
+#)  Replace SetDllDirectory by AddDllDirectory (:pr:`2144`) :user:`dev`
+#)  Bump version: 6.16.0-dev10 → 6.16.0-dev11 [ci skip] (:pr:`2151`) :user:`marcelotduarte`
+#)  fix: pthread missing for building in FreeBSD (:pr:`2150`) :user:`marcelotduarte`
+#)  build(deps): bump wheel from 0.41.3 to 0.42.0 (:pr:`2148`) :user:`dependabot`
+#)  build(deps-dev): bump bump-my-version from 0.11.0 to 0.12.0 (:pr:`2147`) :user:`dependabot`
+#)  chore: switch to bump-my-version (:pr:`2146`) :user:`marcelotduarte`
+#)  bdist_mac: apply the style of other bdist modules (:pr:`2139`) :user:`marcelotduarte`
+#)  hooks: add yt_dlp (:pr:`2145`) :user:`marcelotduarte`
+#)  build(deps-dev): bump pytest-xdist[psutil] from 3.4.0 to 3.5.0 (:pr:`2143`) :user:`dependabot`
+#)  build(deps): update setuptools requirement from <69,>=62.6 to >=62.6,<70 (:pr:`2141`) :user:`dependabot`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2142`) :user:`pre-commit-ci`
+#)  freezer: Improve symlink support to work w/ macOS (:pr:`2138`) :user:`marcelotduarte`
+#)  hooks: adds anyio, pyarrow and tiktoken (:pr:`2134`) :user:`marcelotduarte`
+#)  chore: cosmetic and minor tweaks (:pr:`2137`) :user:`marcelotduarte`
+#)  build_exe: raise exception on invalid build_exe option (:pr:`2132`) :user:`marcelotduarte`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2130`) :user:`pre-commit-ci`
+#)  build(deps-dev): bump pytest-xdist[psutil] from 3.3.1 to 3.4.0 (:pr:`2129`) :user:`dependabot`
+#)  samples: improve qt samples (:pr:`2128`) :user:`marcelotduarte`
+#)  hooks: Support for PyQt5/PySide2 QtWebEngine in macOS (:pr:`2127`) :user:`marcelotduarte`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2125`) :user:`pre-commit-ci`
+#)  hooks: Support for PyQt6/PySide6 QtWebEngine in macOS (:pr:`2124`) :user:`marcelotduarte`
+#)  hooks: use a different approach for pyqt6 in bdist_mac (:pr:`2123`) :user:`marcelotduarte`
+#)  hooks: fix pyqt6 in bdist_mac (.app) (:pr:`2122`) :user:`marcelotduarte`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2120`) :user:`pre-commit-ci`
+#)  build(deps): bump wheel from 0.41.2 to 0.41.3 (:pr:`2119`) :user:`dependabot`
+#)  build(deps-dev): bump pytest from 7.4.2 to 7.4.3 (:pr:`2115`) :user:`dependabot`
+#)  "Bump version: 6.16.0-dev9 → 6.16.0-dev10 [ci skip]" (:pr:`2114`) :user:`marcelotduarte`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2113`) :user:`pre-commit-ci`
+#)  build(deps-dev): bump sphinx-tabs from 3.4.1 to 3.4.4 (:pr:`2112`) :user:`dependabot`
+#)  build(deps-dev): bump pylint from 3.0.1 to 3.0.2 (:pr:`2111`) :user:`dependabot`
+#)  hooks: fix qtwebengine in conda-forge (:pr:`2110`) :user:`marcelotduarte`
+#)  hooks: fix qt.conf for pyqt [macos] (:pr:`2109`) :user:`marcelotduarte`
+#)  hooks: tweaks to the debugging of qt hooks (:pr:`2108`) :user:`marcelotduarte`
+#)  bdist_mac: move set_relative_reference_paths to build_exe (:pr:`2106`) :user:`marcelotduarte`
+#)  darwintools: fix adhocsignature for universal2 machine (:pr:`2107`) :user:`marcelotduarte`
+#)  bdist_mac: make symlink between Resources/share and Contents/MacOS (:pr:`2105`) :user:`marcelotduarte`
+#)  parse: regression fix in get_dependent_files [windows] (:pr:`2104`) :user:`marcelotduarte`
+#)  bdist_mac: skip text files in set_relative_reference_paths (:pr:`2102`) :user:`micah`
+#)  build(deps-dev): bump pytest-mock from 3.11.1 to 3.12.0 (:pr:`2103`) :user:`dependabot`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2101`) :user:`pre-commit-ci`
+#)  bases: update base executables and util module [ci skip] (:pr:`2100`) :user:`marcelotduarte`
+#)  chore: update base executables and util module [ci skip] (:pr:`2099`) :user:`marcelotduarte`
+#)  "Bump version: 6.16.0-dev8 → 6.16.0-dev9 [ci skip]" (:pr:`2098`) :user:`marcelotduarte`
+#)  fix: issues with manifest and windows version (:pr:`2097`) :user:`marcelotduarte`
+#)  build(deps-dev): bump pre-commit from 3.4.0 to 3.5.0 (:pr:`2096`) :user:`dependabot`
+#)  hooks: add triton and support for pytorch 2.1 (:pr:`2090`) :user:`marcelotduarte`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2092`) :user:`pre-commit-ci`
+#)  build(deps-dev): bump pytest-timeout from 2.1.0 to 2.2.0 (:pr:`2091`) :user:`dependabot`
+#)  build(deps-dev): bump pylint from 3.0.0 to 3.0.1 (:pr:`2089`) :user:`dependabot`
+#)  build(deps-dev): bump cibuildwheel from 2.16.1 to 2.16.2 (:pr:`2085`) :user:`dependabot`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2082`) :user:`pre-commit-ci`
+#)  build(deps-dev): bump pylint from 2.17.6 to 3.0.0 (:pr:`2081`) :user:`dependabot`
+#)  tests: use importorskip/skip at module level to skip early (:pr:`2084`) :user:`marcelotduarte`
+#)  chore: rewrite some imports as absolute (:pr:`2083`) :user:`marcelotduarte`
+#)  bdist_deb: add doc and tests (:pr:`2080`) :user:`marcelotduarte`
+#)  doc: minor fixes (:pr:`2079`) :user:`marcelotduarte`
+#)  bdist_deb: create an DEB distribution [new feature] (:pr:`2078`) :user:`marcelotduarte`
+#)  bdist_rpm: remove unused options (:pr:`2077`) :user:`marcelotduarte`
+#)  "Bump version: 6.16.0-dev7 → 6.16.0-dev8 [ci skip]" (:pr:`2076`) :user:`marcelotduarte`
+#)  bdist_rpm: fix issue with install prefix (:pr:`2075`) :user:`marcelotduarte`
+#)  hooks: initialize blas [numpy conda-forge] (:pr:`2074`) :user:`49456524+IperGiove`
+#)  parser: exclude LD_PRELOAD to not include triggered dependencies (:pr:`2073`) :user:`marcelotduarte`
+#)  hooks: add tidylib (:pr:`2072`) :user:`marcelotduarte`
+#)  parser: use the internal path instead of sys.path (:pr:`2071`) :user:`marcelotduarte`
+#)  fix: avoid false builtin modules developing in multi-environment (:pr:`2070`) :user:`marcelotduarte`
+#)  build(deps-dev): bump cibuildwheel from 2.16.0 to 2.16.1 (:pr:`2069`) :user:`dependabot`
+#)  hooks: move tkinter and tz data to share folder (:pr:`2067`) :user:`marcelotduarte`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2066`) :user:`pre-commit-ci`
+#)  build(deps-dev): bump pylint from 2.17.5 to 2.17.6 (:pr:`2065`) :user:`dependabot`
+#)  tests: minor tweaks (:pr:`2063`) :user:`marcelotduarte`
+#)  build_exe: fix typo in command line boolean option 'include-msvcr' (:pr:`2062`) :user:`marcelotduarte`
+#)  hooks: fix scipy windows (:pr:`2060`) :user:`marcelotduarte`
+#)  doc: improve documentation for 'binary wheels' (:pr:`2059`) :user:`marcelotduarte`
+#)  hooks: add numpy 1.26 (:pr:`2058`) :user:`marcelotduarte`
+#)  hooks: fix numpy/scipy regression [mingw] (:pr:`2057`) :user:`marcelotduarte`
+#)  build(deps-dev): bump cibuildwheel from 2.15.0 to 2.16.0 (:pr:`2056`) :user:`dependabot`
+#)  hooks: add RNS (Reticulum) (:pr:`2053`) :user:`marcelotduarte`
+#)  bdist_mac: Copy build_exe to Resources and move executables to MacOS (:pr:`2048`) :user:`marcelotduarte`
+#)  hooks: fix numpy/scipy dylibs are included twice (:pr:`2038`) :user:`marcelotduarte`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2055`) :user:`pre-commit-ci`
+#)  "Bump version: 6.16.0-dev6 → 6.16.0-dev7 [ci skip]" (:pr:`2052`) :user:`marcelotduarte`
+#)  icons: add Python icons (:pr:`2051`) :user:`marcelotduarte`
+#)  Revert "build(deps): bump codecov/codecov-action from 3 to 4" (:pr:`2049`) :user:`marcelotduarte`
+#)  build(deps): bump codecov/codecov-action from 3 to 4 (:pr:`2047`) :user:`dependabot`
+#)  samples: small tweaks to demonstrate independent options (:pr:`2045`) :user:`marcelotduarte`
+#)  build(deps): bump docker/setup-qemu-action from 2 to 3 (:pr:`2044`) :user:`dependabot`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2043`) :user:`pre-commit-ci`
+#)  bdist_mac: small optimization on copy tree (:pr:`2040`) :user:`marcelotduarte`
+#)  bdist_mac: fix duplicate lib in bdist_dmg [regression] (:pr:`2037`) :user:`marcelotduarte`
+#)  hooks: improve numpy and pandas hooks (:pr:`2036`) :user:`marcelotduarte`
+#)  build(deps-dev): bump pytest from 7.4.1 to 7.4.2 (:pr:`2035`) :user:`dependabot`
+#)  "Bump version: 6.16.0-dev5 → 6.16.0-dev6 [ci skip]" (:pr:`2034`) :user:`marcelotduarte`
+#)  doc: Building binary wheels (:pr:`2033`) :user:`marcelotduarte`
+#)  hooks: add support for pandas 2.1.0 (:pr:`2032`) :user:`marcelotduarte`
+#)  build-wheel: fix build and compatibility w/ build 1.0 (:pr:`2030`) :user:`marcelotduarte`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2031`) :user:`pre-commit-ci`
+#)  build(deps): bump actions/checkout from 3 to 4 (:pr:`2029`) :user:`dependabot`
+#)  build(deps-dev): bump pytest from 7.4.0 to 7.4.1 (:pr:`2028`) :user:`dependabot`
+#)  build(deps-dev): bump pre-commit from 3.3.3 to 3.4.0 (:pr:`2027`) :user:`dependabot`
+#)  bdis_mac: Builds pass macOS notarization (:pr:`2025`) :user:`johan.ronnkvist`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2024`) :user:`pre-commit-ci`
+#)  build(deps-dev): bump pluggy from 1.2.0 to 1.3.0 (:pr:`2023`) :user:`dependabot`
+#)  hooks: add pycryptodomex and update pycryptodome (:pr:`2022`) :user:`marcelotduarte`
+#)  build-wheel: add support for ppc64le binary wheels for py310+ (:pr:`2020`) :user:`marcelotduarte`
+#)  hooks: use module.exclude_names to filter missing modules (:pr:`2019`) :user:`marcelotduarte`
+#)  hooks: improve tzdata/zoneinfo/pytz hooks a bit for use in zip (:pr:`2018`) :user:`marcelotduarte`
+#)  build(deps-dev): bump wheel from 0.41.1 to 0.41.2 (:pr:`2017`) :user:`dependabot`
+#)  doc: furo can be used only on html build (:pr:`2015`) :user:`marcelotduarte`
+#)  build(deps-dev): update pre-commit and doc dependencies (:pr:`2014`) :user:`marcelotduarte`
+#)  module: search for the stub file already parsed in the distribution (:pr:`2013`) :user:`marcelotduarte`
+#)  hooks: qt extension modules are detected using stubs (:pr:`2009`) :user:`marcelotduarte`
+#)  module: add a importshed for parsed stubs (:pr:`2008`) :user:`marcelotduarte`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2007`) :user:`pre-commit-ci`
+#)  module: get the implicit imports of extensions in a stub file (:pr:`2006`) :user:`marcelotduarte`
+#)  module: propagate cache_path from the finder (:pr:`2005`) :user:`marcelotduarte`
+#)  chore: new internal _typing module (:pr:`2004`) :user:`marcelotduarte`
+#)  finder: cache_path holds where distribution data is saved (:pr:`2003`) :user:`marcelotduarte`
+#)  build(deps-dev): bump cibuildwheel from 2.14.1 to 2.15.0 (:pr:`2002`) :user:`dependabot`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2000`) :user:`pre-commit-ci`
+#)  build(deps-dev): bump wheel from 0.41.0 to 0.41.1 (:pr:`1999`) :user:`dependabot`
+#)  hooks: add markdown (:pr:`1997`) :user:`marcelotduarte`
+#)  finder: improve scan code to detect packages using import call (:pr:`1966`) :user:`marcelotduarte`
+#)  build(deps-dev): bump sphinx from 7.1.1 to 7.1.2 (:pr:`1995`) :user:`dependabot`
+#)  module: ModuleHook class to support inheritance (:pr:`1998`) :user:`marcelotduarte`
+#)  Bump version: 6.16.0-dev5 (:pr:`1994`) :user:`marcelotduarte`
+#)  hooks: fix pyqt5 webengine [conda linux] (:pr:`1993`) :user:`marcelotduarte`
+#)  hooks: fix pyside2 webengine [conda linux] (:pr:`1992`) :user:`marcelotduarte`
+#)  samples: document the use of qt samples in conda-forge (:pr:`1991`) :user:`marcelotduarte`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`1990`) :user:`pre-commit-ci`
+#)  build(deps-dev): bump sphinx from 7.1.0 to 7.1.1 (:pr:`1989`) :user:`dependabot`
+#)  hooks: move ssl hook to a submodule (:pr:`1988`) :user:`marcelotduarte`
+#)  build(deps-dev): bump pylint from 2.17.4 to 2.17.5 (:pr:`1987`) :user:`dependabot`
+#)  build(deps-dev): bump sphinx from 7.0.1 to 7.1.0 (:pr:`1985`) :user:`dependabot`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`1983`) :user:`pre-commit-ci`
+#)  build(deps-dev): bump wheel from 0.40.0 to 0.41.0 (:pr:`1982`) :user:`dependabot`
+#)  hooks: Disable sandbox in PySide2 WebEngine [Linux and Windows] (:pr:`1981`) :user:`marcelotduarte`
+#)  hooks: Disable sandbox in PyQt5 WebEngine [Linux and Windows] (:pr:`1980`) :user:`marcelotduarte`
+#)  hooks: support opencv-python 4.8.0 [msys2] (:pr:`1975`) :user:`marcelotduarte`
+#)  hooks: support pyside6 6.5.1 [conda] (:pr:`1979`) :user:`marcelotduarte`
+#)  hooks: support for pyqt6 6.5.1 [msys2] (:pr:`1977`) :user:`marcelotduarte`
+#)  hooks: support pyside2 5.15.8 [msys2] (:pr:`1978`) :user:`marcelotduarte`
+#)  hooks: fix for pyqt [conda linux] (:pr:`1976`) :user:`marcelotduarte`
+#)  finder: add base modules at the end to simplify tests (:pr:`1974`) :user:`marcelotduarte`
+#)  hooks: PySide2/6 - shiboken2/6 in zip_include_packages (:pr:`1970`) :user:`marcelotduarte`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`1973`) :user:`pre-commit-ci`
+#)  build-wheel: put jobs in concurrency for speedup [skip ci] (:pr:`1971`) :user:`marcelotduarte`
+#)  build(deps-dev): bump cibuildwheel from 2.14.0 to 2.14.1 (:pr:`1972`) :user:`dependabot`
+#)  startup: get rid of sysconfig at startup (:pr:`1968`) :user:`marcelotduarte`
+#)  hooks: update sysconfig hook (:pr:`1967`) :user:`marcelotduarte`
+#)  samples: update samples using wxPython (:pr:`1965`) :user:`marcelotduarte`
+#)  hooks: multiprocessing support for forkserver and spawn (:pr:`1956`) :user:`marcelotduarte`
+#)  hooks: add py-cord (fork of discord) (:pr:`1964`) :user:`marcelotduarte`
+#)  tests: rewrite create_package to support dedent (:pr:`1960`) :user:`marcelotduarte`
+#)  fix: bdist_rpm to pass tests in python 3.12b4 (:pr:`1963`) :user:`marcelotduarte`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`1959`) :user:`pre-commit-ci`
 #)  Bump version: 6.16.0-dev1 → 6.16.0-dev2 :user:`marcelotduarte`
-#)  chore: enable Python 3.12 wheels and remove universal2 (:pull:`1958`) :user:`marcelotduarte`
-#)  build(deps-dev): bump cibuildwheel from 2.13.1 to 2.14.0 (:pull:`1957`) :user:`dependabot`
-#)  hooks: add boto3 (:pull:`1955`) :user:`marcelotduarte`
-#)  hooks: move sklearn hook to a submodule (:pull:`1954`) :user:`marcelotduarte`
-#)  hooks: fix the sentry_sdk hook (:pull:`1953`) :user:`marcelotduarte`
-#)  hooks: improve hook for pillow [macos] (:pull:`1952`) :user:`marcelotduarte`
-#)  fix: add rpath in macos executable [conda macos] (:pull:`1951`) :user:`marcelotduarte`
-#)  samples: fix pydantic sample to work python < 3.10 (:pull:`1949`) :user:`marcelotduarte`
-#)  chore: add more coverage reports [skip ci] (:pull:`1950`) :user:`marcelotduarte`
-#)  fix: detection of dependent files and python shared library [conda linux/macos] (:pull:`1946`) :user:`marcelotduarte`
-#)  fix: copy dependent files on "lib" directory [macOS] (:pull:`1942`) :user:`marcelotduarte`
-#)  fix: support clang -fno-lto [conda macos] (:pull:`1948`) :user:`marcelotduarte`
-#)  test: xfail some tests when rpmbuild is not present (:pull:`1947`) :user:`marcelotduarte`
-#)  fix: bdist_rpm should generate only binaries [linux] (:pull:`1945`) :user:`marcelotduarte`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`1944`) :user:`pre-commit-ci`
+#)  chore: enable Python 3.12 wheels and remove universal2 (:pr:`1958`) :user:`marcelotduarte`
+#)  build(deps-dev): bump cibuildwheel from 2.13.1 to 2.14.0 (:pr:`1957`) :user:`dependabot`
+#)  hooks: add boto3 (:pr:`1955`) :user:`marcelotduarte`
+#)  hooks: move sklearn hook to a submodule (:pr:`1954`) :user:`marcelotduarte`
+#)  hooks: fix the sentry_sdk hook (:pr:`1953`) :user:`marcelotduarte`
+#)  hooks: improve hook for pillow [macos] (:pr:`1952`) :user:`marcelotduarte`
+#)  fix: add rpath in macos executable [conda macos] (:pr:`1951`) :user:`marcelotduarte`
+#)  samples: fix pydantic sample to work python < 3.10 (:pr:`1949`) :user:`marcelotduarte`
+#)  chore: add more coverage reports [skip ci] (:pr:`1950`) :user:`marcelotduarte`
+#)  fix: detection of dependent files and python shared library [conda linux/macos] (:pr:`1946`) :user:`marcelotduarte`
+#)  fix: copy dependent files on "lib" directory [macOS] (:pr:`1942`) :user:`marcelotduarte`
+#)  fix: support clang -fno-lto [conda macos] (:pr:`1948`) :user:`marcelotduarte`
+#)  test: xfail some tests when rpmbuild is not present (:pr:`1947`) :user:`marcelotduarte`
+#)  fix: bdist_rpm should generate only binaries [linux] (:pr:`1945`) :user:`marcelotduarte`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`1944`) :user:`pre-commit-ci`
 #)  bases: update base executables and util module :user:`marcelotduarte`
-#)  chore: more fine tuning pytest options [ci skip] (:pull:`1941`) :user:`marcelotduarte`
-#)  tests: build executable to test in a subprocess (:pull:`1940`) :user:`marcelotduarte`
-#)  chore: fine tuning pytest options (:pull:`1939`) :user:`marcelotduarte`
-#)  chore: tweak to remove excess of pylint and noqa (:pull:`1938`) :user:`marcelotduarte`
-#)  chore: add basic support for Python 3.12 (:pull:`1925`) :user:`marcelotduarte`
-#)  parser: support for lief 0.14 ParserConfig (:pull:`1924`) :user:`marcelotduarte`
-#)  chore: drop support for python 3.7 (:pull:`1935`) :user:`marcelotduarte`
-#)  chore: to use pre-commit.ci add skip option (:pull:`1936`) :user:`marcelotduarte`
-#)  Bump version: 6.16.0-dev0 → 6.16.0-dev1 (:pull:`1933`) :user:`marcelotduarte`
-#)  chore: use pytest-xdist to speed up the tests (:pull:`1932`) :user:`marcelotduarte`
-#)  fix: zip_include_packages/zip_exclude_packages regression (:pull:`1922`) :user:`marcelotduarte`
-#)  build(deps-dev): bump ruff from 0.0.272 to 0.0.275 (:pull:`1930`) :user:`marcelotduarte`
-#)  tests: add more test cases for ModuleFinder class (:pull:`1929`) :user:`marcelotduarte`
-#)  tests: add more samples to tests (:pull:`1928`) :user:`marcelotduarte`
-#)  chore: use pytest-datafiles to run tests in temporary path (:pull:`1927`) :user:`marcelotduarte`
-#)  build(deps-dev): bump pytest from 7.3.2 to 7.4.0 (:pull:`1926`) :user:`dependabot`
-#)  chore: cleanup tests and dependencies (:pull:`1923`) :user:`marcelotduarte`
-#)  build(deps): update setuptools requirement from <68,>=62.6 to >=62.6,<69 (:pull:`1919`) :user:`dependabot`
-#)  build(deps-dev): bump pytest-mock from 3.10.0 to 3.11.1 (:pull:`1918`) :user:`dependabot`
-#)  chore: bump ruff 0.0.272 and fix local/system dependencies (:pull:`1914`) :user:`marcelotduarte`
-#)  linux: bdist_rpm depends on rpmbuild being installed (:pull:`1913`) :user:`marcelotduarte`
-#)  build(deps-dev): bump cibuildwheel from 2.13.0 to 2.13.1 (:pull:`1909`) :user:`dependabot`
-#)  build(deps-dev): bump pytest from 7.3.1 to 7.3.2 (:pull:`1908`) :user:`dependabot`
-#)  Bump version: 6.15.0 → 6.16.0-dev0 (:pull:`1905`) :user:`marcelotduarte`
-#)  samples: add scipy sample (:pull:`1904`) :user:`marcelotduarte`
-#)  hooks: fix scipy hooks used in zip_include_packages (:pull:`1903`) :user:`marcelotduarte`
-#)  samples: update matplotlib sample using Wx (and remove deprecated test) (:pull:`1902`) :user:`marcelotduarte`
-#)  samples: add a new matplotlib sample using Tk (:pull:`1901`) :user:`marcelotduarte`
-#)  hooks: fix matplotlib hooks used in zip_include_packages (:pull:`1897`) :user:`marcelotduarte`
-#)  hooks: improve scipy hooks (:pull:`1896`) :user:`marcelotduarte`
-#)  fix: increase maximum recursion depth (:pull:`1890`) :user:`marcelotduarte`
+#)  chore: more fine tuning pytest options [ci skip] (:pr:`1941`) :user:`marcelotduarte`
+#)  tests: build executable to test in a subprocess (:pr:`1940`) :user:`marcelotduarte`
+#)  chore: fine tuning pytest options (:pr:`1939`) :user:`marcelotduarte`
+#)  chore: tweak to remove excess of pylint and noqa (:pr:`1938`) :user:`marcelotduarte`
+#)  chore: add basic support for Python 3.12 (:pr:`1925`) :user:`marcelotduarte`
+#)  parser: support for lief 0.14 ParserConfig (:pr:`1924`) :user:`marcelotduarte`
+#)  chore: drop support for python 3.7 (:pr:`1935`) :user:`marcelotduarte`
+#)  chore: to use pre-commit.ci add skip option (:pr:`1936`) :user:`marcelotduarte`
+#)  Bump version: 6.16.0-dev0 → 6.16.0-dev1 (:pr:`1933`) :user:`marcelotduarte`
+#)  chore: use pytest-xdist to speed up the tests (:pr:`1932`) :user:`marcelotduarte`
+#)  fix: zip_include_packages/zip_exclude_packages regression (:pr:`1922`) :user:`marcelotduarte`
+#)  build(deps-dev): bump ruff from 0.0.272 to 0.0.275 (:pr:`1930`) :user:`marcelotduarte`
+#)  tests: add more test cases for ModuleFinder class (:pr:`1929`) :user:`marcelotduarte`
+#)  tests: add more samples to tests (:pr:`1928`) :user:`marcelotduarte`
+#)  chore: use pytest-datafiles to run tests in temporary path (:pr:`1927`) :user:`marcelotduarte`
+#)  build(deps-dev): bump pytest from 7.3.2 to 7.4.0 (:pr:`1926`) :user:`dependabot`
+#)  chore: cleanup tests and dependencies (:pr:`1923`) :user:`marcelotduarte`
+#)  build(deps): update setuptools requirement from <68,>=62.6 to >=62.6,<69 (:pr:`1919`) :user:`dependabot`
+#)  build(deps-dev): bump pytest-mock from 3.10.0 to 3.11.1 (:pr:`1918`) :user:`dependabot`
+#)  chore: bump ruff 0.0.272 and fix local/system dependencies (:pr:`1914`) :user:`marcelotduarte`
+#)  linux: bdist_rpm depends on rpmbuild being installed (:pr:`1913`) :user:`marcelotduarte`
+#)  build(deps-dev): bump cibuildwheel from 2.13.0 to 2.13.1 (:pr:`1909`) :user:`dependabot`
+#)  build(deps-dev): bump pytest from 7.3.1 to 7.3.2 (:pr:`1908`) :user:`dependabot`
+#)  Bump version: 6.15.0 → 6.16.0-dev0 (:pr:`1905`) :user:`marcelotduarte`
+#)  samples: add scipy sample (:pr:`1904`) :user:`marcelotduarte`
+#)  hooks: fix scipy hooks used in zip_include_packages (:pr:`1903`) :user:`marcelotduarte`
+#)  samples: update matplotlib sample using Wx (and remove deprecated test) (:pr:`1902`) :user:`marcelotduarte`
+#)  samples: add a new matplotlib sample using Tk (:pr:`1901`) :user:`marcelotduarte`
+#)  hooks: fix matplotlib hooks used in zip_include_packages (:pr:`1897`) :user:`marcelotduarte`
+#)  hooks: improve scipy hooks (:pr:`1896`) :user:`marcelotduarte`
+#)  fix: increase maximum recursion depth (:pr:`1890`) :user:`marcelotduarte`
 #)  bases: update base executables and util module :user:`marcelotduarte`
-#)  build(deps-dev): bump cibuildwheel from 2.12.3 to 2.13.0 (:pull:`1893`) :user:`dependabot`
-#)  build(deps-dev): bump pytest-cov from 4.0.0 to 4.1.0 (:pull:`1891`) :user:`dependabot`
-#)  Exit with non-zero exit code on exception (:pull:`1783`) :user:`johan.ronnkvist`
+#)  build(deps-dev): bump cibuildwheel from 2.12.3 to 2.13.0 (:pr:`1893`) :user:`dependabot`
+#)  build(deps-dev): bump pytest-cov from 4.0.0 to 4.1.0 (:pr:`1891`) :user:`dependabot`
+#)  Exit with non-zero exit code on exception (:pr:`1783`) :user:`johan.ronnkvist`

--- a/doc/src/releasenotes.rst
+++ b/doc/src/releasenotes.rst
@@ -14,350 +14,350 @@ Release notes
 
 Version 8.3 (May 11)
 --------------------
-#)  Bump version: 8.3.0-dev.0 → 8.3.0 [ci skip] (:pull:`2953`) :user:`marcelotduarte`
-#)  chore: build wheels only for Python 3.11-3.13 on non conventional archs [ci skip] (:pull:`2952`) :user:`marcelotduarte`
-#)  tests: improve install-tools and fixes build-wheel (:pull:`2950`) :user:`marcelotduarte`
-#)  tests: improve build and test on mingw (:pull:`2947`) :user:`marcelotduarte`
-#)  tests: use include_msvcr because tests should pass in a clean system (:pull:`2949`) :user:`marcelotduarte`
-#)  tests: tweaks to work on mingw (:pull:`2948`) :user:`marcelotduarte`
-#)  build(deps): bump pytest-timeout from 2.3.1 to 2.4.0 (:pull:`2946`) :user:`dependabot`
-#)  build(deps): update setuptools requirement from <=80.3.0,>=65.6.3 to >=65.6.3,<=80.3.1 (:pull:`2945`) :user:`dependabot`
-#)  build(deps): update lief requirement to >= 0.15.1 [windows] (:pull:`2944`) :user:`marcelotduarte`
-#)  chore: experimental support for windows arm64 (:pull:`2943`) :user:`marcelotduarte`
-#)  hooks: ensure zlib1.dll is copied if lief is not used in Python 3.12+ (:pull:`2942`) :user:`marcelotduarte`
-#)  build(deps): update setuptools requirement from <=80.0.0,>=65.6.3 to >=65.6.3,<=80.1.0 (:pull:`2941`) :user:`dependabot`
-#)  hooks: add zeroconf (:pull:`2932`) :user:`marcelotduarte`
-#)  build(deps-dev): bump cibuildwheel from 2.23.2 to 2.23.3 (:pull:`2939`) :user:`dependabot`
-#)  build(deps): update setuptools requirement from <=79.0.1,>=65.6.3 to >=65.6.3,<=80.0.0 (:pull:`2940`) :user:`dependabot`
-#)  bases: update base executables and util module [ci skip] (:pull:`2937`) :user:`marcelotduarte`
-#)  hooks: typo in sklearn hook (:pull:`2930`) :user:`marcelotduarte`
-#)  chore: use codespell (:pull:`2936`) :user:`marcelotduarte`
-#)  hooks: support pyarrow 20 on windows (:pull:`2935`) :user:`marcelotduarte`
-#)  chore: get rid of typing_extensions (:pull:`2934`) :user:`marcelotduarte`
-#)  tests: improve fixture tmp_package (install binary) (:pull:`2933`) :user:`marcelotduarte`
-#)  compat: normalize SOABI in mingw python (:pull:`2931`) :user:`marcelotduarte`
-#)  build(deps): bump astral-sh/setup-uv from 5 to 6 (:pull:`2928`) :user:`dependabot`
-#)  build(deps): update setuptools requirement from <=79.0.0,>=65.6.3 to >=65.6.3,<=79.0.1 (:pull:`2927`) :user:`dependabot`
-#)  tests: improve dep_parser tests (:pull:`2925`) :user:`marcelotduarte`
-#)  tests: improve bdist_appimage (:pull:`2924`) :user:`marcelotduarte`
-#)  Bump version: 8.2.0 → 8.3.0-dev.0 [ci skip] (:pull:`2923`) :user:`marcelotduarte`
+#)  Bump version: 8.3.0-dev.0 → 8.3.0 [ci skip] (:pr:`2953`) :user:`marcelotduarte`
+#)  chore: build wheels only for Python 3.11-3.13 on non conventional archs [ci skip] (:pr:`2952`) :user:`marcelotduarte`
+#)  tests: improve install-tools and fixes build-wheel (:pr:`2950`) :user:`marcelotduarte`
+#)  tests: improve build and test on mingw (:pr:`2947`) :user:`marcelotduarte`
+#)  tests: use include_msvcr because tests should pass in a clean system (:pr:`2949`) :user:`marcelotduarte`
+#)  tests: tweaks to work on mingw (:pr:`2948`) :user:`marcelotduarte`
+#)  build(deps): bump pytest-timeout from 2.3.1 to 2.4.0 (:pr:`2946`) :user:`dependabot`
+#)  build(deps): update setuptools requirement from <=80.3.0,>=65.6.3 to >=65.6.3,<=80.3.1 (:pr:`2945`) :user:`dependabot`
+#)  build(deps): update lief requirement to >= 0.15.1 [windows] (:pr:`2944`) :user:`marcelotduarte`
+#)  chore: experimental support for windows arm64 (:pr:`2943`) :user:`marcelotduarte`
+#)  hooks: ensure zlib1.dll is copied if lief is not used in Python 3.12+ (:pr:`2942`) :user:`marcelotduarte`
+#)  build(deps): update setuptools requirement from <=80.0.0,>=65.6.3 to >=65.6.3,<=80.1.0 (:pr:`2941`) :user:`dependabot`
+#)  hooks: add zeroconf (:pr:`2932`) :user:`marcelotduarte`
+#)  build(deps-dev): bump cibuildwheel from 2.23.2 to 2.23.3 (:pr:`2939`) :user:`dependabot`
+#)  build(deps): update setuptools requirement from <=79.0.1,>=65.6.3 to >=65.6.3,<=80.0.0 (:pr:`2940`) :user:`dependabot`
+#)  bases: update base executables and util module [ci skip] (:pr:`2937`) :user:`marcelotduarte`
+#)  hooks: typo in sklearn hook (:pr:`2930`) :user:`marcelotduarte`
+#)  chore: use codespell (:pr:`2936`) :user:`marcelotduarte`
+#)  hooks: support pyarrow 20 on windows (:pr:`2935`) :user:`marcelotduarte`
+#)  chore: get rid of typing_extensions (:pr:`2934`) :user:`marcelotduarte`
+#)  tests: improve fixture tmp_package (install binary) (:pr:`2933`) :user:`marcelotduarte`
+#)  compat: normalize SOABI in mingw python (:pr:`2931`) :user:`marcelotduarte`
+#)  build(deps): bump astral-sh/setup-uv from 5 to 6 (:pr:`2928`) :user:`dependabot`
+#)  build(deps): update setuptools requirement from <=79.0.0,>=65.6.3 to >=65.6.3,<=79.0.1 (:pr:`2927`) :user:`dependabot`
+#)  tests: improve dep_parser tests (:pr:`2925`) :user:`marcelotduarte`
+#)  tests: improve bdist_appimage (:pr:`2924`) :user:`marcelotduarte`
+#)  Bump version: 8.2.0 → 8.3.0-dev.0 [ci skip] (:pr:`2923`) :user:`marcelotduarte`
 
 Version 8.2 (Apr 22)
 --------------------
-#)  Bump version: 8.1.0 → 8.2.0 [ci skip] (:pull:`2922`) :user:`marcelotduarte`
-#)  ci: configure coverage paths (:pull:`2921`) :user:`marcelotduarte`
-#)  tests: fix pytest-cov issue (:pull:`2919`) :user:`marcelotduarte`
-#)  tests: use GHA Python 3.13t and small changes (:pull:`2920`) :user:`marcelotduarte`
-#)  tests: improve some tests for better coverage (:pull:`2918`) :user:`marcelotduarte`
-#)  build(deps): update setuptools requirement from <=78.1.0,>=65.6.3 to >=65.6.3,<=79.0.0 (:pull:`2916`) :user:`dependabot`
-#)  dep_parser: minor fix to improve tests (:pull:`2915`) :user:`marcelotduarte`
-#)  tests: fix dep_parser test in windows (:pull:`2914`) :user:`marcelotduarte`
-#)  tests: improve dep_parser test (:pull:`2913`) :user:`marcelotduarte`
-#)  tests: add anyio, asyncio, uvloop (:pull:`2912`) :user:`marcelotduarte`
-#)  tests: add pyarrow, bcrypt<4 (:pull:`2911`) :user:`marcelotduarte`
-#)  module: improve use of constansts, add tests (:pull:`2909`) :user:`marcelotduarte`
-#)  hooks: fix scipy[zip] in Python>=3.10 [macos] (:pull:`2908`) :user:`marcelotduarte`
-#)  hooks: fix mkl on zip and fix tests (:pull:`2907`) :user:`marcelotduarte`
-#)  tests: test ConstantsModule / BUILD_CONSTANTS (:pull:`2906`) :user:`marcelotduarte`
-#)  tests: add more tests for hooks of crypto packages (:pull:`2905`) :user:`marcelotduarte`
-#)  tests: improve coverage of Executable class (:pull:`2904`) :user:`marcelotduarte`
-#)  build(deps-doc): bump sphinx to 8.2.3 [ci skip] (:pull:`2903`) :user:`marcelotduarte`
-#)  tests: improve winversioninfo tests (:pull:`2901`) :user:`marcelotduarte`
-#)  tests: improve tmp_package fixture adding cwd (:pull:`2902`) :user:`marcelotduarte`
-#)  tests: add test for rasterio (test DistributionCache.binary_files) (:pull:`2900`) :user:`marcelotduarte`
-#)  tests: improve coverage a bit (:pull:`2899`) :user:`marcelotduarte`
-#)  tests: add tests to hooks of pytz and ctypes (:pull:`2893`) :user:`marcelotduarte`
-#)  cli: fix case comparison in windows (:pull:`2898`) :user:`marcelotduarte`
-#)  module: add 'name' property to DistributionCache (:pull:`2897`) :user:`marcelotduarte`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2896`) :user:`pre-commit-ci`
-#)  build(deps-dev): bump bump-my-version from 1.1.1 to 1.1.2 (:pull:`2895`) :user:`dependabot`
-#)  tests: improve tests on windows (:pull:`2892`) :user:`marcelotduarte`
-#)  tests: improve hooks tests with a function to install a package (:pull:`2891`) :user:`marcelotduarte`
-#)  ci: Fetch only the required files for testing (:pull:`2890`) :user:`marcelotduarte`
-#)  tests: improve conftest (:pull:`2889`) :user:`marcelotduarte`
-#)  tests: add scipy sample as a hook test (:pull:`2888`) :user:`marcelotduarte`
-#)  tests: cleanup (:pull:`2887`) :user:`marcelotduarte`
-#)  tests: port more tests to use the new fixture 4 (:pull:`2886`) :user:`marcelotduarte`
-#)  tests: port more tests to use the new fixture 3 (:pull:`2885`) :user:`marcelotduarte`
-#)  tests: port more tests to use the new fixture 2 (:pull:`2884`) :user:`marcelotduarte`
-#)  tests: improve mp tests (:pull:`2882`) :user:`marcelotduarte`
-#)  tests: port more tests to use the new fixture (:pull:`2883`) :user:`marcelotduarte`
-#)  tests: add conftest and port stdlib hooks test to use it (:pull:`2881`) :user:`marcelotduarte`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2880`) :user:`pre-commit-ci`
-#)  build(deps): bump pytest-cov from 6.1.0 to 6.1.1 (:pull:`2879`) :user:`dependabot`
-#)  hooks: fix scipy hook on mingw and catch similar errors (:pull:`2877`) :user:`marcelotduarte`
-#)  doc: small review [ci skip] (:pull:`2876`) :user:`marcelotduarte`
-#)  chore: use sys.prefix as frozen directory (:pull:`2874`) :user:`marcelotduarte`
-#)  chore: support for PEP 639 (:pull:`2873`) :user:`marcelotduarte`
-#)  chore: use importlib.resources (:pull:`2872`) :user:`marcelotduarte`
-#)  bdist_msi: Make MSI checkbox to "launch after install" optional (:pull:`2871`) :user:`jeroen`
+#)  Bump version: 8.1.0 → 8.2.0 [ci skip] (:pr:`2922`) :user:`marcelotduarte`
+#)  ci: configure coverage paths (:pr:`2921`) :user:`marcelotduarte`
+#)  tests: fix pytest-cov issue (:pr:`2919`) :user:`marcelotduarte`
+#)  tests: use GHA Python 3.13t and small changes (:pr:`2920`) :user:`marcelotduarte`
+#)  tests: improve some tests for better coverage (:pr:`2918`) :user:`marcelotduarte`
+#)  build(deps): update setuptools requirement from <=78.1.0,>=65.6.3 to >=65.6.3,<=79.0.0 (:pr:`2916`) :user:`dependabot`
+#)  dep_parser: minor fix to improve tests (:pr:`2915`) :user:`marcelotduarte`
+#)  tests: fix dep_parser test in windows (:pr:`2914`) :user:`marcelotduarte`
+#)  tests: improve dep_parser test (:pr:`2913`) :user:`marcelotduarte`
+#)  tests: add anyio, asyncio, uvloop (:pr:`2912`) :user:`marcelotduarte`
+#)  tests: add pyarrow, bcrypt<4 (:pr:`2911`) :user:`marcelotduarte`
+#)  module: improve use of constansts, add tests (:pr:`2909`) :user:`marcelotduarte`
+#)  hooks: fix scipy[zip] in Python>=3.10 [macos] (:pr:`2908`) :user:`marcelotduarte`
+#)  hooks: fix mkl on zip and fix tests (:pr:`2907`) :user:`marcelotduarte`
+#)  tests: test ConstantsModule / BUILD_CONSTANTS (:pr:`2906`) :user:`marcelotduarte`
+#)  tests: add more tests for hooks of crypto packages (:pr:`2905`) :user:`marcelotduarte`
+#)  tests: improve coverage of Executable class (:pr:`2904`) :user:`marcelotduarte`
+#)  build(deps-doc): bump sphinx to 8.2.3 [ci skip] (:pr:`2903`) :user:`marcelotduarte`
+#)  tests: improve winversioninfo tests (:pr:`2901`) :user:`marcelotduarte`
+#)  tests: improve tmp_package fixture adding cwd (:pr:`2902`) :user:`marcelotduarte`
+#)  tests: add test for rasterio (test DistributionCache.binary_files) (:pr:`2900`) :user:`marcelotduarte`
+#)  tests: improve coverage a bit (:pr:`2899`) :user:`marcelotduarte`
+#)  tests: add tests to hooks of pytz and ctypes (:pr:`2893`) :user:`marcelotduarte`
+#)  cli: fix case comparison in windows (:pr:`2898`) :user:`marcelotduarte`
+#)  module: add 'name' property to DistributionCache (:pr:`2897`) :user:`marcelotduarte`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2896`) :user:`pre-commit-ci`
+#)  build(deps-dev): bump bump-my-version from 1.1.1 to 1.1.2 (:pr:`2895`) :user:`dependabot`
+#)  tests: improve tests on windows (:pr:`2892`) :user:`marcelotduarte`
+#)  tests: improve hooks tests with a function to install a package (:pr:`2891`) :user:`marcelotduarte`
+#)  ci: Fetch only the required files for testing (:pr:`2890`) :user:`marcelotduarte`
+#)  tests: improve conftest (:pr:`2889`) :user:`marcelotduarte`
+#)  tests: add scipy sample as a hook test (:pr:`2888`) :user:`marcelotduarte`
+#)  tests: cleanup (:pr:`2887`) :user:`marcelotduarte`
+#)  tests: port more tests to use the new fixture 4 (:pr:`2886`) :user:`marcelotduarte`
+#)  tests: port more tests to use the new fixture 3 (:pr:`2885`) :user:`marcelotduarte`
+#)  tests: port more tests to use the new fixture 2 (:pr:`2884`) :user:`marcelotduarte`
+#)  tests: improve mp tests (:pr:`2882`) :user:`marcelotduarte`
+#)  tests: port more tests to use the new fixture (:pr:`2883`) :user:`marcelotduarte`
+#)  tests: add conftest and port stdlib hooks test to use it (:pr:`2881`) :user:`marcelotduarte`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2880`) :user:`pre-commit-ci`
+#)  build(deps): bump pytest-cov from 6.1.0 to 6.1.1 (:pr:`2879`) :user:`dependabot`
+#)  hooks: fix scipy hook on mingw and catch similar errors (:pr:`2877`) :user:`marcelotduarte`
+#)  doc: small review [ci skip] (:pr:`2876`) :user:`marcelotduarte`
+#)  chore: use sys.prefix as frozen directory (:pr:`2874`) :user:`marcelotduarte`
+#)  chore: support for PEP 639 (:pr:`2873`) :user:`marcelotduarte`
+#)  chore: use importlib.resources (:pr:`2872`) :user:`marcelotduarte`
+#)  bdist_msi: Make MSI checkbox to "launch after install" optional (:pr:`2871`) :user:`jeroen`
 
 Version 8.1 (Apr 02)
 --------------------
 
-#)  Bump version: 8.0.0 → 8.1.0 [ci skip] (:pull:`2868`) :user:`marcelotduarte`
-#)  chore: support for setuptools fix for pep491 (:pull:`2867`) :user:`marcelotduarte`
-#)  build(deps): bump pytest-cov from 6.0.0 to 6.1.0 (:pull:`2866`) :user:`dependabot`
-#)  build(deps): bump sphinx-new-tab-link from 0.7.0 to 0.8.0 (:pull:`2865`) :user:`dependabot`
-#)  hooks: fix scipy (using numpy) (:pull:`2862`) :user:`marcelotduarte`
-#)  bdist_msi: Add a launch on finish checkbox to the MSI installer (:pull:`2854`) :user:`MeGaGiGaGon`
-#)  build(deps): bump coverage from 7.7.1 to 7.8.0 (:pull:`2864`) :user:`dependabot`
-#)  hooks: include source files that uses @torch.jit._overload_method (:pull:`2863`) :user:`marcelotduarte`
-#)  fix: ruff A005 (:pull:`2859`) :user:`marcelotduarte`
-#)  hooks: zlib module requires the zlib.dll to be present in the executable directory [conda/Windows] (:pull:`2855`) :user:`marcelotduarte`
-#)  hooks: add argon2-cffi (:pull:`2857`) :user:`marcelotduarte`
-#)  fix: ruff LOG015 [ci skip] (:pull:`2858`) :user:`marcelotduarte`
-#)  build(deps-dev): bump cibuildwheel from 2.23.1 to 2.23.2 (:pull:`2853`) :user:`dependabot`
-#)  hooks: update to support pymupdf 1.25.4 (:pull:`2851`) :user:`marcelotduarte`
-#)  hooks: fix importlib hook (:pull:`2852`) :user:`marcelotduarte`
-#)  hooks: enable asynchat and asyncore usage via pyasynchat and pyasyncore packages (:pull:`2850`) :user:`marcelotduarte`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2849`) :user:`pre-commit-ci`
-#)  doc: fix version documentation [ci skip] (:pull:`2847`) :user:`marcelotduarte`
-#)  build(deps-dev): bump bump-my-version from 1.0.2 to 1.1.1 (:pull:`2846`) :user:`dependabot`
-#)  Update setup_script.rst fixed typo in docs (:pull:`2845`) :user:`philipp`
-#)  build(deps): bump coverage from 7.7.0 to 7.7.1 (:pull:`2840`) :user:`dependabot`
-#)  fix: use only console based on PEP587 on Python 3.13 (:pull:`2842`) :user:`marcelotduarte`
+#)  Bump version: 8.0.0 → 8.1.0 [ci skip] (:pr:`2868`) :user:`marcelotduarte`
+#)  chore: support for setuptools fix for pep491 (:pr:`2867`) :user:`marcelotduarte`
+#)  build(deps): bump pytest-cov from 6.0.0 to 6.1.0 (:pr:`2866`) :user:`dependabot`
+#)  build(deps): bump sphinx-new-tab-link from 0.7.0 to 0.8.0 (:pr:`2865`) :user:`dependabot`
+#)  hooks: fix scipy (using numpy) (:pr:`2862`) :user:`marcelotduarte`
+#)  bdist_msi: Add a launch on finish checkbox to the MSI installer (:pr:`2854`) :user:`MeGaGiGaGon`
+#)  build(deps): bump coverage from 7.7.1 to 7.8.0 (:pr:`2864`) :user:`dependabot`
+#)  hooks: include source files that uses @torch.jit._overload_method (:pr:`2863`) :user:`marcelotduarte`
+#)  fix: ruff A005 (:pr:`2859`) :user:`marcelotduarte`
+#)  hooks: zlib module requires the zlib.dll to be present in the executable directory [conda/Windows] (:pr:`2855`) :user:`marcelotduarte`
+#)  hooks: add argon2-cffi (:pr:`2857`) :user:`marcelotduarte`
+#)  fix: ruff LOG015 [ci skip] (:pr:`2858`) :user:`marcelotduarte`
+#)  build(deps-dev): bump cibuildwheel from 2.23.1 to 2.23.2 (:pr:`2853`) :user:`dependabot`
+#)  hooks: update to support pymupdf 1.25.4 (:pr:`2851`) :user:`marcelotduarte`
+#)  hooks: fix importlib hook (:pr:`2852`) :user:`marcelotduarte`
+#)  hooks: enable asynchat and asyncore usage via pyasynchat and pyasyncore packages (:pr:`2850`) :user:`marcelotduarte`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2849`) :user:`pre-commit-ci`
+#)  doc: fix version documentation [ci skip] (:pr:`2847`) :user:`marcelotduarte`
+#)  build(deps-dev): bump bump-my-version from 1.0.2 to 1.1.1 (:pr:`2846`) :user:`dependabot`
+#)  Update setup_script.rst fixed typo in docs (:pr:`2845`) :user:`philipp`
+#)  build(deps): bump coverage from 7.7.0 to 7.7.1 (:pr:`2840`) :user:`dependabot`
+#)  fix: use only console based on PEP587 on Python 3.13 (:pr:`2842`) :user:`marcelotduarte`
 
 Version 8.0 (Mar 21)
 --------------------
 
-#)  hooks: add timm package (:pull:`2834`) :user:`marcelotduarte`
-#)  build(deps-dev): bump pre-commit from 4.1.0 to 4.2.0 (:pull:`2833`) :user:`dependabot`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2832`) :user:`pre-commit-ci`
-#)  build(deps): bump coverage from 7.6.12 to 7.7.0 (:pull:`2830`) :user:`dependabot`
-#)  build(deps-dev): bump cibuildwheel from 2.23.0 to 2.23.1 (:pull:`2831`) :user:`dependabot`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2828`) :user:`pre-commit-ci`
-#)  build(deps-dev): bump bump-my-version from 1.0.1 to 1.0.2 (:pull:`2827`) :user:`dependabot`
-#)  build(deps): bump sphinx-new-tab-link from 0.6.1 to 0.7.0 (:pull:`2826`) :user:`dependabot`
-#)  build(deps): bump pytest from 8.3.4 to 8.3.5 (:pull:`2818`) :user:`dependabot`
-#)  build(deps-dev): bump bump-my-version from 0.32.1 to 1.0.1 (:pull:`2824`) :user:`dependabot`
-#)  build(deps): update lief requirement from <=0.16.3,>=0.13.2 to >=0.13.2,<=0.16.4 (:pull:`2816`) :user:`dependabot`
-#)  build(deps-dev): bump cibuildwheel from 2.22.0 to 2.23.0 (:pull:`2819`) :user:`dependabot`
-#)  fix: setuptools 75.8.1 breaks auditwheel (:pull:`2823`) :user:`marcelotduarte`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2814`) :user:`pre-commit-ci`
-#)  build(deps): update myst-parser requirement from <=4.0.0,>=3.0.1 to >=3.0.1,<=4.0.1 (:pull:`2809`) :user:`dependabot`
-#)  build(deps): bump coverage from 7.6.11 to 7.6.12 (:pull:`2806`) :user:`dependabot`
-#)  build-wheel: use ubuntu 22.04 emulator to build ppc64le (:pull:`2805`) :user:`marcelotduarte`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2804`) :user:`pre-commit-ci`
-#)  build(deps-dev): bump bump-my-version from 0.32.0 to 0.32.1 (:pull:`2803`) :user:`dependabot`
-#)  build(deps): bump coverage from 7.6.10 to 7.6.11 (:pull:`2802`) :user:`dependabot`
-#)  build(deps-dev): bump bump-my-version from 0.31.1 to 0.32.0 (:pull:`2800`) :user:`dependabot`
-#)  fix: missing dlls in top directory [mingw] (:pull:`2799`) :user:`marcelotduarte`
-#)  hooks: fix shapely [windows] (:pull:`2797`) :user:`marcelotduarte`
-#)  build(deps): update lief requirement from <=0.16.2,>=0.13.2 to >=0.13.2,<=0.16.3 (:pull:`2795`) :user:`dependabot`
-#)  tests: fix msi test (:pull:`2796`) :user:`marcelotduarte`
-#)  doc: fix typo [ci skip] (:pull:`2793`) :user:`marcelotduarte`
-#)  doc: improve documentation on using pyproject.toml [ci skip] (:pull:`2792`) :user:`marcelotduarte`
-#)  build(deps-dev): bump bump-my-version from 0.29.0 to 0.31.1 (:pull:`2790`) :user:`dependabot`
-#)  hooks: ctypes, ssl, sqlite3 - conda-forge (:pull:`2791`) :user:`marcelotduarte`
-#)  chore: support ruff 0.9.x (:pull:`2789`) :user:`marcelotduarte`
-#)  hooks: copy only shared libs of Qt in qt hooks (:pull:`2788`) :user:`marcelotduarte`
-#)  hooks: pytorch 2.6.0 (:pull:`2787`) :user:`marcelotduarte`
-#)  chore: build_wheel improvements and use of ubuntu-24.04-arm runner (:pull:`2784`) :user:`marcelotduarte`
-#)  hooks: complementary fix for pytorch/nvidia/torchmetrics (:pull:`2782`) :user:`marcelotduarte`
-#)  hooks: fix pytorch on macOS (:pull:`2781`) :user:`marcelotduarte`
-#)  build(deps-dev): bump pre-commit from 4.0.1 to 4.1.0 (:pull:`2778`) :user:`dependabot`
-#)  fix: work with lief disabled or uninstalled (:pull:`2777`) :user:`marcelotduarte`
-#)  appimage: use full path of appimagetool (:pull:`2771`) :user:`marcelotduarte`
-#)  chore: lief>=0.13.2,<=0.16.2 [windows] (:pull:`2770`) :user:`marcelotduarte`
-#)  chore: use new features of uv (:pull:`2769`) :user:`marcelotduarte`
-#)  chore: enable experimental free-threaded python 3.13 on unix (:pull:`2759`) :user:`marcelotduarte`
-#)  ci: minor tweaks and fixes (:pull:`2768`) :user:`marcelotduarte`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2766`) :user:`pre-commit-ci`
-#)  ci: fix some build and test issues (:pull:`2767`) :user:`marcelotduarte`
-#)  chore: happy new year [ci skip] (:pull:`2765`) :user:`marcelotduarte`
-#)  hooks: fix pyqt5 on conda-forge (:pull:`2763`) :user:`marcelotduarte`
-#)  chore: add some fail-safe checks (:pull:`2764`) :user:`marcelotduarte`
-#)  fix: #2680 regression (:pull:`2762`) :user:`marcelotduarte`
-#)  hooks: update pyqt5/pyqt6/pyside6 resources [ci skip] (:pull:`2761`) :user:`marcelotduarte`
-#)  build-wheel: build only universal2 wheels on macOS (:pull:`2760`) :user:`marcelotduarte`
-#)  hooks: fix for torch and triton backends (:pull:`2751`) :user:`marcelotduarte`
-#)  hooks: fix for pytorch/nvidia/torchmetrics (:pull:`2750`) :user:`marcelotduarte`
-#)  doc: Corrects a typo in `setup_script.rst` (:pull:`2757`) :user:`patocv2`
-#)  ci: Publish to testpypi does not work on PR on a fork [ci skip] (:pull:`2758`) :user:`marcelotduarte`
-#)  hooks: add shapely.py (:pull:`2749`) :user:`marcelotduarte`
-#)  bases: update base executables and util module [ci skip] (:pull:`2756`) :user:`marcelotduarte`
-#)  build-wheel: use uvx w/ bump-my-version and cibuildwheel (:pull:`2755`) :user:`marcelotduarte`
-#)  chore: use pythoncapi_compat (:pull:`2754`) :user:`marcelotduarte`
-#)  build(deps): bump coverage from 7.6.9 to 7.6.10 (:pull:`2752`) :user:`dependabot`
-#)  fix: three small fixes (:pull:`2748`) :user:`marcelotduarte`
-#)  build-wheel: improve performance (:pull:`2747`) :user:`marcelotduarte`
-#)  build(deps): bump astral-sh/setup-uv from 4 to 5 (:pull:`2744`) :user:`dependabot`
-#)  build(deps-dev): bump bump-my-version from 0.28.3 to 0.29.0 (:pull:`2745`) :user:`dependabot`
-#)  bases: update base executables and util module [ci skip] (:pull:`2746`) :user:`marcelotduarte`
-#)  chore: use uv build and uvx (:pull:`2743`) :user:`marcelotduarte`
-#)  chore: use private heap instead of stack for buffers (:pull:`2742`) :user:`marcelotduarte`
-#)  fix: a segmentation fault in py313t (:pull:`2740`) :user:`marcelotduarte`
-#)  tests: remove psutil to speedup tests up to 30% [ci skip] (:pull:`2741`) :user:`marcelotduarte`
-#)  hooks: support opencv-python 4.10.x (including headless) (:pull:`2735`) :user:`marcelotduarte`
-#)  build(deps-dev): bump bump-my-version from 0.28.2 to 0.28.3 (:pull:`2739`) :user:`dependabot`
-#)  build(deps-dev): bump bump-my-version from 0.28.1 to 0.28.2 (:pull:`2734`) :user:`dependabot`
-#)  chore: use is_relative_to (py39+) to simplify code (:pull:`2732`) :user:`marcelotduarte`
-#)  bases: update base executables and util module [ci skip] (:pull:`2731`) :user:`marcelotduarte`
-#)  chore: cleanup (:pull:`2730`) :user:`marcelotduarte`
-#)  chore: add support for Python 3.13 [macOS] (:pull:`2728`) :user:`marcelotduarte`
-#)  chore: use stdlib importlib.metadata (:pull:`2727`) :user:`marcelotduarte`
-#)  bases: PEP587 - Python Initialization Configuration (:pull:`2726`) :user:`marcelotduarte`
-#)  chore: add support for Python 3.13 [Linux and Windows] (:pull:`2630`) :user:`marcelotduarte`
-#)  doc: improve installation doc using tabs (:pull:`2725`) :user:`marcelotduarte`
-#)  chore: move doc and tests requirements to directory of same name (:pull:`2724`) :user:`marcelotduarte`
-#)  build(deps): update lief requirement from <0.16.0,>=0.12.0 to >=0.12.0,<0.17.0 (:pull:`2723`) :user:`dependabot`
-#)  doc: improve doc for conda use and add warning to recomment its use (:pull:`2722`) :user:`marcelotduarte`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2721`) :user:`pre-commit-ci`
-#)  fix: support uv python in Linux (:pull:`2719`) :user:`marcelotduarte`
-#)  doc: update .readthedocs.yaml [ci skip] (:pull:`2720`) :user:`marcelotduarte`
-#)  hooks: fix support for Pillow in Linux (:pull:`2718`) :user:`marcelotduarte`
-#)  chore: publish on testpypi on push (:pull:`2717`) :user:`marcelotduarte`
-#)  build(deps): bump coverage from 7.6.8 to 7.6.9 (:pull:`2716`) :user:`dependabot`
-#)  chore: use python-coverage-comment-action to report coverage status (:pull:`2714`) :user:`marcelotduarte`
-#)  build(deps): bump pytest from 8.3.3 to 8.3.4 (:pull:`2711`) :user:`dependabot`
-#)  chore: get rid of codecov (:pull:`2712`) :user:`marcelotduarte`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2710`) :user:`pre-commit-ci`
-#)  build(deps): bump codecov/codecov-action from 4 to 5 (:pull:`2686`) :user:`dependabot`
-#)  build-wheel: use multiple versions of a pr in testpipy (:pull:`2709`) :user:`marcelotduarte`
-#)  fix: regression in module due to namespace changes (:pull:`2708`) :user:`marcelotduarte`
-#)  ci: use download merge-multiple (:pull:`2707`) :user:`marcelotduarte`
-#)  chore: send wheel from pr to testpypi (:pull:`2706`) :user:`marcelotduarte`
-#)  chore: refactor build-wheel and ci (:pull:`2705`) :user:`marcelotduarte`
-#)  ci: make rpm/deb tests do not xfail (:pull:`2700`) :user:`marcelotduarte`
-#)  build(deps): bump coverage from 7.6.7 to 7.6.8 (:pull:`2704`) :user:`dependabot`
-#)  build(deps-dev): bump cibuildwheel from 2.21.3 to 2.22.0 (:pull:`2703`) :user:`dependabot`
-#)  build(deps): bump astral-sh/setup-uv from 3 to 4 (:pull:`2702`) :user:`dependabot`
-#)  build-wheel: fix build sdist [ci skip] (:pull:`2699`) :user:`marcelotduarte`
-#)  parser: use patchelf to get dependent file in arm [Linux] (:pull:`2695`) :user:`marcelotduarte`
-#)  build-wheel: fix the build number (:pull:`2698`) :user:`marcelotduarte`
-#)  pre-commit: update ruff code to new schema in validate-pyproject-schema-store 2024.11.22 (:pull:`2697`) :user:`marcelotduarte`
-#)  build-wheel: fix the dev suffix (:pull:`2696`) :user:`marcelotduarte`
-#)  Bump version: 7.3.0-dev0 → 7.3.0-dev.1 [ci skip] (:pull:`2694`) :user:`marcelotduarte`
-#)  freezer: fix rpath [linux] (:pull:`2693`) :user:`marcelotduarte`
-#)  build-wheel: Publish package to TestPyPI (:pull:`2689`) :user:`marcelotduarte`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2692`) :user:`pre-commit-ci`
-#)  Fix namespace package containing extensions (:pull:`2680`) :user:`sankilkis`
-#)  build(deps): bump coverage from 7.6.5 to 7.6.7 (:pull:`2690`) :user:`dependabot`
-#)  hooks: cleanup and reorganization (:pull:`2688`) :user:`marcelotduarte`
-#)  setup: small fixes (:pull:`2687`) :user:`marcelotduarte`
-#)  build(deps): bump coverage from 7.6.4 to 7.6.5 (:pull:`2685`) :user:`dependabot`
-#)  ci: use_oidc with codecov (:pull:`2684`) :user:`marcelotduarte`
-#)  setup: copy pre-built bases on Windows (compilation is optional) (:pull:`2681`) :user:`marcelotduarte`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2678`) :user:`pre-commit-ci`
-#)  fix: use of build_exe --excludes with namespace packages (:pull:`2677`) :user:`marcelotduarte`
-#)  fix: fix _get_top_dependencies to work on mingw (:pull:`2675`) :user:`marcelotduarte`
-#)  hooks: support for pkg_resources from setuptools >= 71 (:pull:`2674`) :user:`marcelotduarte`
-#)  hooks: numpy - resolve missing modules (:pull:`2670`) :user:`marcelotduarte`
-#)  finder: fine-tuning the excludes list (:pull:`2669`) :user:`marcelotduarte`
-#)  cli: add --verbose and --debug options (:pull:`2668`) :user:`marcelotduarte`
-#)  fix: remove incorrect excludes (:pull:`2667`) :user:`marcelotduarte`
-#)  fix: a more consise fix for namespace packages (:pull:`2665`) :user:`marcelotduarte`
-#)  hooks: zoneinfo has an error not caught by a typo in tests (:pull:`2666`) :user:`marcelotduarte`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2662`) :user:`pre-commit-ci`
-#)  build(deps-dev): bump bump-my-version from 0.28.0 to 0.28.1 (:pull:`2661`) :user:`dependabot`
-#)  chore: use convenient functions from stdlib that exist since 3.9 (:pull:`2658`) :user:`marcelotduarte`
-#)  build(deps): bump pytest-cov from 5.0.0 to 6.0.0 (:pull:`2657`) :user:`dependabot`
-#)  hooks: add fontTools (:pull:`2656`) :user:`marcelotduarte`
-#)  hooks: fix for pymupdf 1.24.11+ (:pull:`2655`) :user:`marcelotduarte`
-#)  cli: #2439 complementary fix on windows (:pull:`2654`) :user:`marcelotduarte`
-#)  bases: update base executables and util module [ci skip] (:pull:`2652`) :user:`marcelotduarte`
-#)  fix: After #2624 'Load python3.dll if it is on the target dir' (:pull:`2651`) :user:`marcelotduarte`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2650`) :user:`pre-commit-ci`
-#)  hooks: sets the alias for os.path (:pull:`2649`) :user:`marcelotduarte`
-#)  hooks: optimize/improve more modules (:pull:`2648`) :user:`marcelotduarte`
-#)  hooks: optimize/improve some modules (:pull:`2647`) :user:`marcelotduarte`
-#)  chore: use uv with cibuildwheel [ci skip] (:pull:`2645`) :user:`marcelotduarte`
-#)  hooks: optimize pyzmq, setuptools and pkg_resources (:pull:`2643`) :user:`marcelotduarte`
-#)  finder: improve the report of missing modules (:pull:`2639`) :user:`marcelotduarte`
-#)  bdist_dmg: catch errors when resource is busy (:pull:`2640`) :user:`marcelotduarte`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2637`) :user:`pre-commit-ci`
-#)  Enable github sponsor [ci skip] (:pull:`2638`) :user:`marcelotduarte`
-#)  build(deps): bump coverage from 7.6.3 to 7.6.4 (:pull:`2636`) :user:`dependabot`
-#)  fix: cache only `distribution.requires` that are evaluated in the environment (:pull:`2634`) :user:`marcelotduarte`
-#)  hooks: improve pyzmq (:pull:`2635`) :user:`marcelotduarte`
-#)  build(deps-dev): bump bump-my-version from 0.27.0 to 0.28.0 (:pull:`2633`) :user:`dependabot`
-#)  freezer: include_msvcr now uses Redistributable files (:pull:`2451`) :user:`marcelotduarte`
-#)  build(deps): bump coverage from 7.6.2 to 7.6.3 (:pull:`2626`) :user:`dependabot`
-#)  hooks: pydantic - #2610 missing file (:pull:`2628`) :user:`marcelotduarte`
-#)  chore: simplify code using _compat and removing not required class (:pull:`2627`) :user:`marcelotduarte`
-#)  freezer: Optimize the search for dependencies (:pull:`2624`) :user:`marcelotduarte`
-#)  ci: migrate to astral-sh/setup-uv with cache (:pull:`2623`) :user:`marcelotduarte`
-#)  tests: fix tkinter test in older macOS (:pull:`2622`) :user:`marcelotduarte`
-#)  freezer: improve the use of rpath [linux] (:pull:`2621`) :user:`marcelotduarte`
-#)  freezer: change the order to fix bugs with patchelf (:pull:`2620`) :user:`marcelotduarte`
-#)  build(deps): bump coverage from 7.6.1 to 7.6.2 (:pull:`2619`) :user:`dependabot`
-#)  build(deps-dev): bump cibuildwheel from 2.21.2 to 2.21.3 (:pull:`2618`) :user:`dependabot`
-#)  build(deps-dev): bump pre-commit from 4.0.0 to 4.0.1 (:pull:`2617`) :user:`dependabot`
-#)  build(deps): bump sphinx-tabs from 3.4.5 to 3.4.7 (:pull:`2616`) :user:`dependabot`
-#)  build(deps-dev): bump blacken-docs from 1.18.0 to 1.19.0 (:pull:`2615`) :user:`marcelotduarte`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2614`) :user:`pre-commit-ci`
-#)  build(deps-dev): bump pre-commit from 3.8.0 to 4.0.0 (:pull:`2613`) :user:`dependabot`
-#)  build(deps-dev): bump bump-my-version from 0.26.1 to 0.27.0 (:pull:`2612`) :user:`dependabot`
-#)  hooks: update pydantic hook and fix the sample (:pull:`2610`) :user:`marcelotduarte`
-#)  module: preserve entry_points.txt from .egg-info (:pull:`2609`) :user:`cluck`
-#)  build(deps-dev): bump cibuildwheel from 2.21.1 to 2.21.2 (:pull:`2605`) :user:`dependabot`
-#)  build(deps): bump sphinx-new-tab-link from 0.6.0 to 0.6.1 (:pull:`2598`) :user:`dependabot`
-#)  chore: Drop Python 3.8 (:pull:`2607`) :user:`marcelotduarte`
-#)  Bump version: 7.2.3 → 7.3.0-dev0 [ci skip] (:pull:`2606`) :user:`marcelotduarte`
-#)  hooks: refactor tkinter - add tests (:pull:`2604`) :user:`marcelotduarte`
-#)  hooks: refactor pytz (:pull:`2603`) :user:`marcelotduarte`
+#)  hooks: add timm package (:pr:`2834`) :user:`marcelotduarte`
+#)  build(deps-dev): bump pre-commit from 4.1.0 to 4.2.0 (:pr:`2833`) :user:`dependabot`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2832`) :user:`pre-commit-ci`
+#)  build(deps): bump coverage from 7.6.12 to 7.7.0 (:pr:`2830`) :user:`dependabot`
+#)  build(deps-dev): bump cibuildwheel from 2.23.0 to 2.23.1 (:pr:`2831`) :user:`dependabot`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2828`) :user:`pre-commit-ci`
+#)  build(deps-dev): bump bump-my-version from 1.0.1 to 1.0.2 (:pr:`2827`) :user:`dependabot`
+#)  build(deps): bump sphinx-new-tab-link from 0.6.1 to 0.7.0 (:pr:`2826`) :user:`dependabot`
+#)  build(deps): bump pytest from 8.3.4 to 8.3.5 (:pr:`2818`) :user:`dependabot`
+#)  build(deps-dev): bump bump-my-version from 0.32.1 to 1.0.1 (:pr:`2824`) :user:`dependabot`
+#)  build(deps): update lief requirement from <=0.16.3,>=0.13.2 to >=0.13.2,<=0.16.4 (:pr:`2816`) :user:`dependabot`
+#)  build(deps-dev): bump cibuildwheel from 2.22.0 to 2.23.0 (:pr:`2819`) :user:`dependabot`
+#)  fix: setuptools 75.8.1 breaks auditwheel (:pr:`2823`) :user:`marcelotduarte`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2814`) :user:`pre-commit-ci`
+#)  build(deps): update myst-parser requirement from <=4.0.0,>=3.0.1 to >=3.0.1,<=4.0.1 (:pr:`2809`) :user:`dependabot`
+#)  build(deps): bump coverage from 7.6.11 to 7.6.12 (:pr:`2806`) :user:`dependabot`
+#)  build-wheel: use ubuntu 22.04 emulator to build ppc64le (:pr:`2805`) :user:`marcelotduarte`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2804`) :user:`pre-commit-ci`
+#)  build(deps-dev): bump bump-my-version from 0.32.0 to 0.32.1 (:pr:`2803`) :user:`dependabot`
+#)  build(deps): bump coverage from 7.6.10 to 7.6.11 (:pr:`2802`) :user:`dependabot`
+#)  build(deps-dev): bump bump-my-version from 0.31.1 to 0.32.0 (:pr:`2800`) :user:`dependabot`
+#)  fix: missing dlls in top directory [mingw] (:pr:`2799`) :user:`marcelotduarte`
+#)  hooks: fix shapely [windows] (:pr:`2797`) :user:`marcelotduarte`
+#)  build(deps): update lief requirement from <=0.16.2,>=0.13.2 to >=0.13.2,<=0.16.3 (:pr:`2795`) :user:`dependabot`
+#)  tests: fix msi test (:pr:`2796`) :user:`marcelotduarte`
+#)  doc: fix typo [ci skip] (:pr:`2793`) :user:`marcelotduarte`
+#)  doc: improve documentation on using pyproject.toml [ci skip] (:pr:`2792`) :user:`marcelotduarte`
+#)  build(deps-dev): bump bump-my-version from 0.29.0 to 0.31.1 (:pr:`2790`) :user:`dependabot`
+#)  hooks: ctypes, ssl, sqlite3 - conda-forge (:pr:`2791`) :user:`marcelotduarte`
+#)  chore: support ruff 0.9.x (:pr:`2789`) :user:`marcelotduarte`
+#)  hooks: copy only shared libs of Qt in qt hooks (:pr:`2788`) :user:`marcelotduarte`
+#)  hooks: pytorch 2.6.0 (:pr:`2787`) :user:`marcelotduarte`
+#)  chore: build_wheel improvements and use of ubuntu-24.04-arm runner (:pr:`2784`) :user:`marcelotduarte`
+#)  hooks: complementary fix for pytorch/nvidia/torchmetrics (:pr:`2782`) :user:`marcelotduarte`
+#)  hooks: fix pytorch on macOS (:pr:`2781`) :user:`marcelotduarte`
+#)  build(deps-dev): bump pre-commit from 4.0.1 to 4.1.0 (:pr:`2778`) :user:`dependabot`
+#)  fix: work with lief disabled or uninstalled (:pr:`2777`) :user:`marcelotduarte`
+#)  appimage: use full path of appimagetool (:pr:`2771`) :user:`marcelotduarte`
+#)  chore: lief>=0.13.2,<=0.16.2 [windows] (:pr:`2770`) :user:`marcelotduarte`
+#)  chore: use new features of uv (:pr:`2769`) :user:`marcelotduarte`
+#)  chore: enable experimental free-threaded python 3.13 on unix (:pr:`2759`) :user:`marcelotduarte`
+#)  ci: minor tweaks and fixes (:pr:`2768`) :user:`marcelotduarte`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2766`) :user:`pre-commit-ci`
+#)  ci: fix some build and test issues (:pr:`2767`) :user:`marcelotduarte`
+#)  chore: happy new year [ci skip] (:pr:`2765`) :user:`marcelotduarte`
+#)  hooks: fix pyqt5 on conda-forge (:pr:`2763`) :user:`marcelotduarte`
+#)  chore: add some fail-safe checks (:pr:`2764`) :user:`marcelotduarte`
+#)  fix: #2680 regression (:pr:`2762`) :user:`marcelotduarte`
+#)  hooks: update pyqt5/pyqt6/pyside6 resources [ci skip] (:pr:`2761`) :user:`marcelotduarte`
+#)  build-wheel: build only universal2 wheels on macOS (:pr:`2760`) :user:`marcelotduarte`
+#)  hooks: fix for torch and triton backends (:pr:`2751`) :user:`marcelotduarte`
+#)  hooks: fix for pytorch/nvidia/torchmetrics (:pr:`2750`) :user:`marcelotduarte`
+#)  doc: Corrects a typo in `setup_script.rst` (:pr:`2757`) :user:`patocv2`
+#)  ci: Publish to testpypi does not work on PR on a fork [ci skip] (:pr:`2758`) :user:`marcelotduarte`
+#)  hooks: add shapely.py (:pr:`2749`) :user:`marcelotduarte`
+#)  bases: update base executables and util module [ci skip] (:pr:`2756`) :user:`marcelotduarte`
+#)  build-wheel: use uvx w/ bump-my-version and cibuildwheel (:pr:`2755`) :user:`marcelotduarte`
+#)  chore: use pythoncapi_compat (:pr:`2754`) :user:`marcelotduarte`
+#)  build(deps): bump coverage from 7.6.9 to 7.6.10 (:pr:`2752`) :user:`dependabot`
+#)  fix: three small fixes (:pr:`2748`) :user:`marcelotduarte`
+#)  build-wheel: improve performance (:pr:`2747`) :user:`marcelotduarte`
+#)  build(deps): bump astral-sh/setup-uv from 4 to 5 (:pr:`2744`) :user:`dependabot`
+#)  build(deps-dev): bump bump-my-version from 0.28.3 to 0.29.0 (:pr:`2745`) :user:`dependabot`
+#)  bases: update base executables and util module [ci skip] (:pr:`2746`) :user:`marcelotduarte`
+#)  chore: use uv build and uvx (:pr:`2743`) :user:`marcelotduarte`
+#)  chore: use private heap instead of stack for buffers (:pr:`2742`) :user:`marcelotduarte`
+#)  fix: a segmentation fault in py313t (:pr:`2740`) :user:`marcelotduarte`
+#)  tests: remove psutil to speedup tests up to 30% [ci skip] (:pr:`2741`) :user:`marcelotduarte`
+#)  hooks: support opencv-python 4.10.x (including headless) (:pr:`2735`) :user:`marcelotduarte`
+#)  build(deps-dev): bump bump-my-version from 0.28.2 to 0.28.3 (:pr:`2739`) :user:`dependabot`
+#)  build(deps-dev): bump bump-my-version from 0.28.1 to 0.28.2 (:pr:`2734`) :user:`dependabot`
+#)  chore: use is_relative_to (py39+) to simplify code (:pr:`2732`) :user:`marcelotduarte`
+#)  bases: update base executables and util module [ci skip] (:pr:`2731`) :user:`marcelotduarte`
+#)  chore: cleanup (:pr:`2730`) :user:`marcelotduarte`
+#)  chore: add support for Python 3.13 [macOS] (:pr:`2728`) :user:`marcelotduarte`
+#)  chore: use stdlib importlib.metadata (:pr:`2727`) :user:`marcelotduarte`
+#)  bases: PEP587 - Python Initialization Configuration (:pr:`2726`) :user:`marcelotduarte`
+#)  chore: add support for Python 3.13 [Linux and Windows] (:pr:`2630`) :user:`marcelotduarte`
+#)  doc: improve installation doc using tabs (:pr:`2725`) :user:`marcelotduarte`
+#)  chore: move doc and tests requirements to directory of same name (:pr:`2724`) :user:`marcelotduarte`
+#)  build(deps): update lief requirement from <0.16.0,>=0.12.0 to >=0.12.0,<0.17.0 (:pr:`2723`) :user:`dependabot`
+#)  doc: improve doc for conda use and add warning to recomment its use (:pr:`2722`) :user:`marcelotduarte`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2721`) :user:`pre-commit-ci`
+#)  fix: support uv python in Linux (:pr:`2719`) :user:`marcelotduarte`
+#)  doc: update .readthedocs.yaml [ci skip] (:pr:`2720`) :user:`marcelotduarte`
+#)  hooks: fix support for Pillow in Linux (:pr:`2718`) :user:`marcelotduarte`
+#)  chore: publish on testpypi on push (:pr:`2717`) :user:`marcelotduarte`
+#)  build(deps): bump coverage from 7.6.8 to 7.6.9 (:pr:`2716`) :user:`dependabot`
+#)  chore: use python-coverage-comment-action to report coverage status (:pr:`2714`) :user:`marcelotduarte`
+#)  build(deps): bump pytest from 8.3.3 to 8.3.4 (:pr:`2711`) :user:`dependabot`
+#)  chore: get rid of codecov (:pr:`2712`) :user:`marcelotduarte`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2710`) :user:`pre-commit-ci`
+#)  build(deps): bump codecov/codecov-action from 4 to 5 (:pr:`2686`) :user:`dependabot`
+#)  build-wheel: use multiple versions of a pr in testpipy (:pr:`2709`) :user:`marcelotduarte`
+#)  fix: regression in module due to namespace changes (:pr:`2708`) :user:`marcelotduarte`
+#)  ci: use download merge-multiple (:pr:`2707`) :user:`marcelotduarte`
+#)  chore: send wheel from pr to testpypi (:pr:`2706`) :user:`marcelotduarte`
+#)  chore: refactor build-wheel and ci (:pr:`2705`) :user:`marcelotduarte`
+#)  ci: make rpm/deb tests do not xfail (:pr:`2700`) :user:`marcelotduarte`
+#)  build(deps): bump coverage from 7.6.7 to 7.6.8 (:pr:`2704`) :user:`dependabot`
+#)  build(deps-dev): bump cibuildwheel from 2.21.3 to 2.22.0 (:pr:`2703`) :user:`dependabot`
+#)  build(deps): bump astral-sh/setup-uv from 3 to 4 (:pr:`2702`) :user:`dependabot`
+#)  build-wheel: fix build sdist [ci skip] (:pr:`2699`) :user:`marcelotduarte`
+#)  parser: use patchelf to get dependent file in arm [Linux] (:pr:`2695`) :user:`marcelotduarte`
+#)  build-wheel: fix the build number (:pr:`2698`) :user:`marcelotduarte`
+#)  pre-commit: update ruff code to new schema in validate-pyproject-schema-store 2024.11.22 (:pr:`2697`) :user:`marcelotduarte`
+#)  build-wheel: fix the dev suffix (:pr:`2696`) :user:`marcelotduarte`
+#)  Bump version: 7.3.0-dev0 → 7.3.0-dev.1 [ci skip] (:pr:`2694`) :user:`marcelotduarte`
+#)  freezer: fix rpath [linux] (:pr:`2693`) :user:`marcelotduarte`
+#)  build-wheel: Publish package to TestPyPI (:pr:`2689`) :user:`marcelotduarte`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2692`) :user:`pre-commit-ci`
+#)  Fix namespace package containing extensions (:pr:`2680`) :user:`sankilkis`
+#)  build(deps): bump coverage from 7.6.5 to 7.6.7 (:pr:`2690`) :user:`dependabot`
+#)  hooks: cleanup and reorganization (:pr:`2688`) :user:`marcelotduarte`
+#)  setup: small fixes (:pr:`2687`) :user:`marcelotduarte`
+#)  build(deps): bump coverage from 7.6.4 to 7.6.5 (:pr:`2685`) :user:`dependabot`
+#)  ci: use_oidc with codecov (:pr:`2684`) :user:`marcelotduarte`
+#)  setup: copy pre-built bases on Windows (compilation is optional) (:pr:`2681`) :user:`marcelotduarte`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2678`) :user:`pre-commit-ci`
+#)  fix: use of build_exe --excludes with namespace packages (:pr:`2677`) :user:`marcelotduarte`
+#)  fix: fix _get_top_dependencies to work on mingw (:pr:`2675`) :user:`marcelotduarte`
+#)  hooks: support for pkg_resources from setuptools >= 71 (:pr:`2674`) :user:`marcelotduarte`
+#)  hooks: numpy - resolve missing modules (:pr:`2670`) :user:`marcelotduarte`
+#)  finder: fine-tuning the excludes list (:pr:`2669`) :user:`marcelotduarte`
+#)  cli: add --verbose and --debug options (:pr:`2668`) :user:`marcelotduarte`
+#)  fix: remove incorrect excludes (:pr:`2667`) :user:`marcelotduarte`
+#)  fix: a more consise fix for namespace packages (:pr:`2665`) :user:`marcelotduarte`
+#)  hooks: zoneinfo has an error not caught by a typo in tests (:pr:`2666`) :user:`marcelotduarte`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2662`) :user:`pre-commit-ci`
+#)  build(deps-dev): bump bump-my-version from 0.28.0 to 0.28.1 (:pr:`2661`) :user:`dependabot`
+#)  chore: use convenient functions from stdlib that exist since 3.9 (:pr:`2658`) :user:`marcelotduarte`
+#)  build(deps): bump pytest-cov from 5.0.0 to 6.0.0 (:pr:`2657`) :user:`dependabot`
+#)  hooks: add fontTools (:pr:`2656`) :user:`marcelotduarte`
+#)  hooks: fix for pymupdf 1.24.11+ (:pr:`2655`) :user:`marcelotduarte`
+#)  cli: #2439 complementary fix on windows (:pr:`2654`) :user:`marcelotduarte`
+#)  bases: update base executables and util module [ci skip] (:pr:`2652`) :user:`marcelotduarte`
+#)  fix: After #2624 'Load python3.dll if it is on the target dir' (:pr:`2651`) :user:`marcelotduarte`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2650`) :user:`pre-commit-ci`
+#)  hooks: sets the alias for os.path (:pr:`2649`) :user:`marcelotduarte`
+#)  hooks: optimize/improve more modules (:pr:`2648`) :user:`marcelotduarte`
+#)  hooks: optimize/improve some modules (:pr:`2647`) :user:`marcelotduarte`
+#)  chore: use uv with cibuildwheel [ci skip] (:pr:`2645`) :user:`marcelotduarte`
+#)  hooks: optimize pyzmq, setuptools and pkg_resources (:pr:`2643`) :user:`marcelotduarte`
+#)  finder: improve the report of missing modules (:pr:`2639`) :user:`marcelotduarte`
+#)  bdist_dmg: catch errors when resource is busy (:pr:`2640`) :user:`marcelotduarte`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2637`) :user:`pre-commit-ci`
+#)  Enable github sponsor [ci skip] (:pr:`2638`) :user:`marcelotduarte`
+#)  build(deps): bump coverage from 7.6.3 to 7.6.4 (:pr:`2636`) :user:`dependabot`
+#)  fix: cache only `distribution.requires` that are evaluated in the environment (:pr:`2634`) :user:`marcelotduarte`
+#)  hooks: improve pyzmq (:pr:`2635`) :user:`marcelotduarte`
+#)  build(deps-dev): bump bump-my-version from 0.27.0 to 0.28.0 (:pr:`2633`) :user:`dependabot`
+#)  freezer: include_msvcr now uses Redistributable files (:pr:`2451`) :user:`marcelotduarte`
+#)  build(deps): bump coverage from 7.6.2 to 7.6.3 (:pr:`2626`) :user:`dependabot`
+#)  hooks: pydantic - #2610 missing file (:pr:`2628`) :user:`marcelotduarte`
+#)  chore: simplify code using _compat and removing not required class (:pr:`2627`) :user:`marcelotduarte`
+#)  freezer: Optimize the search for dependencies (:pr:`2624`) :user:`marcelotduarte`
+#)  ci: migrate to astral-sh/setup-uv with cache (:pr:`2623`) :user:`marcelotduarte`
+#)  tests: fix tkinter test in older macOS (:pr:`2622`) :user:`marcelotduarte`
+#)  freezer: improve the use of rpath [linux] (:pr:`2621`) :user:`marcelotduarte`
+#)  freezer: change the order to fix bugs with patchelf (:pr:`2620`) :user:`marcelotduarte`
+#)  build(deps): bump coverage from 7.6.1 to 7.6.2 (:pr:`2619`) :user:`dependabot`
+#)  build(deps-dev): bump cibuildwheel from 2.21.2 to 2.21.3 (:pr:`2618`) :user:`dependabot`
+#)  build(deps-dev): bump pre-commit from 4.0.0 to 4.0.1 (:pr:`2617`) :user:`dependabot`
+#)  build(deps): bump sphinx-tabs from 3.4.5 to 3.4.7 (:pr:`2616`) :user:`dependabot`
+#)  build(deps-dev): bump blacken-docs from 1.18.0 to 1.19.0 (:pr:`2615`) :user:`marcelotduarte`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2614`) :user:`pre-commit-ci`
+#)  build(deps-dev): bump pre-commit from 3.8.0 to 4.0.0 (:pr:`2613`) :user:`dependabot`
+#)  build(deps-dev): bump bump-my-version from 0.26.1 to 0.27.0 (:pr:`2612`) :user:`dependabot`
+#)  hooks: update pydantic hook and fix the sample (:pr:`2610`) :user:`marcelotduarte`
+#)  module: preserve entry_points.txt from .egg-info (:pr:`2609`) :user:`cluck`
+#)  build(deps-dev): bump cibuildwheel from 2.21.1 to 2.21.2 (:pr:`2605`) :user:`dependabot`
+#)  build(deps): bump sphinx-new-tab-link from 0.6.0 to 0.6.1 (:pr:`2598`) :user:`dependabot`
+#)  chore: Drop Python 3.8 (:pr:`2607`) :user:`marcelotduarte`
+#)  Bump version: 7.2.3 → 7.3.0-dev0 [ci skip] (:pr:`2606`) :user:`marcelotduarte`
+#)  hooks: refactor tkinter - add tests (:pr:`2604`) :user:`marcelotduarte`
+#)  hooks: refactor pytz (:pr:`2603`) :user:`marcelotduarte`
 #)  Bump version: 7.2.3-dev0 → 7.2.3 [ci skip] :user:`marcelotduarte`
-#)  ci: remove pre-commit GHA workflow in favor of pre-commit.ci (:pull:`2602`) :user:`marcelotduarte`
-#)  hooks: add urlib and fix pkg_resources (:pull:`2601`) :user:`marcelotduarte`
-#)  samples: fix pycountry sample for pycountry 23+ (:pull:`2600`) :user:`marcelotduarte`
-#)  hooks: support scipy 1.14 in zip library (:pull:`2597`) :user:`marcelotduarte`
-#)  hooks: add VTK (vtkmodules) (:pull:`2595`) :user:`marcelotduarte`
-#)  hooks: zoneinfo refactored - add tests (:pull:`2592`) :user:`marcelotduarte`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2594`) :user:`pre-commit-ci`
-#)  build_exe: fix include_path option (:pull:`2591`) :user:`marcelotduarte`
-#)  hooks: torch - fix duplicate files (:pull:`2587`) :user:`marcelotduarte`
-#)  freezer: fix reporting missing dependencies (:pull:`2590`) :user:`marcelotduarte`
-#)  Bump version: 7.2.2 → 7.2.3-dev0 [ci skip] (:pull:`2589`) :user:`marcelotduarte`
-#)  hooks: numpy - fix #2586 regression in windows (:pull:`2588`) :user:`marcelotduarte`
-#)  hooks: numpy - fix duplicate files (:pull:`2586`) :user:`marcelotduarte`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2585`) :user:`pre-commit-ci`
-#)  Bump version: 7.2.1 → 7.2.2 [ci skip] (:pull:`2584`) :user:`marcelotduarte`
-#)  executable: target_name does not need to be an identifier to be a valid filename (:pull:`2583`) :user:`marcelotduarte`
-#)  cli: undeprecated --target-dir (:pull:`2582`) :user:`marcelotduarte`
-#)  hooks: add pymupdf (:pull:`2581`) :user:`marcelotduarte`
-#)  hooks: pkg_resources from setuptools >= 71 does not uses _vendor (:pull:`2580`) :user:`marcelotduarte`
-#)  hooks: fix copy of files to wrong directories (qt) (:pull:`2578`) :user:`marcelotduarte`
-#)  hooks: fix numpy/mkl in conda (:pull:`2579`) :user:`marcelotduarte`
-#)  hooks: fix qml support for qt hooks (:pull:`2577`) :user:`marcelotduarte`
-#)  build(deps-dev): bump cibuildwheel from 2.21.0 to 2.21.1 (:pull:`2573`) :user:`dependabot`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2571`) :user:`pre-commit-ci`
-#)  build(deps): update setuptools requirement from <75,>=65.6.3 to >=65.6.3,<76 (:pull:`2569`) :user:`dependabot`
-#)  build(deps-dev): bump bump-my-version from 0.26.0 to 0.26.1 (:pull:`2570`) :user:`dependabot`
-#)  build(deps-dev): bump cibuildwheel from 2.20.0 to 2.21.0 (:pull:`2567`) :user:`dependabot`
-#)  bases: update base executables and util module [ci skip] (:pull:`2566`) :user:`marcelotduarte`
-#)  Bump version: 7.2.0 → 7.2.1 [ci skip] (:pull:`2565`) :user:`marcelotduarte`
-#)  build(deps): bump pytest from 8.3.2 to 8.3.3 (:pull:`2562`) :user:`dependabot`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2561`) :user:`pre-commit-ci`
-#)  hooks: add tortoise-orm (:pull:`2564`) :user:`marcelotduarte`
-#)  hooks: fix regression in qt windows (:pull:`2563`) :user:`marcelotduarte`
-#)  build(deps): bump sphinx-new-tab-link from 0.5.3 to 0.6.0 (:pull:`2558`) :user:`dependabot`
-#)  build(deps): update setuptools requirement (:pull:`2556`) :user:`marcelotduarte`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2550`) :user:`pre-commit-ci`
-#)  build(deps-dev): bump bump-my-version from 0.25.1 to 0.26.0 (:pull:`2549`) :user:`dependabot`
-#)  build(deps): bump sphinx-new-tab-link from 0.5.2 to 0.5.3 (:pull:`2547`) :user:`dependabot`
-#)  ci: run pytest on build wheels (instead of editable wheels) (:pull:`2555`) :user:`marcelotduarte`
-#)  setup: do not copy libraries in develop mode (:pull:`2543`) :user:`marcelotduarte`
-#)  docs: use brackets for the default value of option arguments (:pull:`2541`) :user:`marcelotduarte`
-#)  build(deps,docs): update python dependencies (:pull:`2540`) :user:`marcelotduarte`
-#)  build(deps-dev): bump bump-my-version from 0.25.0 to 0.25.1 (:pull:`2538`) :user:`dependabot`
-#)  build(deps): use setuptools >= 70.1 to build (get rid of wheel) (:pull:`2539`) :user:`marcelotduarte`
-#)  build(deps-dev): bump bump-my-version from 0.24.3 to 0.25.0 (:pull:`2537`) :user:`dependabot`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2536`) :user:`pre-commit-ci`
-#)  build(deps-dev): bump cibuildwheel from 2.19.2 to 2.20.0 (:pull:`2535`) :user:`dependabot`
-#)  build(deps): bump coverage from 7.6.0 to 7.6.1 (:pull:`2533`) :user:`dependabot`
-#)  bases: fix regression because the order used by clang-format (:pull:`2530`) :user:`marcelotduarte`
-#)  bdist_rpm: fix use of 'cxfreeze bdist_rpm' command (:pull:`2529`) :user:`marcelotduarte`
-#)  build(deps): bump sphinx-new-tab-link from 0.5.1 to 0.5.2 (:pull:`2528`) :user:`dependabot`
-#)  pre-commit: use clang-format (:pull:`2525`) :user:`marcelotduarte`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2524`) :user:`pre-commit-ci`
-#)  build(deps): update setuptools requirement from <72,>=65.6.3 to >=65.6.3,<73 (:pull:`2523`) :user:`dependabot`
-#)  build(deps): bump sphinx-new-tab-link from 0.5.0 to 0.5.1 (:pull:`2522`) :user:`dependabot`
-#)  build(deps): prepare for setuptools stop vendoring packages (:pull:`2521`) :user:`marcelotduarte`
-#)  build(deps): bump pytest from 8.3.1 to 8.3.2 (:pull:`2520`) :user:`dependabot`
-#)  parser: add compatibility with lief 0.15.x (:pull:`2519`) :user:`marcelotduarte`
-#)  [pre-commit.ci] pre-commit autoupdate (:pull:`2517`) :user:`pre-commit-ci`
-#)  build(deps): bump pytest from 8.2.2 to 8.3.1 (:pull:`2516`) :user:`dependabot`
-#)  build_exe: MingW and posix systems silently ignore include_msvcr option (:pull:`2514`) :user:`marcelotduarte`
-#)  build(deps-dev): bump bump-my-version from 0.24.2 to 0.24.3 (:pull:`2511`) :user:`dependabot`
-#)  build(deps): update setuptools requirement from <71,>=65.6.3 to >=65.6.3,<72 (:pull:`2512`) :user:`dependabot`
+#)  ci: remove pre-commit GHA workflow in favor of pre-commit.ci (:pr:`2602`) :user:`marcelotduarte`
+#)  hooks: add urlib and fix pkg_resources (:pr:`2601`) :user:`marcelotduarte`
+#)  samples: fix pycountry sample for pycountry 23+ (:pr:`2600`) :user:`marcelotduarte`
+#)  hooks: support scipy 1.14 in zip library (:pr:`2597`) :user:`marcelotduarte`
+#)  hooks: add VTK (vtkmodules) (:pr:`2595`) :user:`marcelotduarte`
+#)  hooks: zoneinfo refactored - add tests (:pr:`2592`) :user:`marcelotduarte`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2594`) :user:`pre-commit-ci`
+#)  build_exe: fix include_path option (:pr:`2591`) :user:`marcelotduarte`
+#)  hooks: torch - fix duplicate files (:pr:`2587`) :user:`marcelotduarte`
+#)  freezer: fix reporting missing dependencies (:pr:`2590`) :user:`marcelotduarte`
+#)  Bump version: 7.2.2 → 7.2.3-dev0 [ci skip] (:pr:`2589`) :user:`marcelotduarte`
+#)  hooks: numpy - fix #2586 regression in windows (:pr:`2588`) :user:`marcelotduarte`
+#)  hooks: numpy - fix duplicate files (:pr:`2586`) :user:`marcelotduarte`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2585`) :user:`pre-commit-ci`
+#)  Bump version: 7.2.1 → 7.2.2 [ci skip] (:pr:`2584`) :user:`marcelotduarte`
+#)  executable: target_name does not need to be an identifier to be a valid filename (:pr:`2583`) :user:`marcelotduarte`
+#)  cli: undeprecated --target-dir (:pr:`2582`) :user:`marcelotduarte`
+#)  hooks: add pymupdf (:pr:`2581`) :user:`marcelotduarte`
+#)  hooks: pkg_resources from setuptools >= 71 does not uses _vendor (:pr:`2580`) :user:`marcelotduarte`
+#)  hooks: fix copy of files to wrong directories (qt) (:pr:`2578`) :user:`marcelotduarte`
+#)  hooks: fix numpy/mkl in conda (:pr:`2579`) :user:`marcelotduarte`
+#)  hooks: fix qml support for qt hooks (:pr:`2577`) :user:`marcelotduarte`
+#)  build(deps-dev): bump cibuildwheel from 2.21.0 to 2.21.1 (:pr:`2573`) :user:`dependabot`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2571`) :user:`pre-commit-ci`
+#)  build(deps): update setuptools requirement from <75,>=65.6.3 to >=65.6.3,<76 (:pr:`2569`) :user:`dependabot`
+#)  build(deps-dev): bump bump-my-version from 0.26.0 to 0.26.1 (:pr:`2570`) :user:`dependabot`
+#)  build(deps-dev): bump cibuildwheel from 2.20.0 to 2.21.0 (:pr:`2567`) :user:`dependabot`
+#)  bases: update base executables and util module [ci skip] (:pr:`2566`) :user:`marcelotduarte`
+#)  Bump version: 7.2.0 → 7.2.1 [ci skip] (:pr:`2565`) :user:`marcelotduarte`
+#)  build(deps): bump pytest from 8.3.2 to 8.3.3 (:pr:`2562`) :user:`dependabot`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2561`) :user:`pre-commit-ci`
+#)  hooks: add tortoise-orm (:pr:`2564`) :user:`marcelotduarte`
+#)  hooks: fix regression in qt windows (:pr:`2563`) :user:`marcelotduarte`
+#)  build(deps): bump sphinx-new-tab-link from 0.5.3 to 0.6.0 (:pr:`2558`) :user:`dependabot`
+#)  build(deps): update setuptools requirement (:pr:`2556`) :user:`marcelotduarte`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2550`) :user:`pre-commit-ci`
+#)  build(deps-dev): bump bump-my-version from 0.25.1 to 0.26.0 (:pr:`2549`) :user:`dependabot`
+#)  build(deps): bump sphinx-new-tab-link from 0.5.2 to 0.5.3 (:pr:`2547`) :user:`dependabot`
+#)  ci: run pytest on build wheels (instead of editable wheels) (:pr:`2555`) :user:`marcelotduarte`
+#)  setup: do not copy libraries in develop mode (:pr:`2543`) :user:`marcelotduarte`
+#)  docs: use brackets for the default value of option arguments (:pr:`2541`) :user:`marcelotduarte`
+#)  build(deps,docs): update python dependencies (:pr:`2540`) :user:`marcelotduarte`
+#)  build(deps-dev): bump bump-my-version from 0.25.0 to 0.25.1 (:pr:`2538`) :user:`dependabot`
+#)  build(deps): use setuptools >= 70.1 to build (get rid of wheel) (:pr:`2539`) :user:`marcelotduarte`
+#)  build(deps-dev): bump bump-my-version from 0.24.3 to 0.25.0 (:pr:`2537`) :user:`dependabot`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2536`) :user:`pre-commit-ci`
+#)  build(deps-dev): bump cibuildwheel from 2.19.2 to 2.20.0 (:pr:`2535`) :user:`dependabot`
+#)  build(deps): bump coverage from 7.6.0 to 7.6.1 (:pr:`2533`) :user:`dependabot`
+#)  bases: fix regression because the order used by clang-format (:pr:`2530`) :user:`marcelotduarte`
+#)  bdist_rpm: fix use of 'cxfreeze bdist_rpm' command (:pr:`2529`) :user:`marcelotduarte`
+#)  build(deps): bump sphinx-new-tab-link from 0.5.1 to 0.5.2 (:pr:`2528`) :user:`dependabot`
+#)  pre-commit: use clang-format (:pr:`2525`) :user:`marcelotduarte`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2524`) :user:`pre-commit-ci`
+#)  build(deps): update setuptools requirement from <72,>=65.6.3 to >=65.6.3,<73 (:pr:`2523`) :user:`dependabot`
+#)  build(deps): bump sphinx-new-tab-link from 0.5.0 to 0.5.1 (:pr:`2522`) :user:`dependabot`
+#)  build(deps): prepare for setuptools stop vendoring packages (:pr:`2521`) :user:`marcelotduarte`
+#)  build(deps): bump pytest from 8.3.1 to 8.3.2 (:pr:`2520`) :user:`dependabot`
+#)  parser: add compatibility with lief 0.15.x (:pr:`2519`) :user:`marcelotduarte`
+#)  [pre-commit.ci] pre-commit autoupdate (:pr:`2517`) :user:`pre-commit-ci`
+#)  build(deps): bump pytest from 8.2.2 to 8.3.1 (:pr:`2516`) :user:`dependabot`
+#)  build_exe: MingW and posix systems silently ignore include_msvcr option (:pr:`2514`) :user:`marcelotduarte`
+#)  build(deps-dev): bump bump-my-version from 0.24.2 to 0.24.3 (:pr:`2511`) :user:`dependabot`
+#)  build(deps): update setuptools requirement from <71,>=65.6.3 to >=65.6.3,<72 (:pr:`2512`) :user:`dependabot`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ dev = [
 ]
 doc = [
     "sphinx==8.2.3 ;python_version >= '3.11'",
+    "sphinx-issues==5.0.1 ;python_version >= '3.11'",
     "sphinx-new-tab-link==0.8.0 ;python_version >= '3.11'",
     "sphinx-tabs==3.4.7 ;python_version >= '3.11'",
     "furo==2024.8.6 ;python_version >= '3.11'",


### PR DESCRIPTION
This Sphinx extension implements more generic roles that can also be used more flexibly. Relying on an external extension allows us to stop maintaining an in-repo copy of the commonly used behavior.

As a part of the change, the :pull: RST role is being replaced with :pr:.