### PR TITLE
bdist_appimage: add "runtime-file" argument to bdist_appimage command

### DIFF
--- a/cx_Freeze/command/bdist_appimage.py
+++ b/cx_Freeze/command/bdist_appimage.py
@@ -30,7 +30,9 @@ __all__ = ["bdist_appimage"]
 
 ARCH = platform.machine()
 APPIMAGETOOL_RELEASES_URL = "https://github.com/AppImage/appimagetool/releases"
+TYPE2RUNTIME_RELEASES_URL = "https://github.com/AppImage/type2-runtime/releases"
 APPIMAGETOOL_DOWNLOAD = f"download/continuous/appimagetool-{ARCH}.AppImage"
+TYPE2RUNTIME_DOWNLOAD = f"download/continuous/runtime-{ARCH}"
 APPIMAGETOOL_CACHE = f"~/.local/bin/appimagetool-{ARCH}.AppImage"
 
 
@@ -44,6 +46,11 @@ class bdist_appimage(Command):
             None,
             "path to appimagetool (formerly AppImageKit) "
             f'[default: "{APPIMAGETOOL_CACHE}"]',
+        ),
+        (
+            "runtime=",
+            None,
+            "path to type2 runtime (optional)",
         ),
         (
             "bdist-base=",
@@ -76,6 +83,7 @@ class bdist_appimage(Command):
 
     def initialize_options(self) -> None:
         self.appimagekit = None
+        self.runtime = None
 
         self.bdist_base = None
         self.build_dir = None
@@ -145,31 +153,39 @@ class bdist_appimage(Command):
             if build_exe:
                 build_exe.silent = self.silent
 
-        # validate or download appimagekit
-        self._get_appimagekit()
-
-    def _get_appimagekit(self) -> None:
-        """Fetch appimagetool from the web if not available locally."""
-        appimagekit = os.path.expanduser(
-            self.appimagekit or APPIMAGETOOL_CACHE
+        # validate or download appimagetool
+        self.appimagekit = self._get_file(
+            self.appimagekit or APPIMAGETOOL_CACHE,
+            APPIMAGETOOL_RELEASES_URL,
+            APPIMAGETOOL_DOWNLOAD
         )
-        appimagekit_dir = os.path.dirname(appimagekit)
-        self.mkpath(appimagekit_dir)
-        with FileLock(appimagekit + ".lock"):
-            if not os.path.exists(appimagekit):
-                self.announce(
-                    "download and install appimagetool from "
-                    f"{APPIMAGETOOL_RELEASES_URL}",
-                    INFO,
-                )
-                urlretrieve(  # noqa: S310
-                    os.path.join(
-                        APPIMAGETOOL_RELEASES_URL, APPIMAGETOOL_DOWNLOAD
-                    ),
-                    appimagekit,
-                )
-                os.chmod(appimagekit, stat.S_IRWXU)
-        self.appimagekit = appimagekit
+
+        # optionally, download type2 runtime
+        self.runtime = self._get_file(
+            self.runtime,
+            TYPE2RUNTIME_RELEASES_URL,
+            TYPE2RUNTIME_DOWNLOAD
+        )
+
+    def _get_file(self, file_path: str | None, releases_url: str, download_path: str) -> str | None:
+        """Fetch appimagetool or (optional) runtime from the web if not available locally."""
+        if file_path is not None:
+            file_path = os.path.expanduser(file_path)
+            self.mkpath(os.path.dirname(file_path))
+            with FileLock(file_path + ".lock"):
+                if not os.path.exists(file_path):
+                    self.announce(
+                        f"download and install {os.path.basename(download_path)}"
+                        f" from {releases_url}",
+                        INFO,
+                    )
+                    urlretrieve(  # noqa: S310
+                        os.path.join(releases_url, download_path),
+                        file_path,
+                    )
+                    if os.path.splitext(file_path)[1] == ".AppImage":
+                        os.chmod(file_path, stat.S_IRWXU)
+        return file_path
 
     def run(self) -> None:
         # Create the application bundle
@@ -263,7 +279,10 @@ class bdist_appimage(Command):
 
         # Build an AppImage from an AppDir
         os.environ["ARCH"] = ARCH
-        cmd = [self.appimagekit, "--no-appstream", appdir, output]
+        cmd = [self.appimagekit]
+        if self.runtime is not None:
+            cmd.extend(["--runtime-file", self.runtime])
+        cmd.extend(["--no-appstream", appdir, output])
         if find_library("fuse") is None:  # libfuse.so.2 is not found
             cmd.insert(1, "--appimage-extract-and-run")
         with FileLock(self.appimagekit + ".lock"):

--- a/cx_Freeze/command/bdist_appimage.py
+++ b/cx_Freeze/command/bdist_appimage.py
@@ -168,15 +168,16 @@ class bdist_appimage(Command):
     def _get_file(
         self, file_path: str | None, releases_url: str, download_path: str
     ) -> str | None:
-        """Fetch appimagetool or (optional) runtime from the web if not available locally."""
+        """Fetch appimagetool from the web if not available locally."""
         if file_path is not None:
             file_path = os.path.expanduser(file_path)
             self.mkpath(os.path.dirname(file_path))
             with FileLock(file_path + ".lock"):
                 if not os.path.exists(file_path):
                     self.announce(
-                        f"download and install {os.path.basename(download_path)}"
-                        f" from {releases_url}",
+                        "download and install "
+                        f"{os.path.basename(download_path)} "
+                        f"from {releases_url}",
                         INFO,
                     )
                     urlretrieve(  # noqa: S310

--- a/cx_Freeze/command/bdist_appimage.py
+++ b/cx_Freeze/command/bdist_appimage.py
@@ -30,7 +30,9 @@ __all__ = ["bdist_appimage"]
 
 ARCH = platform.machine()
 APPIMAGETOOL_RELEASES_URL = "https://github.com/AppImage/appimagetool/releases"
-TYPE2RUNTIME_RELEASES_URL = "https://github.com/AppImage/type2-runtime/releases"
+TYPE2RUNTIME_RELEASES_URL = (
+    "https://github.com/AppImage/type2-runtime/releases"
+)
 APPIMAGETOOL_DOWNLOAD = f"download/continuous/appimagetool-{ARCH}.AppImage"
 TYPE2RUNTIME_DOWNLOAD = f"download/continuous/runtime-{ARCH}"
 APPIMAGETOOL_CACHE = f"~/.local/bin/appimagetool-{ARCH}.AppImage"
@@ -157,17 +159,17 @@ class bdist_appimage(Command):
         self.appimagekit = self._get_file(
             self.appimagekit or APPIMAGETOOL_CACHE,
             APPIMAGETOOL_RELEASES_URL,
-            APPIMAGETOOL_DOWNLOAD
+            APPIMAGETOOL_DOWNLOAD,
         )
 
         # optionally, download type2 runtime
         self.runtime = self._get_file(
-            self.runtime,
-            TYPE2RUNTIME_RELEASES_URL,
-            TYPE2RUNTIME_DOWNLOAD
+            self.runtime, TYPE2RUNTIME_RELEASES_URL, TYPE2RUNTIME_DOWNLOAD
         )
 
-    def _get_file(self, file_path: str | None, releases_url: str, download_path: str) -> str | None:
+    def _get_file(
+        self, file_path: str | None, releases_url: str, download_path: str
+    ) -> str | None:
         """Fetch appimagetool or (optional) runtime from the web if not available locally."""
         if file_path is not None:
             file_path = os.path.expanduser(file_path)

--- a/doc/src/bdist_appimage.rst
+++ b/doc/src/bdist_appimage.rst
@@ -28,6 +28,8 @@ file executable.
      - description
    * - .. option:: appimagekit
      - path to appimagetool (formerly AppImageKit) [default: the latest version is downloaded]
+   * - .. option:: runtime
+     - path to type2 runtime [default: the latest version is downloaded by appimagetool]
    * - .. option:: bdist_base
      - base directory for creating built distributions
    * - .. option:: build_dir (-b)

--- a/doc/src/bdist_appimage.rst
+++ b/doc/src/bdist_appimage.rst
@@ -28,7 +28,7 @@ file executable.
      - description
    * - .. option:: appimagekit
      - path to appimagetool (formerly AppImageKit) [default: the latest version is downloaded]
-   * - .. option:: runtime
+   * - .. option:: runtime_file
      - path to type2 runtime [default: the latest version is downloaded by appimagetool]
    * - .. option:: bdist_base
      - base directory for creating built distributions

--- a/tests/test_command_bdist_appimage.py
+++ b/tests/test_command_bdist_appimage.py
@@ -52,6 +52,19 @@ def test_bdist_appimage_download_appimagetool() -> None:
 
 
 @pytest.mark.skipif(not IS_LINUX, reason="Linux test")
+def test_bdist_appimage_download_runtime(tmp_path) -> None:
+    """Test bdist_appimage for "offline" builds."""
+    dist = Distribution(DIST_ATTRS)
+    cmd = bdist_appimage(dist)
+    # use locally installed appimagetool and runtime
+    cmd.appimagekit = str(tmp_path / "appimagetool.AppImage")
+    cmd.runtime = str(tmp_path / "type2_runtime")
+    cmd.finalize_options()
+    cmd.ensure_finalized()
+    assert cmd.fullname == "foo-0.0"
+
+
+@pytest.mark.skipif(not IS_LINUX, reason="Linux test")
 def test_bdist_appimage_target_name() -> None:
     """Test the bdist_appimage with extra target_name option."""
     dist = Distribution(DIST_ATTRS)

--- a/tests/test_command_bdist_appimage.py
+++ b/tests/test_command_bdist_appimage.py
@@ -58,7 +58,7 @@ def test_bdist_appimage_download_runtime(tmp_path) -> None:
     cmd = bdist_appimage(dist)
     # use locally installed appimagetool and runtime
     cmd.appimagekit = str(tmp_path / "appimagetool.AppImage")
-    cmd.runtime = str(tmp_path / "type2_runtime")
+    cmd.runtime_file = str(tmp_path / "type2_runtime")
     cmd.finalize_options()
     cmd.ensure_finalized()
     assert cmd.fullname == "foo-0.0"


### PR DESCRIPTION
When using bdist_appimage to build an AppImage, the appimagetool will automatically download the latest "type2 runtime" from https://github.com/AppImage/type2-runtime/releases to be included in the AppImage file. While such an automatic download can be convenient, some environments require full "offline" buildability of the target application. The appimagetool already provides a solution for this with the "--runtime-file" argument, which is not yet used in cx_Freeze.

This patch adds an additional argument "runtime" to the bdist_appimage command, which behaves very similar to the existing argument "appimagekit". If provided, the runtime will downloaded to the given path (if not already there) and it will be passed onwards to the appimagetool when invoked in the freezing process.

I tried to test my approach by following the build instructions in doc/src/development/index.rst and tests/README.md but failed miserably. Please take the suggested changes with care. I will try again in a container. Any suggestions are welcome.