### PR TITLE
tests: avoid duplicate qt libs

### DIFF
--- a/cx_Freeze/freezer.py
+++ b/cx_Freeze/freezer.py
@@ -1386,7 +1386,11 @@ class LinuxFreezer(Freezer, ELFParser):
         lib_files = self.finder.lib_files
         fix_rpath = set()
         fix_needed = {}
-        conda_prefix = Path(os.environ["CONDA_PREFIX"]) if IS_CONDA else None
+        conda_prefix = (
+            Path(os.environ["CONDA_PREFIX"])
+            if "CONDA_PREFIX" in os.environ
+            else None
+        )
         site_packages = next(
             (path for path in self.path if path.endswith("site-packages")),
             None,

--- a/cx_Freeze/freezer.py
+++ b/cx_Freeze/freezer.py
@@ -1405,45 +1405,40 @@ class LinuxFreezer(Freezer, ELFParser):
                     relative = Path(
                         os.path.relpath(dependent_target, target_dir)
                     )
+            # put the dependency (relatively) in the target_dir subtree
+            # this is possible with most packages installed by pip
+            elif dependent_source.is_relative_to(source_dir):
+                relative = dependent_source.relative_to(source_dir)
+                # dependency located with source or in a subdirectory
+                dependent_target = target_dir / relative
+            elif site_packages and dependent_source.is_relative_to(
+                site_packages
+            ):
+                # put the dependency in the in the target_dir under the same
+                # path as it is in the site-packages folder
+                relative = dependent_source.relative_to(site_packages)
+                dependent_target = self.target_dir / "lib" / relative
+            elif conda_prefix and dependent_source.is_relative_to(
+                conda_prefix / "lib"
+            ):
+                # put conda libs where they are in the conda env
+                rel = dependent_source.relative_to(conda_prefix / "lib")
+                dependent_target = self.target_dir / "lib" / rel
+                relative = Path(os.path.relpath(dependent_target, target_dir))
             else:
-                # put the dependency (relatively) in the target_dir subtree
-                # this is possible with most packages installed by pip
-                if dependent_source.is_relative_to(source_dir):
-                    relative = dependent_source.relative_to(source_dir)
-                    # dependency located with source or in a subdirectory
-                    dependent_target = target_dir / relative
-                elif site_packages and dependent_source.is_relative_to(
-                    site_packages
-                ):
-                    # put the dependency in the in the target_dir under the same
-                    # path as it is in the site-packages folder
-                    relative = dependent_source.relative_to(site_packages)
-                    dependent_target = self.target_dir / "lib" / relative
-                elif conda_prefix and dependent_source.is_relative_to(
-                    conda_prefix / "lib"
-                ):
-                    # put conda libs where they are in the conda env
-                    rel = dependent_source.relative_to(conda_prefix / "lib")
-                    dependent_target = self.target_dir / "lib" / rel
-                    relative = Path(
-                        os.path.relpath(dependent_target, target_dir)
-                    )
-                else:
-                    # put the dependency in target_dir along with the binary
-                    # file being copied, unless the dependency has already been
-                    # copied to another location and is relative to the source
-                    dependent_target = target_dir / dependent_name
-                    relative = Path(dependent_name)
-                    for file in self.files_copied:
-                        if file.name == dependent_name:
-                            try:
-                                relative = file.relative_to(target_dir)
-                                dependent_target = file
-                            except ValueError:
-                                relative = Path(
-                                    os.path.relpath(file, target_dir)
-                                )
-                            break
+                # put the dependency in target_dir along with the binary
+                # file being copied, unless the dependency has already been
+                # copied to another location and is relative to the source
+                dependent_target = target_dir / dependent_name
+                relative = Path(dependent_name)
+                for file in self.files_copied:
+                    if file.name == dependent_name:
+                        try:
+                            relative = file.relative_to(target_dir)
+                            dependent_target = file
+                        except ValueError:
+                            relative = Path(os.path.relpath(file, target_dir))
+                        break
             fix_rpath.add(f"$ORIGIN/{relative.parent.as_posix()}")
             self._copy_file(
                 dependent_source, dependent_target, copy_dependent_files

--- a/tests/hooks/test_qt.py
+++ b/tests/hooks/test_qt.py
@@ -1,12 +1,10 @@
-"""Tests for hooks for qt"""
+"""Tests for hooks for qt."""
 
 from __future__ import annotations
 
 import pytest
 
-from cx_Freeze._compat import IS_MACOS, IS_MINGW, IS_WINDOWS
-
-from ..conftest import IS_CONDA
+from cx_Freeze._compat import IS_CONDA, IS_MACOS, IS_MINGW, IS_WINDOWS
 
 TIMEOUT = 10
 
@@ -53,6 +51,7 @@ pyproject.toml
 
 
 def find_duplicates_libs(build_lib_dir) -> dict[str, list[str]]:
+    """Look for any duplicate libs files in the build lib dir."""
     if IS_MINGW or IS_WINDOWS:
         extension = "*.dll"
     elif IS_MACOS:
@@ -74,10 +73,10 @@ def test_qt(tmp_package, qt_impl) -> None:
     """Test if anyio is working correctly."""
     tmp_package.create(
         SOURCE_QT
-        % dict(
-            qt_mod=qt_impl,
-            qt_dep=qt_impl.lower().rstrip("456") if IS_CONDA else qt_impl,
-        )
+        % {
+            "qt_mod": qt_impl,
+            "qt_dep": qt_impl.lower().rstrip("456") if IS_CONDA else qt_impl,
+        }
     )
     tmp_package.freeze()
 

--- a/tests/hooks/test_qt.py
+++ b/tests/hooks/test_qt.py
@@ -1,0 +1,91 @@
+"""Tests for hooks for qt"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from ..conftest import IS_CONDA
+
+TIMEOUT = 10
+
+QT_IMPLS = []
+for qt_impl in ("PyQt6", "PySide6", "PyQt5", "PySide2"):
+    try:
+        __import__(qt_impl)
+        QT_IMPLS.append(qt_impl)
+    except ImportError:
+        pass
+
+
+SOURCE_QT = """
+test_qt.py
+    from %(qt_mod)s.QtCore import QTimer
+    from %(qt_mod)s.QtWidgets import QApplication, QLabel
+
+    app = QApplication([])
+    label = QLabel('Hello from Qt!')
+    label.show()
+    timer = QTimer()
+
+    def quit():
+        print(label.text())
+        app.quit()
+
+    timer.start(500)
+    timer.timeout.connect(quit)
+    app.exec()
+
+pyproject.toml
+    [project]
+    name = "test_qt"
+    version = "0.1.2.3"
+    dependencies = ["%(qt_dep)s"]
+
+    [tool.cxfreeze]
+    executables = ["test_qt.py"]
+
+    [tool.cxfreeze.build_exe]
+    excludes = ["tkinter", "unittest"]
+    silent = true
+"""
+
+
+def find_duplicates_libs(build_lib_dir) -> dict[str, list[str]]:
+    if sys.platform == "win32":
+        lib_pattern = "**/*.dll"
+    else:
+        lib_pattern = "**/*.so*"
+
+    libs = {}
+    for p in build_lib_dir.glob(lib_pattern):
+        if p.name not in libs:
+            libs[p.name] = []
+        libs[p.name].append(str(p.relative_to(build_lib_dir)))
+    return {k: v for k, v in libs.items() if len(v) > 1}
+
+
+@pytest.mark.venv
+@pytest.mark.skipif(not QT_IMPLS, reason="No Qt libraries installed")
+@pytest.mark.parametrize("qt_impl", QT_IMPLS)
+def test_qt(tmp_package, qt_impl) -> None:
+    """Test if anyio is working correctly."""
+    tmp_package.create(
+        SOURCE_QT
+        % dict(
+            qt_mod=qt_impl,
+            qt_dep=qt_impl.lower().rstrip("456") if IS_CONDA else qt_impl,
+        )
+    )
+    tmp_package.freeze()
+
+    # Test frozen app
+    executable = tmp_package.executable("test_qt")
+    assert executable.is_file()
+    result = tmp_package.run(executable, timeout=TIMEOUT)
+    result.stdout.fnmatch_lines(["Hello from Qt!"])
+
+    # Check for duplicate libs
+    duplicate_libs = find_duplicates_libs(executable.parent / "lib")
+    assert not duplicate_libs

--- a/tests/hooks/test_qt.py
+++ b/tests/hooks/test_qt.py
@@ -2,9 +2,20 @@
 
 from __future__ import annotations
 
+import os
+import sys
+
 import pytest
 
-from cx_Freeze._compat import IS_MACOS, IS_MINGW, IS_WINDOWS
+from cx_Freeze._compat import (
+    ABI_THREAD,
+    IS_ARM_64,
+    IS_CONDA,
+    IS_LINUX,
+    IS_MACOS,
+    IS_MINGW,
+    IS_WINDOWS,
+)
 
 TIMEOUT = 10
 
@@ -14,7 +25,7 @@ test_qt.py
     from %(qt_mod)s.QtWidgets import QApplication, QLabel
 
     app = QApplication([])
-    label = QLabel('Hello from Qt!')
+    label = QLabel("Hello from Qt!")
     label.show()
     timer = QTimer()
 
@@ -39,6 +50,7 @@ pyproject.toml
     executables = ["test_qt.py"]
 
     [tool.cxfreeze.build_exe]
+    include_msvcr = true
     excludes = ["tkinter", "unittest"]
     silent = true
 """
@@ -60,27 +72,60 @@ def find_duplicates_libs(build_lib_dir) -> dict[str, list[str]]:
     return {k: v for k, v in libs.items() if len(v) > 1}
 
 
+@pytest.mark.xfail(
+    sys.version_info[:2] >= (3, 13) and ABI_THREAD == "t",
+    raises=ModuleNotFoundError,
+    reason="Qt does not support Python 3.13t",
+    strict=True,
+)
 @pytest.mark.venv
 @pytest.mark.parametrize("qt_impl", ["PyQt6", "PySide6", "PyQt5", "PySide2"])
 def test_qt(tmp_package, qt_impl) -> None:
     """Test if qt is working correctly."""
+    if IS_CONDA:
+        if qt_impl == "PyQt6":
+            pytest.skip(f"{qt_impl} not supported in conda")
+        if qt_impl == "PySide2" and sys.version_info[:2] >= (3, 13):
+            pytest.skip("PySide2 does not support Python 3.13+ on conda")
+    else:
+        if qt_impl == "PySide2":
+            if IS_MACOS:
+                pytest.skip("PySide2 does not support macOS")
+            if not IS_MINGW and sys.version_info[:2] >= (3, 11):
+                pytest.skip("PySide2 does not support Python 3.11+")
+        if (
+            qt_impl in ("PyQt5", "PySide2")
+            and (IS_LINUX or IS_WINDOWS)
+            and IS_ARM_64
+        ):
+            pytest.skip(f"{qt_impl} not supported in arm64")
+
     tmp_package.map_package_to_conda.update(
         {
-            "PyQt6": "-c anaconda pyqt=6",
             "PyQt5": "pyqt=5",
             "PySide2": "pyside2",
             "PySide6": "pyside6",
         }
     )
-    tmp_package.map_package_to_mingw[qt_impl] = qt_impl.lower()
+    tmp_package.map_package_to_mingw.update(
+        {
+            "PyQt5": "python-pyqt5",
+            "PyQt6": "python-pyqt6",
+            "PySide2": "pyside2",
+            "PySide6": "pyside6",
+        }
+    )
     tmp_package.create(SOURCE_QT % {"qt_mod": qt_impl})
     tmp_package.freeze()
 
     # Test frozen app
     executable = tmp_package.executable("test_qt")
     assert executable.is_file()
-    result = tmp_package.run(executable, timeout=TIMEOUT)
-    result.stdout.fnmatch_lines(["Hello from Qt!"])
+    # Do not test in Linux using CI yet because of missing xcb libs
+    # but we can compare duplicate libs
+    if not (IS_LINUX and os.environ.get("CI")):
+        result = tmp_package.run(executable, timeout=TIMEOUT)
+        result.stdout.fnmatch_lines(["Hello from Qt!"])
 
     # Check for duplicate libs
     duplicate_libs = find_duplicates_libs(executable.parent / "lib")

--- a/tests/hooks/test_qt.py
+++ b/tests/hooks/test_qt.py
@@ -24,7 +24,10 @@ test_qt.py
 
     timer.start(500)
     timer.timeout.connect(quit)
-    app.exec()
+    if hasattr(app, "exec"):
+        app.exec()
+    else:
+        app.exec_()
 
 pyproject.toml
     [project]
@@ -64,7 +67,7 @@ def test_qt(tmp_package, qt_impl) -> None:
     tmp_package.map_package_to_conda.update(
         {
             "PyQt6": "-c anaconda pyqt=6",
-            "PyQt5": "-c anaconda pyqt=5",
+            "PyQt5": "pyqt=5",
             "PySide2": "pyside2",
             "PySide6": "pyside6",
         }

--- a/tests/hooks/test_qt.py
+++ b/tests/hooks/test_qt.py
@@ -2,13 +2,11 @@
 
 from __future__ import annotations
 
-import sys
-
 import pytest
 
-from ..conftest import IS_CONDA
-
 from cx_Freeze._compat import IS_MACOS, IS_MINGW, IS_WINDOWS
+
+from ..conftest import IS_CONDA
 
 TIMEOUT = 10
 

--- a/tests/hooks/test_qt.py
+++ b/tests/hooks/test_qt.py
@@ -8,6 +8,8 @@ import pytest
 
 from ..conftest import IS_CONDA
 
+from cx_Freeze._compat import IS_MACOS, IS_MINGW, IS_WINDOWS
+
 TIMEOUT = 10
 
 QT_IMPLS = []
@@ -53,13 +55,14 @@ pyproject.toml
 
 
 def find_duplicates_libs(build_lib_dir) -> dict[str, list[str]]:
-    if sys.platform == "win32":
-        lib_pattern = "**/*.dll"
+    if IS_MINGW or IS_WINDOWS:
+        extension = "*.dll"
+    elif IS_MACOS:
+        extension = "*.dylib"
     else:
-        lib_pattern = "**/*.so*"
-
+        extension = "*.so*"
     libs = {}
-    for p in build_lib_dir.glob(lib_pattern):
+    for p in build_lib_dir.glob(f"**/{extension}"):
         if p.name not in libs:
             libs[p.name] = []
         libs[p.name].append(str(p.relative_to(build_lib_dir)))


### PR DESCRIPTION
The issue with duplicates lib files from https://github.com/marcelotduarte/cx_Freeze/issues/2531 has returned. 

This adds a fix for linux with libs in site-packages and any libs using conda.