### PR TITLE
Fix Windows permission error

### DIFF
--- a/cx_Freeze/dep_parser.py
+++ b/cx_Freeze/dep_parser.py
@@ -57,9 +57,10 @@ class Parser(ABC):
         env_path = os.environ["PATH"].split(os.pathsep)
         new_path = []
         for path in self._path + self._bin_path_includes + env_path:
-            resolved_path = Path(path).resolve()
-            if resolved_path not in new_path and resolved_path.is_dir():
-                new_path.append(resolved_path)
+            with suppress(PermissionError):
+                resolved_path = Path(path).resolve()
+                if resolved_path not in new_path and resolved_path.is_dir():
+                    new_path.append(resolved_path)
         return new_path
 
     def find_library(


### PR DESCRIPTION
# Purpose
Fixes a bug when building executables on Windows that causes a PermissionError. The issue stems from attempting to run `Path.is_dir` on a protected directory. For me this is specifically caused by 'C:\Windows\system32\config\systemprofile\AppData\Local\Microsoft\WindowsApps' being in my PATH. 

# Rationale
If we don't have permissions for the directory, it shouldn't be added regardless. Simply suppress the error.

Let me know if you'd prefer if I create an issue for this.

Thanks for the awesome tool!