### PR TITLE
chore: python-msilib as dependency for python 3.13

### DIFF
--- a/cx_Freeze/command/bdist_msi.py
+++ b/cx_Freeze/command/bdist_msi.py
@@ -14,14 +14,16 @@ from typing import ClassVar
 from packaging.version import Version
 from setuptools import Command
 
-from cx_Freeze._compat import IS_MINGW, IS_WINDOWS, PLATFORM
+from cx_Freeze._compat import ABI_THREAD, IS_MINGW, IS_WINDOWS, PLATFORM
 from cx_Freeze.exception import OptionError, PlatformError
 
 __all__ = ["bdist_msi"]
 
 logger = logging.getLogger(__name__)
 
-if (IS_MINGW or IS_WINDOWS) and sys.version_info[:2] < (3, 13):
+if (IS_MINGW or IS_WINDOWS) and not (
+    sys.version_info[:2] == (3, 13) and ABI_THREAD == "t"
+):
 
     @contextlib.contextmanager
     def suppress_known_deprecation() -> contextlib.AbstractContextManager:
@@ -1058,11 +1060,9 @@ class bdist_msi(Command):
         self.launch_on_finish = None
 
     def finalize_options(self) -> None:
-        major = sys.version_info.major
-        minor = sys.version_info.minor
-        if (major, minor) >= (3, 13):
+        if sys.version_info[:2] == (3, 13) and ABI_THREAD == "t":
             msg = (
-                f"bdist_msi is not supported on Python {major}.{minor} yet.\n"
+                "bdist_msi is not supported on Python 3.13t yet.\n"
                 "       Please check the pinned issue "
                 "https://github.com/marcelotduarte/cx_Freeze/issues/2837"
             )

--- a/cx_Freeze/hooks/unused_modules.py
+++ b/cx_Freeze/hooks/unused_modules.py
@@ -199,8 +199,15 @@ if PY_VERSION >= (3, 10):
 if PY_VERSION >= (3, 11):
     DEFAULT_EXCLUDES.add("binhex")
 if PY_VERSION >= (3, 12):
-    DEFAULT_EXCLUDES.update(["distutils", "imp", "smtpd"])
-    # asynchat and asyncore are available as pyasynchat and pyasyncore packages
+    DEFAULT_EXCLUDES.update(
+        [
+            # "asynchat",  # available as pyasynchat
+            # "asyncore",  # available as pyasyncore
+            "distutils",
+            "imp",
+            "smtpd",
+        ]
+    )
 if PY_VERSION >= (3, 13):
     DEFAULT_EXCLUDES.update(
         [
@@ -214,7 +221,7 @@ if PY_VERSION >= (3, 13):
             "imghdr",
             "lib2to3",
             "mailcap",
-            "msilib",
+            # "msilib",  # available as python-msilib
             "nis",
             "nntplib",
             "ossaudiodev",

--- a/doc/src/bdist_msi.rst
+++ b/doc/src/bdist_msi.rst
@@ -6,7 +6,7 @@ their dependencies creating Windows installer packages.
 
 .. warning::
 
-   This command is not supported in Python 3.13. See :issue:`2837`.
+   This command is not supported in Python 3.13t. See :issue:`2837`.
 
 The following options were added to the standard set of options for the
 command:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ dependencies = [
     "filelock>=3.12.3",
     "freeze-core>=0.2.0",
     "packaging>=24",
-    "python-msilib>=0.1.1 ;python_version >= '3.13'",
     "setuptools>=65.6.3,<=80.9.0",
     "tomli>=2.0.1 ;python_version < '3.11'",
     # Linux
@@ -48,6 +47,7 @@ dependencies = [
     "dmgbuild>=1.6.1 ;sys_platform == 'darwin'",
     # Windows
     "lief>=0.15.1,<=0.17.0 ;sys_platform == 'win32'",
+    "python-msilib>=0.1.1 ;sys_platform == 'win32' and python_version >= '3.13'",
 ]
 dynamic = ["version"]
 keywords = ["cx-freeze cxfreeze cx_Freeze freeze python"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "filelock>=3.12.3",
     "freeze-core>=0.2.0",
     "packaging>=24",
+    "python-msilib>=0.1.1 ;python_version >= '3.13'",
     "setuptools>=65.6.3,<=80.9.0",
     "tomli>=2.0.1 ;python_version < '3.11'",
     # Linux

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 filelock>=3.12.3
 freeze-core>=0.2.0
 packaging>=24
+python-msilib>=0.1.1 ;python_version >= '3.13'
 setuptools>=65.6.3,<=80.9.0
 tomli>=2.0.1 ;python_version < '3.11'
 patchelf>=0.14,<0.18 ;sys_platform == 'linux' and platform_machine == 'x86_64'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 filelock>=3.12.3
 freeze-core>=0.2.0
 packaging>=24
-python-msilib>=0.1.1 ;python_version >= '3.13'
 setuptools>=65.6.3,<=80.9.0
 tomli>=2.0.1 ;python_version < '3.11'
 patchelf>=0.14,<0.18 ;sys_platform == 'linux' and platform_machine == 'x86_64'
@@ -12,3 +11,4 @@ patchelf>=0.14,<0.18 ;sys_platform == 'linux' and platform_machine == 'ppc64le'
 patchelf>=0.14,<0.18 ;sys_platform == 'linux' and platform_machine == 's390x'
 dmgbuild>=1.6.1 ;sys_platform == 'darwin'
 lief>=0.15.1,<=0.17.0 ;sys_platform == 'win32'
+python-msilib>=0.1.1 ;sys_platform == 'win32' and python_version >= '3.13'

--- a/tests/test_command_bdist_msi.py
+++ b/tests/test_command_bdist_msi.py
@@ -7,12 +7,12 @@ import sys
 import pytest
 from setuptools import Distribution
 
-from cx_Freeze._compat import IS_MINGW, IS_WINDOWS, PLATFORM
+from cx_Freeze._compat import ABI_THREAD, IS_MINGW, IS_WINDOWS, PLATFORM
 from cx_Freeze.command.bdist_msi import bdist_msi
 
-if sys.version_info[:2] >= (3, 13):
+if sys.version_info[:2] == (3, 13) and ABI_THREAD == "t":
     pytest.skip(
-        reason="bdist_msi is not supported on Python 3.13 yet.",
+        reason="bdist_msi is not supported on Python 3.13t yet.",
         allow_module_level=True,
     )
 


### PR DESCRIPTION
#2837 