### PR TITLE
finder: optimized implementation of '_find_editable_spec'

### DIFF
--- a/cx_Freeze/finder.py
+++ b/cx_Freeze/finder.py
@@ -88,14 +88,9 @@ class ModuleFinder:
         self._tmp_dir = TemporaryDirectory(prefix="cxfreeze-")
         self.cache_path = Path(self._tmp_dir.name)
         self.lib_files: dict[Path, str] = {}
-        if hasattr(importlib.metadata, "packages_distributions"):
-            # the distribution name may vary from the module name (eg may include '-').
-            # packages_distributions returns the mapping but is only available on 3.10+
-            self.packages_distributions = (
-                importlib.metadata.packages_distributions()
-            )
-        else:
-            self.packages_distributions = None
+        self.packages_distributions = (
+            importlib.metadata.packages_distributions()
+        )
 
     def cleanup(self) -> None:
         self._tmp_dir.cleanup()
@@ -362,11 +357,7 @@ class ModuleFinder:
         self, name: str, path: Sequence[str] | None
     ) -> importlib.machinery.ModuleSpec | None:
         """Find the spec for a module installed as an editable package."""
-        if self.packages_distributions is None:
-            dist_names = [name]
-        else:
-            dist_names = self.packages_distributions.get(name, [])
-        for dist_name in dist_names:
+        for dist_name in self.packages_distributions.get(name, []):
             dist = importlib.metadata.distribution(dist_name)
             if not dist:
                 continue

--- a/cx_Freeze/finder.py
+++ b/cx_Freeze/finder.py
@@ -91,7 +91,9 @@ class ModuleFinder:
         if hasattr(importlib.metadata, "packages_distributions"):
             # the distribution name may vary from the module name (eg may include '-').
             # packages_distributions returns the mapping but is only available on 3.10+
-            self.packages_distributions = importlib.metadata.packages_distributions()
+            self.packages_distributions = (
+                importlib.metadata.packages_distributions()
+            )
         else:
             self.packages_distributions = None
 
@@ -363,9 +365,7 @@ class ModuleFinder:
         if self.packages_distributions is None:
             dist_names = [name]
         else:
-            dist_names = self.packages_distributions.get(
-                name, []
-            )
+            dist_names = self.packages_distributions.get(name, [])
         for dist_name in dist_names:
             dist = importlib.metadata.distribution(dist_name)
             if not dist:

--- a/cx_Freeze/finder.py
+++ b/cx_Freeze/finder.py
@@ -88,7 +88,9 @@ class ModuleFinder:
         self._tmp_dir = TemporaryDirectory(prefix="cxfreeze-")
         self.cache_path = Path(self._tmp_dir.name)
         self.lib_files: dict[Path, str] = {}
-        self.packages_distributions = importlib.metadata.packages_distributions()
+        self.packages_distributions = (
+            importlib.metadata.packages_distributions()
+        )
 
     def cleanup(self) -> None:
         self._tmp_dir.cleanup()
@@ -351,8 +353,8 @@ class ModuleFinder:
             return None
         return module
 
-    def _find_editable_spec(self,
-        name: str, path: Sequence[str] | None
+    def _find_editable_spec(
+        self, name: str, path: Sequence[str] | None
     ) -> importlib.machinery.ModuleSpec | None:
         """Find the spec for a module installed as an editable package."""
         # the distribution name may vary from the module name (eg may

--- a/cx_Freeze/finder.py
+++ b/cx_Freeze/finder.py
@@ -357,6 +357,8 @@ class ModuleFinder:
         self, name: str, path: Sequence[str] | None
     ) -> importlib.machinery.ModuleSpec | None:
         """Find the spec for a module installed as an editable package."""
+        # the distribution name may vary from the module name (eg may
+        # include '-'). packages_distributions returns the mapping
         for dist_name in self.packages_distributions.get(name, []):
             dist = importlib.metadata.distribution(dist_name)
             if not dist:

--- a/cx_Freeze/finder.py
+++ b/cx_Freeze/finder.py
@@ -88,6 +88,7 @@ class ModuleFinder:
         self._tmp_dir = TemporaryDirectory(prefix="cxfreeze-")
         self.cache_path = Path(self._tmp_dir.name)
         self.lib_files: dict[Path, str] = {}
+        self.packages_distributions = importlib.metadata.packages_distributions()
 
     def cleanup(self) -> None:
         self._tmp_dir.cleanup()
@@ -350,14 +351,13 @@ class ModuleFinder:
             return None
         return module
 
-    @staticmethod
-    def _find_editable_spec(
+    def _find_editable_spec(self,
         name: str, path: Sequence[str] | None
     ) -> importlib.machinery.ModuleSpec | None:
         """Find the spec for a module installed as an editable package."""
         # the distribution name may vary from the module name (eg may
         # include '-'). packages_distributions returns the mapping
-        dist_names = importlib.metadata.packages_distributions().get(name, [])
+        dist_names = self.packages_distributions.get(name, [])
 
         for dist_name in dist_names:
             dist = importlib.metadata.distribution(dist_name)
@@ -415,7 +415,7 @@ class ModuleFinder:
                 return module
 
         if not spec:
-            spec = ModuleFinder._find_editable_spec(name, path)
+            spec = self._find_editable_spec(name, path)
 
         if spec:
             loader = spec.loader


### PR DESCRIPTION
Optimized the "find_editable_spec" implementation by refactoring it from a static method to a class method, resulting in better performance.

Moved "importlib.metadata.packages_distributions()" call from the static method to ModuleFinder initialization to avoid rebuilding package distributions for each package file.