### PR TITLE
feat(hooks): add winrt module hook for automatic package inclusion

### DIFF
--- a/cx_Freeze/hooks/_winrt_.py
+++ b/cx_Freeze/hooks/_winrt_.py
@@ -28,7 +28,9 @@ class Hook(ModuleHook):
     def __getattr__(self, name: str) -> Any:
         if name.startswith("winrt_"):
 
-            def _include_subpackage(finder: ModuleFinder, module: Module) -> None:
+            def _include_subpackage(
+                finder: ModuleFinder, module: Module
+            ) -> None:
                 finder.include_package(module.name)
 
             return _include_subpackage

--- a/cx_Freeze/hooks/_winrt_.py
+++ b/cx_Freeze/hooks/_winrt_.py
@@ -1,0 +1,35 @@
+"""A collection of functions which are triggered automatically by finder when
+winrt package (pywinrt) is included.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from cx_Freeze.module import Module, ModuleHook
+
+if TYPE_CHECKING:
+    from cx_Freeze.finder import ModuleFinder
+
+
+__all__ = ["Hook"]
+
+
+class Hook(ModuleHook):
+    """The Hook class for winrt (pywinrt)."""
+
+    def winrt(
+        self,
+        finder: ModuleFinder,
+        module: Module,  # noqa: ARG002
+    ) -> None:
+        finder.include_package("winrt")
+
+    def __getattr__(self, name: str) -> Any:
+        if name.startswith("winrt_"):
+
+            def _include_subpackage(finder: ModuleFinder, module: Module) -> None:
+                finder.include_package(module.name)
+
+            return _include_subpackage
+        return super().__getattribute__(name)

--- a/tests/hooks/test_winrt.py
+++ b/tests/hooks/test_winrt.py
@@ -13,7 +13,9 @@ TIMEOUT = 15
 if sys.platform != "win32":
     pytest.skip(reason="Windows tests", allow_module_level=True)
 
-zip_packages = pytest.mark.parametrize("zip_packages", [False, True], ids=["", "zip_packages"])
+zip_packages = pytest.mark.parametrize(
+    "zip_packages", [False, True], ids=["", "zip_packages"]
+)
 
 
 SOURCE_WINRT = """

--- a/tests/hooks/test_winrt.py
+++ b/tests/hooks/test_winrt.py
@@ -1,0 +1,69 @@
+"""Tests for hooks of winrt (pywinrt)."""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+TIMEOUT = 15
+
+if sys.platform != "win32":
+    pytest.skip(reason="Windows tests", allow_module_level=True)
+
+zip_packages = pytest.mark.parametrize("zip_packages", [False, True], ids=["", "zip_packages"])
+
+
+SOURCE_WINRT = """
+test.py
+    from winrt.windows.foundation import Uri
+
+    # Test importing winrt submodule
+    print("winrt.windows.foundation imported successfully")
+
+    # Test Uri class from foundation
+    test_uri = Uri("https://github.com/marcelotduarte/cx_Freeze")
+    print(f"Uri domain: {test_uri.domain}")
+    print(f"Uri scheme: {test_uri.scheme_name}")
+
+    print("Test completed successfully")
+
+pyproject.toml
+    [project]
+    name = "test_winrt"
+    version = "0.1.0"
+    dependencies = ["winrt.windows.foundation"]
+
+    [tool.cxfreeze]
+    executables = ["test.py"]
+
+    [tool.cxfreeze.build_exe]
+    include_msvcr = true
+    excludes = ["tkinter", "unittest"]
+    silent = true
+"""
+
+
+@pytest.mark.venv(scope="module")
+@zip_packages
+def test_winrt(tmp_package, zip_packages: bool) -> None:
+    """Test if winrt hook is working correctly."""
+    tmp_package.create(SOURCE_WINRT)
+    if zip_packages:
+        pyproject = tmp_package.path / "pyproject.toml"
+        buf = pyproject.read_bytes().decode().splitlines()
+        buf += ['zip_include_packages = "*"', 'zip_exclude_packages = ""']
+        pyproject.write_bytes("\n".join(buf).encode("utf_8"))
+    tmp_package.freeze()
+
+    executable = tmp_package.executable("test")
+    assert executable.is_file()
+    result = tmp_package.run(executable, timeout=TIMEOUT)
+    result.stdout.fnmatch_lines(
+        [
+            "winrt.windows.foundation imported successfully",
+            "Uri domain: github.com",
+            "Uri scheme: https",
+            "Test completed successfully",
+        ]
+    )

--- a/tests/hooks/test_winrt.py
+++ b/tests/hooks/test_winrt.py
@@ -11,7 +11,9 @@ TIMEOUT = 15
 if sys.platform != "win32":
     pytest.skip(reason="Windows tests", allow_module_level=True)
 
-zip_packages = pytest.mark.parametrize("zip_packages", [False, True], ids=["", "zip_packages"])
+zip_packages = pytest.mark.parametrize(
+    "zip_packages", [False, True], ids=["", "zip_packages"]
+)
 
 
 SOURCE_WINRT = """

--- a/tests/hooks/test_winrt.py
+++ b/tests/hooks/test_winrt.py
@@ -6,14 +6,14 @@ import sys
 
 import pytest
 
+from cx_Freeze._compat import ABI_THREAD
+
 TIMEOUT = 15
 
 if sys.platform != "win32":
     pytest.skip(reason="Windows tests", allow_module_level=True)
 
-zip_packages = pytest.mark.parametrize(
-    "zip_packages", [False, True], ids=["", "zip_packages"]
-)
+zip_packages = pytest.mark.parametrize("zip_packages", [False, True], ids=["", "zip_packages"])
 
 
 SOURCE_WINRT = """
@@ -46,6 +46,12 @@ pyproject.toml
 """
 
 
+@pytest.mark.xfail(
+    ABI_THREAD == "t",
+    raises=ModuleNotFoundError,
+    reason="pywinrt does not support Python 3.13t/3.14t",
+    strict=True,
+)
 @pytest.mark.venv(scope="module")
 @zip_packages
 def test_winrt(tmp_package, zip_packages: bool) -> None:


### PR DESCRIPTION
This PR adds a new hook for [pywinrt](https://github.com/pywinrt/pywinrt) that automatically includes all `winrt` packages and `subpackages`, eliminating the need for manual module inclusion.

Previously, users had to manually specify every `winrt` submodule in their build configuration
```python
"includes": [
    "winrt.windows.ui.notifications",
    "winrt.windows.ui.notifications.management",
    "winrt.windows.data.xml.dom",
    "winrt.windows.media",
    "winrt.windows.media.control",
    "winrt.windows.management.deployment",
    "winrt.windows.applicationmodel",
    "winrt.windows.networking",
    "winrt.windows.networking.connectivity",
    "winrt.windows.storage",
    "winrt.windows.storage.streams",
    "winrt.windows.foundation",
    "winrt.windows.foundation.collections",
    "winrt.windows.devices.wifi",
    "winrt.windows.security.credentials",
    # ... and many more
]
```
The new `winrt` hook automatically includes the base package, dynamically handles all `winrt.*` subpackages using `__getattr__`.

Tested with [YASB](https://github.com/amnweb/yasb) and works fine.