### PR TITLE
fix: include-msvcr is also used on MSYS2 environments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ tests: wheel
 	cp pyproject.toml $(COV_TMPDIR)/
 	cp -a samples $(COV_TMPDIR)/
 	cp -a tests $(COV_TMPDIR)/
-	cd $(COV_TMPDIR) && pytest --dist=loadfile -nauto -v || true
+	cd $(COV_TMPDIR) && pytest --dist=loadfile -nauto -v -rpfEsXx tests|| true
 
 .PHONY: cov
 cov: wheel

--- a/cx_Freeze/_compat.py
+++ b/cx_Freeze/_compat.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import platform
 import sys
 from pathlib import Path
@@ -17,6 +18,7 @@ __all__ = [
     "IS_LINUX",
     "IS_MACOS",
     "IS_MINGW",
+    "IS_UCRT",
     "IS_WINDOWS",
     "IS_X86_32",
     "IS_X86_64",
@@ -43,6 +45,10 @@ IS_LINUX = PLATFORM.startswith("linux")
 IS_MACOS = PLATFORM.startswith("macos")
 IS_MINGW = PLATFORM.startswith("mingw")
 IS_WINDOWS = PLATFORM.startswith("win")
+
+IS_UCRT = IS_WINDOWS or (
+    IS_MINGW and os.environ.get("MSYSTEM", "").startswith(("UCRT", "CLANG"))
+)
 
 SOABI = get_config_var("SOABI")
 if SOABI is None or IS_MINGW:

--- a/cx_Freeze/command/build_exe.py
+++ b/cx_Freeze/command/build_exe.py
@@ -11,7 +11,7 @@ from typing import ClassVar
 
 from setuptools import Command
 
-from cx_Freeze._compat import BUILD_EXE_DIR, IS_WINDOWS
+from cx_Freeze._compat import BUILD_EXE_DIR, IS_UCRT
 from cx_Freeze.common import normalize_to_list
 from cx_Freeze.exception import OptionError, SetupError
 from cx_Freeze.freezer import Freezer
@@ -282,8 +282,8 @@ class build_exe(Command):
         elif self.no_compress is False:
             self.zip_filename = "library.zip"
 
-        # include-msvcr is used on Windows, but not in MingW
-        if IS_WINDOWS:
+        # include-msvcr is used on Windows and some MSYS2 environments
+        if IS_UCRT:
             if self.include_msvcr_version is not None:
                 self.include_msvcr = True
             self.include_msvcr = bool(self.include_msvcr)

--- a/cx_Freeze/freezer.py
+++ b/cx_Freeze/freezer.py
@@ -27,6 +27,7 @@ from cx_Freeze._compat import (
     IS_CONDA,
     IS_MACOS,
     IS_MINGW,
+    IS_UCRT,
     IS_WINDOWS,
     PYTHON_VERSION,
 )
@@ -140,8 +141,8 @@ class Freezer:
         self.compress: bool = True if compress is None else compress
         self.optimize: int = int(optimize or 0)
         self.path: list[str] | None = self._validate_path(path)
-        # include-msvcr is used on Windows, but not in MingW
-        self.include_msvcr: bool = IS_WINDOWS and bool(include_msvcr)
+        # include-msvcr is used on Windows and some MSYS2 environments
+        self.include_msvcr: bool = IS_UCRT and bool(include_msvcr)
         self.include_msvcr_version: str | None = include_msvcr_version
         self.target_dir = target_dir
         self.default_bin_includes: list[str] = self._default_bin_includes()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,7 +184,7 @@ source = [
 ]
 
 [tool.coverage.run]
-command_line = "-m pytest --dist=loadfile --durations=20 -nauto"
+command_line = "-m pytest --dist=loadfile --durations=20 -nauto -rpfEsXx tests"
 source = ["cx_Freeze"]
 parallel = true
 patch = ["subprocess"]

--- a/tests/hooks/test_av.py
+++ b/tests/hooks/test_av.py
@@ -9,7 +9,6 @@ from cx_Freeze._compat import (
     IS_CONDA,
     IS_LINUX,
     IS_MACOS,
-    IS_MINGW,
     IS_WINDOWS,
 )
 
@@ -44,12 +43,6 @@ pyproject.toml
 @pytest.mark.skipif(
     IS_CONDA and (IS_LINUX or (IS_ARM_64 and IS_MACOS)),
     reason="av (pyAV) is too slow in conda-forge (Linux and OSX_ARM64)",
-)
-@pytest.mark.xfail(
-    IS_MINGW,
-    raises=ModuleNotFoundError,
-    reason="av (pyAV) not supported in mingw",
-    strict=True,
 )
 @pytest.mark.xfail(
     IS_WINDOWS and IS_ARM_64,

--- a/tests/test_command_build_exe.py
+++ b/tests/test_command_build_exe.py
@@ -7,7 +7,7 @@ import os
 import pytest
 from setuptools import Distribution
 
-from cx_Freeze._compat import BUILD_EXE_DIR, IS_WINDOWS
+from cx_Freeze._compat import BUILD_EXE_DIR, IS_UCRT
 from cx_Freeze.command.build_exe import build_exe
 from cx_Freeze.exception import SetupError
 
@@ -62,22 +62,22 @@ DIST_ATTRS = {
         ),
         pytest.param(
             {"include_msvcr": True},
-            {"include_msvcr": IS_WINDOWS},
+            {"include_msvcr": IS_UCRT},
             id="include-msvcr=true",
         ),
         pytest.param(
             {"include_msvcr_version": "15"},
-            {"include_msvcr": IS_WINDOWS, "include_msvcr_version": "15"},
+            {"include_msvcr": IS_UCRT, "include_msvcr_version": "15"},
             id="include-msvcr-version=15",
         ),
         pytest.param(
             {"include_msvcr_version": "16"},
-            {"include_msvcr": IS_WINDOWS, "include_msvcr_version": "16"},
+            {"include_msvcr": IS_UCRT, "include_msvcr_version": "16"},
             id="include-msvcr-version=16",
         ),
         pytest.param(
             {"include_msvcr_version": "17"},
-            {"include_msvcr": IS_WINDOWS, "include_msvcr_version": "17"},
+            {"include_msvcr": IS_UCRT, "include_msvcr_version": "17"},
             id="include-msvcr-version=17",
         ),
         pytest.param(
@@ -358,22 +358,22 @@ def test_build_exe_finalize_options_raises(
         ),
         pytest.param(
             ["--include-msvcr"],
-            {"include_msvcr": IS_WINDOWS},
+            {"include_msvcr": IS_UCRT},
             id="--include-msvcr",
         ),
         pytest.param(
             ["--include-msvcr-version=15"],
-            {"include_msvcr": IS_WINDOWS, "include_msvcr_version": "15"},
+            {"include_msvcr": IS_UCRT, "include_msvcr_version": "15"},
             id="--include-msvcr-version=15",
         ),
         pytest.param(
             ["--include-msvcr-version=16"],
-            {"include_msvcr": IS_WINDOWS, "include_msvcr_version": "16"},
+            {"include_msvcr": IS_UCRT, "include_msvcr_version": "16"},
             id="--include-msvcr-version=16",
         ),
         pytest.param(
             ["--include-msvcr-version=17"],
-            {"include_msvcr": IS_WINDOWS, "include_msvcr_version": "17"},
+            {"include_msvcr": IS_UCRT, "include_msvcr_version": "17"},
             id="--include-msvcr-version=17",
         ),
     ],

--- a/tests/test_freezer.py
+++ b/tests/test_freezer.py
@@ -15,6 +15,7 @@ from cx_Freeze._compat import (
     IS_CONDA,
     IS_MACOS,
     IS_MINGW,
+    IS_UCRT,
     IS_WINDOWS,
     PYTHON_VERSION,
 )
@@ -178,7 +179,7 @@ def test_freezer_populate_zip_options_invalid_values(tmp_package) -> None:
         ),
         pytest.param(
             {"include_msvcr": True},
-            {"include_msvcr": IS_WINDOWS},
+            {"include_msvcr": IS_UCRT},
             id="include_msvcr=true",
         ),
         pytest.param(


### PR DESCRIPTION
https://www.msys2.org/docs/environments/
| Name | Prefix | Toolchain | Architecture | C Library | C++ Library |
| ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
| UCRT64 | /ucrt64 | gcc | x86_64 | **ucrt** | libstdc++ |
| CLANG64 | /clang64 | llvm | x86_64 | **ucrt** | libc++ |
| CLANG32 | /clang32 | llvm | i686 | **ucrt** | libc++ |
| CLANGARM64 | /clangarm64 | llvm | aarch64 | **ucrt** | libc++ |
| MINGW64 | /mingw64 | gcc | x86_64 | msvcrt | libstdc++ |
| MINGW32 | /mingw32 | gcc | i686 | msvcrt | libstdc++ |
| MSYS | /usr | gcc | x86_64 | cygwin | libstdc++ |

Note: clangarm64 requires Windows 11 ARM64.
