### PR TITLE
bdist_msi: refactor to work better with pyproject

### DIFF
--- a/cx_Freeze/command/bdist_msi.py
+++ b/cx_Freeze/command/bdist_msi.py
@@ -100,39 +100,90 @@ class bdist_msi(Command):
             "skip rebuilding everything (for testing/debugging)",
         ),
         # cx_Freeze specific
-        ("add-to-path=", None, "add target dir to PATH environment variable"),
-        ("all-users=", None, "installation for all users (or just me)"),
+        (
+            "add-to-path=",
+            None,
+            "add target directory to the PATH environment variable "
+            "[default: False]",
+        ),
+        (
+            "all-users=",
+            None,
+            "install for all users or just for the installing user "
+            "[default: False]",
+        ),
         (
             "data=",
             None,
             "dictionary of data indexed by table name, and each value is a "
             "tuple to include in table",
         ),
-        ("directories=", None, "list of 3-tuples of directories to create"),
-        ("environment-variables=", None, "list of environment variables"),
+        (
+            "directories=",
+            None,
+            "list of 3-tuples of directories that should be created during "
+            "installation",
+        ),
+        (
+            "environment-variables=",
+            None,
+            "list of environment variables that should be added to the "
+            "system during installation",
+        ),
         ("extensions=", None, "Extensions for which to register Verbs"),
         ("initial-target-dir=", None, "initial target directory"),
-        ("install-icon=", None, "icon path to add/remove programs "),
-        ("product-code=", None, "product code to use"),
         (
-            "summary-data=",
+            "install-icon=",
             None,
-            "Dictionary of data to include in msi summary data stream. "
-            'Allowed keys are "author", "comments", "keywords".',
-        ),
-        ("target-name=", None, "name of the file to create"),
-        ("target-version=", None, "version of the file to create"),
-        ("upgrade-code=", None, "upgrade code to use"),
-        (
-            "license-file=",
-            None,
-            "rft formatted license file to include in the installer",
+            "path of icon to use for the add/remove programs",
         ),
         (
             "launch-on-finish",
             None,
-            "Include a Launch on Finish checkbox in the installer.",
+            "include a 'Launch on Finish' checkbox in the installer"
+            "[default: False]",
         ),
+        (
+            "license-file=",
+            None,
+            "path to a rtf formmated file to be used as the license agreement",
+        ),
+        (
+            "output-name=",
+            None,
+            "specifies the name of the file that is to be created",
+        ),
+        (
+            "product-code=",
+            None,
+            "define the product code for the package that is created",
+        ),
+        (
+            "product-name=",
+            None,
+            "define the product name for the package that is created "
+            "[default: metadata name]",
+        ),
+        (
+            "product-version=",
+            None,
+            "define the product version for the package that is created "
+            "[default: metadata version if available]",
+        ),
+        (
+            "summary-data=",
+            None,
+            "dictionary of data to include in MSI summary data stream "
+            '(allowed keys are "author", "comments" and "keywords")',
+        ),
+        (
+            "upgrade-code=",
+            None,
+            "define the GUID of the upgrade code for the package that is "
+            "created",
+        ),
+        ("target-name=", None, "[removed]"),
+        ("target-version=", None, "[removed]"),
     ]
 
     boolean_options: ClassVar[list[str]] = [
@@ -398,7 +449,8 @@ class bdist_msi(Command):
                         "VSDCA_Launch",
                         226,
                         "TARGETDIR",
-                        f"[TARGETDIR]\\{self.distribution.executables[0].target_name}",
+                        "[TARGETDIR]\\"
+                        f"{self.distribution.executables[0].target_name}",
                     )
                 ],
             )
@@ -1043,23 +1095,27 @@ class bdist_msi(Command):
         self.skip_build = None
         self.install_script = None
         self.pre_install_script = None
-        # cx_Freeze specific
-        self.upgrade_code = None
-        self.product_code = None
-        self.add_to_path = None
-        self.initial_target_dir = None
-        self.target_name = None
-        self.target_version = None
         self.fullname = None
+        # cx_Freeze specific
+        self.add_to_path = None
+        self.all_users = False
+        self.data = None
         self.directories = None
         self.environment_variables = None
-        self.data = None
-        self.summary_data = None
-        self.install_icon = None
-        self.all_users = False
         self.extensions = None
-        self.license_file = None
+        self.initial_target_dir = None
+        self.install_icon = None
         self.launch_on_finish = None
+        self.license_file = None
+        self.output_name = None
+        self.product_code = None
+        self.product_name = None
+        self.product_version = None
+        self.summary_data = None
+        self.upgrade_code = None
+        # removed
+        self.target_name = None
+        self.target_version = None
 
         self._warnings = []
 
@@ -1095,47 +1151,44 @@ class bdist_msi(Command):
                 raise OptionError(msg)
         self.install_script_key = None
 
-        # default values for target_name and target_version
-        if self.target_name is None:
-            if self.distribution.metadata.name:
-                self.target_name = self.distribution.metadata.name
-            else:
-                executables = self.distribution.executables
-                executable = executables[0]
-                self.warn_delayed(
-                    "using the first executable as target_name: "
-                    f"{executable.target_name}"
-                )
-                self.target_name = executable.target_name
-        if self.target_version is None and self.distribution.metadata.version:
-            self.target_version = self.distribution.metadata.version
+        # removed
+        if self.target_name is not None:
+            msg = (
+                "target_name option was removed, use output_name"
+                " (or in some cases, use project.name or product_name instead)"
+            )
+            raise OptionError(msg)
+        if self.target_version is not None:
+            msg = (
+                "target_version option was removed, "
+                "use project.version or product_version instead"
+            )
+            raise OptionError(msg)
 
-        name = self.target_name
-        version = self.target_version
-        name, ext = os.path.splitext(name)
-        if ext == ".msi":
-            self.msi_name = self.target_name
-            self.fullname = name
-        elif version:
-            self.msi_name = f"{name}-{version}-{MSI_PLATFORM}.msi"
-            self.fullname = f"{name}-{version}"
-        else:
-            self.msi_name = f"{name}-{MSI_PLATFORM}.msi"
-            self.fullname = name
-
-        # default metadata name and version if not set in setup/pyproject
+        # name is required
         if not self.distribution.metadata.name:
-            self.distribution.metadata.name = name.split("-")[0]
-        if not self.distribution.metadata.version:
-            self.distribution.metadata.version = version
-        name = self.distribution.get_name()
+            msg = "name is required"
+            raise OptionError(msg)
+
+        # default values for product_name and product_version
+        self.ensure_string("product_name", self.distribution.get_name())
+        self.ensure_string("product_version", self.distribution.get_version())
+        # ProductVersion must be strictly numeric
+        self.product_version = Version(self.product_version).base_version
+        self.fullname = f"{self.product_name}-{self.product_version}"
+        self.ensure_string(
+            "output_name", f"{self.fullname}-{MSI_PLATFORM}.msi"
+        )
 
         if self.initial_target_dir is None:
             if IS_ARM_64 or IS_X86_64:
                 program_files_folder = "ProgramFiles64Folder"
             else:
                 program_files_folder = "ProgramFilesFolder"
-            self.initial_target_dir = rf"[{program_files_folder}]\{name}"
+            self.initial_target_dir = (
+                rf"[{program_files_folder}]\{self.product_name}"
+            )
+        self.ensure_filename("install_icon")
         if self.add_to_path is None:
             self.add_to_path = False
         if self.directories is None:
@@ -1144,6 +1197,7 @@ class bdist_msi(Command):
             self.environment_variables = []
         if self.license_file is not None:
             self.license_file = os.path.abspath(self.license_file)
+        self.ensure_filename("license_file")
         if self.data is None:
             self.data = {}
         if not isinstance(self.summary_data, dict):
@@ -1179,7 +1233,9 @@ class bdist_msi(Command):
                 )
                 raise ValueError(msg) from None
             stem = os.path.splitext(executable)[0]
-            progid = make_id(f"{name}.{stem}.{version}")
+            progid = make_id(
+                f"{self.product_name}.{stem}.{self.product_version}"
+            )
             mime = extension.get("mime", None)
             # "%1" a better default for argument?
             argument = extension.get("argument", None)
@@ -1207,7 +1263,7 @@ class bdist_msi(Command):
                 -1,
                 rf"Software\Classes\{progid}",
                 "FriendlyAppName",
-                name,
+                self.product_name,
                 component,
             )
             self._append_to_data(
@@ -1216,7 +1272,7 @@ class bdist_msi(Command):
                 -1,
                 rf"Software\Classes\{progid}\shell\{verb}",
                 "FriendlyAppName",
-                name,
+                self.product_name,
                 component,
             )
             self._append_to_data(
@@ -1246,17 +1302,12 @@ class bdist_msi(Command):
         # make msi (by default in dist directory)
         self.mkpath(self.dist_dir)
         installer_name = os.path.abspath(
-            os.path.join(self.dist_dir, self.msi_name)
+            os.path.join(self.dist_dir, self.output_name)
         )
         if os.path.exists(installer_name):
             os.unlink(installer_name)
 
         author = self.distribution.metadata.get_contact() or "UNKNOWN"
-        distribution_name = self.distribution.get_name()
-        # ProductVersion must be strictly numeric
-        distribution_version = Version(
-            self.target_version or self.distribution.get_version()
-        ).base_version
 
         # msilib is reloaded in order to reset the "_directories" global member
         # in that module.  That member is used by msilib to prevent any two
@@ -1272,20 +1323,20 @@ class bdist_msi(Command):
         self.db = init_database(
             installer_name,
             schema,
-            distribution_name,
+            self.product_name,
             self.product_code,
-            distribution_version,
+            self.product_version,
             author,
         )
         add_tables(self.db, sequence)
         self.add_properties()
         self.add_config()
-        self.add_upgrade_config(distribution_version)
+        self.add_upgrade_config(self.product_version)
         self.add_ui()
         self.add_files()
         self.db.Commit()
         self.distribution.dist_files.append(
-            ("bdist_msi", distribution_version or "any", distribution_name)
+            ("bdist_msi", self.product_version or "any", self.product_name)
         )
 
         if not self.keep_temp:

--- a/cx_Freeze/command/bdist_msi.py
+++ b/cx_Freeze/command/bdist_msi.py
@@ -6,6 +6,7 @@ import logging
 import os
 import re
 import shutil
+from contextlib import suppress
 from typing import ClassVar
 
 from packaging.version import Version
@@ -1304,7 +1305,7 @@ class bdist_msi(Command):
         installer_name = os.path.abspath(
             os.path.join(self.dist_dir, self.output_name)
         )
-        if os.path.exists(installer_name):
+        with suppress(FileNotFoundError):
             os.unlink(installer_name)
 
         author = self.distribution.metadata.get_contact() or "UNKNOWN"

--- a/doc/src/bdist_msi.rst
+++ b/doc/src/bdist_msi.rst
@@ -32,12 +32,10 @@ command:
    * - option name
      - description
    * - .. option:: add_to_path
-     - add the target directory to the PATH environment variable; the default
-       value is True if there are any console-based executables and False
-       otherwise.
+     - add the target directory to the PATH environment variable
+       [default: False]
    * - .. option:: all_users
-     - install for all users; the default value is False and results in an
-       installation for just the installing user.
+     - install for all users or just for the installing user [default: False]
    * - .. option:: data
      - dictionary of arbitrary MSI data indexed by table name; for each table,
        a list of tuples should be provided, representing the rows that should
@@ -65,21 +63,25 @@ command:
        during installation.
    * - .. option:: launch_on_finish
      - boolean flag that includes a "Launch the installed app on finish?"
-       checkbox to the final step of the installer. [default: False]
+       checkbox to the final step of the installer [default: False]
    * - .. option:: license_file
-     - path to an rtf formmated file to be used as the license agreement.
-       Refer to `Windows Installer Scrollable Text
+     - path to a rtf formmated file to be used as the license agreement;
+       refer to `Windows Installer Scrollable Text
        <https://learn.microsoft.com/en-us/windows/win32/msi/scrollabletext-control#control-attributes>`_.
+   * - .. option:: output_name
+     - specifies the name of the file that is to be created
+       [default: metadata name-version-platform.msi]
    * - .. option:: product_code
-     - define the product code for the package that is created.
+     - define the product code for the package that is created
+   * - .. option:: product_name
+     - define the product name for the package that is created
+       [default: metadata name]
+   * - .. option:: product_version
+     - define the product version for the package that is created
+       [default: metadata version if available]
    * - .. option:: summary_data
      - dictionary of data to include in MSI summary information stream
        (allowable keys are "author", "comments", and "keywords").
-   * - .. option:: target_name
-     - specifies the name of the file that is to be created; if the name
-       ends with ".msi" then it is used verbatim, otherwise, information
-       about the program version and platform will be added to the installer
-       name.
    * - .. option:: upgrade_code
      - define the GUID of the upgrade code for the package that is created;
        this is used to force the removal of any packages created with the same
@@ -94,6 +96,11 @@ command:
     :option:`license_file` option.
 .. versionadded:: 8.2
     :option:`launch_on_finish` option.
+.. versionadded:: 8.6
+    :option:`output_name`, :option:`product_name`, and
+    :option:`product_version` options.
+.. versionremoved:: 8.6
+    :option:`target_name` option.
 
 For example:
 
@@ -125,6 +132,7 @@ For example:
         environment_variables = [
             ["E_MYAPP_VAR", "=-*MYAPP_VAR", "1", "TARGETDIR"]
         ]
+        product_name = "Hello cx_Freeze"
         # use a different upgrade_code for your project
         upgrade_code = "{6B29FC40-CA47-1067-B31D-00DD010662DA}"
 

--- a/tests/test_command_bdist_msi.py
+++ b/tests/test_command_bdist_msi.py
@@ -50,6 +50,30 @@ def test_bdist_msi_target_name() -> None:
 
 
 @pytest.mark.skipif(not (IS_WINDOWS or IS_MINGW), reason="Windows test")
+def test_bdist_msi_target_version() -> None:
+    """Test the bdist_msi with extra target_version [removed] option."""
+    dist = Distribution(DIST_ATTRS)
+    cmd = bdist_msi(dist)
+    cmd.target_version = "0.1"
+    msg = "target_version option was removed,"
+    with pytest.raises(OptionError, match=msg):
+        cmd.finalize_options()
+
+
+@pytest.mark.skipif(not (IS_WINDOWS or IS_MINGW), reason="Windows test")
+def test_bdist_msi_no_name() -> None:
+    """Test the bdist_msi with no project name option."""
+    dist = Distribution(
+        {"executables": ["hello.py"], "script_name": "setup.py"}
+    )
+    cmd = bdist_msi(dist)
+    cmd.target_name = "mytest"
+    msg = "target_name option was removed, use output_name"
+    with pytest.raises(OptionError, match=msg):
+        cmd.finalize_options()
+
+
+@pytest.mark.skipif(not (IS_WINDOWS or IS_MINGW), reason="Windows test")
 def test_bdist_msi_product_name() -> None:
     """Test the bdist_msi with extra product_name option."""
     dist = Distribution(DIST_ATTRS)

--- a/tests/test_command_bdist_msi.py
+++ b/tests/test_command_bdist_msi.py
@@ -67,8 +67,7 @@ def test_bdist_msi_no_name() -> None:
         {"executables": ["hello.py"], "script_name": "setup.py"}
     )
     cmd = bdist_msi(dist)
-    cmd.target_name = "mytest"
-    msg = "target_name option was removed, use output_name"
+    msg = "name is required"
     with pytest.raises(OptionError, match=msg):
         cmd.finalize_options()
 


### PR DESCRIPTION
Closes #3233 

Added in version 8.6: [output_name](https://cx-freeze--3235.org.readthedocs.build/en/3235/bdist_msi.html#cmdoption-arg-output_name), [product_name](https://cx-freeze--3235.org.readthedocs.build/en/3235/bdist_msi.html#cmdoption-arg-product_name), and [product_version](https://cx-freeze--3235.org.readthedocs.build/en/3235/bdist_msi.html#cmdoption-arg-product_version) options.

Removed in version 8.6: [target_name](https://cx-freeze--3235.org.readthedocs.build/en/3235/bdist_appimage.html#cmdoption-arg-target_name) option.