### PR TITLE
chore: support setuptools v81 and v82

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
           - validate-pyproject-schema-store[all]>=2025.11.14
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.0
+    rev: v0.15.1
     hooks:
       - id: ruff-check
         args: ["--fix", "--show-fixes"]

--- a/cx_Freeze/_compat.py
+++ b/cx_Freeze/_compat.py
@@ -51,8 +51,7 @@ IS_UCRT = IS_WINDOWS or (
 )
 
 SOABI = get_config_var("SOABI")
-if SOABI is None or IS_MINGW:
+if SOABI is None:
     # Python <= 3.12 on Windows
-    # Python 3.12 MSYS2 incorrectly returns only sys.implementation.cache_tag
     platform_nodot = PLATFORM.replace(".", "").replace("-", "_")
     SOABI = f"{sys.implementation.cache_tag}-{platform_nodot}"

--- a/cx_Freeze/command/bdist_appimage.py
+++ b/cx_Freeze/command/bdist_appimage.py
@@ -353,9 +353,6 @@ class bdist_appimage(Command):
         if self.verbose >= 1:
             self.announce(f"creating {outfile}", logging.INFO)
 
-        if self.dry_run:
-            return (outfile, 1)
-
         if isinstance(data, str):
             data = data.encode()
         with open(outfile, "wb") as out:

--- a/cx_Freeze/command/bdist_deb.py
+++ b/cx_Freeze/command/bdist_deb.py
@@ -72,51 +72,45 @@ class bdist_deb(Command):
             dist_dir=self.dist_dir,
         )
         cmd_rpm.ensure_finalized()
-        if not self.dry_run:
-            cmd_rpm.run()
-            rpm_filename = None
-            for command, _, filename in self.distribution.dist_files:
-                if command == "bdist_rpm":
-                    rpm_filename = os.path.basename(filename)
-                    break
-            if rpm_filename is None:
-                msg = "could not build rpm"
-                raise ExecError(msg)
-        else:
-            rpm_filename = "filename.rpm"
+        cmd_rpm.run()
+        rpm_filename = None
+        for command, _, filename in self.distribution.dist_files:
+            if command == "bdist_rpm":
+                rpm_filename = os.path.basename(filename)
+                break
+        if rpm_filename is None:
+            msg = "could not build rpm"
+            raise ExecError(msg)
 
         # convert rpm to deb (by default in dist directory)
         logger.info("building DEB")
         cmd = ["alien", "--to-deb", rpm_filename]
         if os.getuid() != 0:
             cmd.insert(0, "fakeroot")
-        if self.dry_run:
-            self.spawn(cmd)
-        else:
-            logger.info(subprocess.list2cmdline(cmd))
-            process = subprocess.run(
-                cmd,
-                text=True,
-                capture_output=True,
-                check=False,
-                cwd=self.dist_dir,
-            )
-            if process.returncode != 0:
-                msg = process.stderr.splitlines()[0]
-                if msg.startswith(f"Unpacking of '{rpm_filename}' failed at"):
-                    info = [
-                        "\n\t\x08Please check if you have `cpio 2.13` on "
-                        "Ubuntu 22.04.",
-                        "\t\x08You can try to install a previous version:",
-                        "\t\x08$ sudo apt-get install cpio=2.13+dfsg-7",
-                    ]
-                    msg += "\n".join(info)
-                raise ExecError(msg)
-            output = process.stdout
-            logger.info(output)
-            filename = output.splitlines()[0].split()[0]
-            filename = os.path.join(self.dist_dir, filename)
-            if not os.path.exists(filename):
-                msg = "could not build deb"
-                raise ExecError(msg)
-            self.distribution.dist_files.append(("bdist_deb", "any", filename))
+        logger.info(subprocess.list2cmdline(cmd))
+        process = subprocess.run(
+            cmd,
+            text=True,
+            capture_output=True,
+            check=False,
+            cwd=self.dist_dir,
+        )
+        if process.returncode != 0:
+            msg = process.stderr.splitlines()[0]
+            if msg.startswith(f"Unpacking of '{rpm_filename}' failed at"):
+                info = [
+                    "\n\t\x08Please check if you have `cpio 2.13` on "
+                    "Ubuntu 22.04.",
+                    "\t\x08You can try to install a previous version:",
+                    "\t\x08$ sudo apt-get install cpio=2.13+dfsg-7",
+                ]
+                msg += "\n".join(info)
+            raise ExecError(msg)
+        output = process.stdout
+        logger.info(output)
+        filename = output.splitlines()[0].split()[0]
+        filename = os.path.join(self.dist_dir, filename)
+        if not os.path.exists(filename):
+            msg = "could not build deb"
+            raise ExecError(msg)
+        self.distribution.dist_files.append(("bdist_deb", "any", filename))

--- a/cx_Freeze/command/bdist_msi.py
+++ b/cx_Freeze/command/bdist_msi.py
@@ -1342,11 +1342,10 @@ class bdist_msi(Command):
 
         if not self.keep_temp:
             logger.info("removing '%s' (and everything under it)", install_dir)
-            if not self.dry_run:
-                try:
-                    shutil.rmtree(install_dir)
-                except OSError as exc:
-                    logger.warning("error removing %s: %s", install_dir, exc)
+            try:
+                shutil.rmtree(install_dir)
+            except OSError as exc:
+                logger.warning("error removing %s: %s", install_dir, exc)
 
         # Cause the MSI file to be released. Without this, then if bdist_msi
         # is run programmatically from within a larger script, subsequent

--- a/cx_Freeze/command/bdist_rpm.py
+++ b/cx_Freeze/command/bdist_rpm.py
@@ -360,17 +360,14 @@ class bdist_rpm(Command):
 
         self.spawn(rpm_cmd)
 
-        if not self.dry_run:
-            for binary_rpm in binary_rpms:
-                rpm = os.path.join(rpm_dir["RPMS"], binary_rpm)
-                if os.path.exists(rpm):
-                    self.move_file(rpm, self.dist_dir)
-                    filename = os.path.join(
-                        self.dist_dir, os.path.basename(rpm)
-                    )
-                    self.distribution.dist_files.append(
-                        ("bdist_rpm", PYTHON_VERSION, filename)
-                    )
+        for binary_rpm in binary_rpms:
+            rpm = os.path.join(rpm_dir["RPMS"], binary_rpm)
+            if os.path.exists(rpm):
+                self.move_file(rpm, self.dist_dir)
+                filename = os.path.join(self.dist_dir, os.path.basename(rpm))
+                self.distribution.dist_files.append(
+                    ("bdist_rpm", PYTHON_VERSION, filename)
+                )
 
     def _make_spec_file(self) -> list[str]:
         """Generate the text of an RPM spec file and return it as a

--- a/doc/src/installation.rst
+++ b/doc/src/installation.rst
@@ -55,11 +55,11 @@ Python requirements are installed automatically by pip or conda.
 
   .. code-block:: console
 
-   freeze-core >= 0.4.0
-   packaging >= 24
-   setuptools >= 78.1.1,<81
+   freeze-core >= 0.6.0
+   packaging >= 25.0
+   setuptools >= 78.1.1,<=82.0
    tomli >= 2.0.1           #  Python 3.10, Python 3.11+ has tomllib
-   filelock >= 3.15.3       #  Linux
+   filelock >= 3.20.3       #  Linux
    patchelf >= 0.14,<0.18   #  Linux
    dmgbuild >= 1.6.1        #  macOS
    lief >= 0.15.1           #  Windows

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
-    # setuptools 77.0.3+ supports PEP 639
-    # setuptools 78.1.1 fix path traversal vulnerability
-    "setuptools>=78.1.1,<81",
+    "setuptools~=82.0",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -29,11 +27,11 @@ classifiers = [
 ]
 dependencies = [
     "freeze-core>=0.5.0",
-    "packaging>=24",
-    "setuptools>=78.1.1,<81",
+    "packaging>=25.0",
+    "setuptools>=78.1.1,<=82.0",
     "tomli>=2.0.1 ;python_version == '3.10'",
     # Linux
-    "filelock>=3.20.1 ;sys_platform == 'linux'",
+    "filelock>=3.20.3 ;sys_platform == 'linux'",
     "patchelf>=0.16.1,<0.18 ;sys_platform == 'linux' and platform_machine == 'x86_64'",
     "patchelf>=0.16.1,<0.18 ;sys_platform == 'linux' and platform_machine == 'i686'",
     "patchelf>=0.16.1,<0.18 ;sys_platform == 'linux' and platform_machine == 'aarch64'",
@@ -76,8 +74,8 @@ doc = [
     "myst-parser==4.0.1 ;python_version >= '3.11'",
 ]
 tests = [
-    "coverage==7.13.2",
-    "filelock>=3.20.1",
+    "coverage==7.13.4",
+    "filelock>=3.20.3",
     "pytest==9.0.2",
         "pluggy==1.6.0",
     "pytest-mock==3.15.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 freeze-core>=0.5.0
-packaging>=24
-setuptools>=78.1.1,<81
+packaging>=25.0
+setuptools>=78.1.1,<=82.0
 tomli>=2.0.1 ;python_version == '3.10'
-filelock>=3.20.1 ;sys_platform == 'linux'
+filelock>=3.20.3 ;sys_platform == 'linux'
 patchelf>=0.16.1,<0.18 ;sys_platform == 'linux' and platform_machine == 'x86_64'
 patchelf>=0.16.1,<0.18 ;sys_platform == 'linux' and platform_machine == 'i686'
 patchelf>=0.16.1,<0.18 ;sys_platform == 'linux' and platform_machine == 'aarch64'

--- a/samples/pytz/pyproject.toml
+++ b/samples/pytz/pyproject.toml
@@ -1,8 +1,11 @@
 [project]
 name = "test_pytz"
-version = "0.4"
+version = "0.4.1"
 description = "cx_Freeze script to test pytz"
-dependencies = ["pytz"]
+dependencies = [
+    "pytz",
+    "setuptools<82.0",
+]
 
 [tool.cxfreeze]
 executables = ["test_pytz.py"]

--- a/tests/hooks/test_numpy.py
+++ b/tests/hooks/test_numpy.py
@@ -318,15 +318,21 @@ pyproject.toml
     strict=True,
 )
 @pytest.mark.xfail(
-    sys.version_info[:2] >= (3, 13) and ABI_THREAD == "t",
+    sys.version_info[:2] == (3, 13) and ABI_THREAD == "t",
     raises=ModuleNotFoundError,
-    reason="vtkmodules (vtk) does not support Python 3.13t/3.14t",
+    reason="vtkmodules (vtk) does not support Python 3.13t",
     strict=True,
 )
 @pytest.mark.xfail(
-    sys.version_info[:2] >= (3, 14),
+    sys.version_info[:2] >= (3, 14) and ABI_THREAD == "t" and IS_WINDOWS,
     raises=ModuleNotFoundError,
-    reason="vtkmodules (vtk) does not support Python 3.14+",
+    reason="vtkmodules (vtk) does not support Python 3.14t in Windows",
+    strict=True,
+)
+@pytest.mark.xfail(
+    sys.version_info[:2] >= (3, 14) and ABI_THREAD == "t" and IS_MACOS,
+    raises=ModuleNotFoundError,
+    reason="vtkmodules (vtk) does not support Python 3.14t in macOS",
     strict=True,
 )
 @pytest.mark.venv

--- a/tests/hooks/test_pytz.py
+++ b/tests/hooks/test_pytz.py
@@ -9,7 +9,7 @@ zip_packages = pytest.mark.parametrize(
 )
 
 
-@pytest.mark.venv(scope="module")
+@pytest.mark.venv
 @zip_packages
 def test_pytz(tmp_package, zip_packages: bool) -> None:
     """Test if pytz hook is working correctly."""

--- a/tests/hooks/test_zstd.py
+++ b/tests/hooks/test_zstd.py
@@ -7,8 +7,6 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from cx_Freeze._compat import IS_MINGW
-
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -70,12 +68,6 @@ pyproject.toml
 """
 
 
-@pytest.mark.xfail(
-    IS_MINGW,
-    raises=ModuleNotFoundError,
-    reason="backports.zstd not supported in mingw",
-    strict=True,
-)
 @pytest.mark.venv
 @zip_packages
 def test_zstd(tmp_package, zip_packages: bool) -> None:

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,5 @@
-coverage==7.13.2
-filelock>=3.20.1
+coverage==7.13.4
+filelock>=3.20.3
 pytest==9.0.2
 pluggy==1.6.0
 pytest-mock==3.15.1

--- a/tests/test_command_bdist_deb.py
+++ b/tests/test_command_bdist_deb.py
@@ -2,17 +2,12 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import pytest
 from setuptools import Distribution
 
 from cx_Freeze._compat import IS_LINUX
 from cx_Freeze.command.bdist_deb import bdist_deb
 from cx_Freeze.exception import PlatformError
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 DIST_ATTRS = {
     "name": "foo",
@@ -55,22 +50,6 @@ def test_bdist_deb_not_fakeroot(monkeypatch) -> None:
     monkeypatch.setattr("shutil.which", lambda cmd: cmd != "fakeroot")
     with pytest.raises(PlatformError, match="failed to find 'fakeroot'"):
         cmd.finalize_options()
-
-
-@pytest.mark.skipif(not IS_LINUX, reason="Linux test")
-def test_bdist_deb_dry_run(monkeypatch, tmp_path: Path) -> None:
-    """Test the bdist_deb dry_run."""
-    monkeypatch.chdir(tmp_path)
-    attrs = DIST_ATTRS.copy()
-    attrs["dry_run"] = True
-    dist = Distribution(attrs)
-    cmd = bdist_deb(dist)
-    monkeypatch.setattr("os.getuid", lambda: 1000)
-    monkeypatch.setattr(
-        "shutil.which", lambda cmd: cmd != "alien" or cmd != "fakeroot"
-    )
-    cmd.finalize_options()
-    cmd.run()
 
 
 @pytest.mark.skipif(not IS_LINUX, reason="Linux test")


### PR DESCRIPTION
From the [changelog](https://setuptools.pypa.io/en/latest/history.html#v82-0-0):
Setuptools 81: removed support for the –dry-run parameter to setup.py.
Setuptools 82: pkg_resources has been removed from Setuptools.