### PR TITLE
Prevent qthooks.py from placing all libs into PyQt6/libs on linux

### DIFF
--- a/cx_Freeze/hooks/qthooks.py
+++ b/cx_Freeze/hooks/qthooks.py
@@ -197,7 +197,7 @@ class QtHook(ModuleHook):
         if IS_MINGW or IS_WINDOWS:
             patterns = ["*.dll"]
         else:
-            patterns = ["*.so*"]
+            patterns = ["libQt*.so*"]
             if IS_MACOS:
                 patterns.append("*.dylib")
         for pattern in patterns:


### PR DESCRIPTION
Currently on linux with cx freeze `8.6.0` every library is getting placed in the PyQt6/lib folder (at least when using PyQt6 or PySide6 installed from conda).

This is because the pattern here catches every `so` file conda env's lib folder.  

The app works either way but I don't think it is expected to do this.