### PR TITLE
tests: improve test for setuptools hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,7 +62,7 @@ repos:
         exclude: (?x)^(cx_Freeze/hooks/global_names.py)$
 
   - repo: https://github.com/rbubley/mirrors-prettier
-    rev: 515f543f5718ebfd6ce22e16708bb32c68ff96e1 # frozen: v3.8.3
+    rev: 06507ab9500d4a9919b5ebd76d9d5b7074f15c1f # frozen: v3.8.4
     hooks:
       - id: prettier
         types_or: [yaml, markdown, html, css, scss, javascript, json]

--- a/cx_Freeze/hooks/_setuptools_.py
+++ b/cx_Freeze/hooks/_setuptools_.py
@@ -41,7 +41,7 @@ class Hook(ModuleHook):
         except metadata.PackageNotFoundError:
             requires = None
         if requires:
-            core_names = set()
+            core_names: set[str] = set()
             for requirement_string in requires:
                 require = Requirement(requirement_string)
                 if require.marker is None:
@@ -49,14 +49,14 @@ class Hook(ModuleHook):
                 if require.marker.evaluate({"extra": "core"}):
                     core_names.add(require.name)
         else:
-            core_names = (
+            core_names = {
                 "jaraco.functools",
                 "jaraco.text",
                 "more_itertools",
                 "packaging",
                 "platformdirs",
                 "wheel",
-            )
+            }
         failed = [
             name
             for name in core_names

--- a/tests/hooks/test_setuptools.py
+++ b/tests/hooks/test_setuptools.py
@@ -2,11 +2,20 @@
 
 from __future__ import annotations
 
+import sys
 from typing import TYPE_CHECKING
 
 import pytest
+from packaging.requirements import Requirement
+
+if sys.version_info[:2] >= (3, 11):
+    import tomllib
+else:
+    from setuptools.compat.py310 import tomllib
 
 if TYPE_CHECKING:
+    from packaging.specifiers import SpecifierSet
+
     from tests.conftest import TempPackage
 
 zip_packages = pytest.mark.parametrize(
@@ -16,20 +25,27 @@ zip_packages = pytest.mark.parametrize(
 SOURCE_TEST_SETUPTOOLS = """
 test_setuptools.py
     import setuptools
+    import jaraco.collections
+    import jaraco.functools
+    from importlib.metadata import version
 
     print("Hello from cx_Freeze")
-    print("Hello", setuptools.__name__)
+    print(setuptools.__name__, version("setuptools"))
+    print(jaraco.collections.__name__, version("jaraco.collections"))
+    print(jaraco.functools.__name__, version("jaraco.functools"))
 pyproject.toml
     [project]
     name = "test_setuptools"
     version = "0.1.2.3"
     dependencies = [
-        "setuptools==78.1.1;python_version == '3.10'",
-        "setuptools==80.9.0;python_version == '3.11'",
-        "setuptools==80.10.2;python_version == '3.12'",
-        "setuptools>=81.0;python_version > '3.12'",
+        "setuptools==78.1.1;python_version <= '3.12'",
+        "setuptools==80.9.0;python_version == '3.13'",
+        "setuptools==80.10.2;python_version == '3.14'",
+        "setuptools>=81.0;python_version > '3.14'",
+        # using versions greater than vendored by latest setuptools
+        "jaraco.collections>5.1.0",
+        "jaraco.functools>4.4.0",
     ]
-
 
     [tool.cxfreeze]
     executables = ["test_setuptools.py"]
@@ -46,14 +62,41 @@ pyproject.toml
 def test_setuptools(tmp_package: TempPackage, zip_packages: bool) -> None:
     """Test if setuptools hook is working correctly."""
     tmp_package.create(SOURCE_TEST_SETUPTOOLS)
+    pyproject = tmp_package.path / "pyproject.toml"
     if zip_packages:
-        pyproject = tmp_package.path / "pyproject.toml"
         buf = pyproject.read_bytes().decode().splitlines()
         buf += ['zip_include_packages = "*"', 'zip_exclude_packages = ""']
         pyproject.write_bytes("\n".join(buf).encode("utf_8"))
-    tmp_package.install_dependencies()
     tmp_package.freeze()
     executable = tmp_package.executable("test_setuptools")
     assert executable.is_file()
     result = tmp_package.run(executable)
-    result.stdout.fnmatch_lines(["Hello from cx_Freeze", "Hello setuptools*"])
+    output = result.stdout
+    output.fnmatch_lines(
+        [
+            "Hello from cx_Freeze",
+            "setuptools *",
+            "jaraco.collections *",
+            "jaraco.functools *",
+        ],
+        consecutive=True,
+    )
+
+    # Check if installed versions are not from setuptools
+    with pyproject.open("rb") as file:
+        config = tomllib.load(file)
+    dependencies = config["project"]["dependencies"]
+    tools: list[tuple[str, str]] = [
+        tuple(line.split(" ")) for line in output.lines[1:]
+    ]
+    installed: list[tuple[str, str, SpecifierSet]] = []
+    for name, version in tools:
+        for dep in dependencies:
+            req = Requirement(dep)
+            if req.name == name and (
+                req.marker is None or req.marker.evaluate()
+            ):
+                installed.append((name, version, req.specifier))
+    assert len(tools) == len(installed)
+    for _name, version, specifier in installed:
+        assert version in specifier


### PR DESCRIPTION
The improvement in the setuptools hook test is to prove that the version installed by the user prevails, not the version vendored in setuptools, which may be included in the freeze if no other version exists.

Closes #3296 