### PR TITLE
finder: optimize/reduce the modules in the resulting frozen executable

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,7 +62,7 @@ repos:
         exclude: (?x)^(cx_Freeze/hooks/global_names.py)$
 
   - repo: https://github.com/rbubley/mirrors-prettier
-    rev: 39e2973981e6d2f9b6c543b0086a2d2393abdc89 # frozen: v3.9.4
+    rev: 9337a74165b178ae2c766f60bee7252a0f06f3e8 # frozen: v3.9.5
     hooks:
       - id: prettier
         types_or: [yaml, markdown, html, css, scss, javascript, json]

--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,9 @@ uninstall:
 	@prek uninstall -q
 	@rm -f .git/hooks/pre-commit
 
-.PHONY: upgrade
-upgrade: install
-	prek auto-update --freeze
+.PHONY: update
+update: install
+	prek update --freeze
 	$(MAKE) prek
 
 .PHONY: html

--- a/cx_Freeze/finder.py
+++ b/cx_Freeze/finder.py
@@ -158,8 +158,9 @@ class ModuleFinder:
         builtin_modules: dict[str, str] = {}
         for name in sys.builtin_module_names:
             builtin_modules[name] = "built-in"
-        for name in _imp._frozen_module_names():  # ty: ignore # noqa: SLF001
-            builtin_modules[name] = "frozen"
+        if sys.version_info[:2] >= (3, 11):
+            for name in _imp._frozen_module_names():  # noqa: SLF001
+                builtin_modules[name] = "frozen"
         core_lib = resource_path("lib")
         if core_lib and core_lib.is_dir():
             # discard modules that exist in freeze-core 'lib'
@@ -877,14 +878,21 @@ class ModuleFinder:
     @cached_property
     def modules(self) -> list[Module]:
         """Sorted list of modules expected in the frozen executable."""
-        valid_modules = [
+        valid_modules = {
             module
             for name, module in self._modules.items()
             if module is not None
             and module not in self.namespaces
             and name not in self._builtin_modules
-        ]
-        return sorted(set(valid_modules), key=lambda module: module.name)
+        }
+        if sys.version_info[:2] < (3, 11):
+            frozen = [
+                module
+                for module in valid_modules
+                if module.file and module.file.name == "frozen"
+            ]
+            valid_modules.difference_update(frozen)
+        return sorted(valid_modules, key=lambda module: module.name)
 
     @property
     def optimize(self) -> int:

--- a/cx_Freeze/finder.py
+++ b/cx_Freeze/finder.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import _imp
 import inspect
 import linecache
 import logging
@@ -15,7 +16,9 @@ from importlib.machinery import (
     BYTECODE_SUFFIXES,
     EXTENSION_SUFFIXES,
     SOURCE_SUFFIXES,
+    BuiltinImporter,
     ExtensionFileLoader,
+    FrozenImporter,
     ModuleSpec,
     PathFinder,
     SourceFileLoader,
@@ -109,17 +112,6 @@ class ModuleFinder:
     def cleanup(self) -> None:
         self._tmp_dir.cleanup()
 
-    @cached_property
-    def modules(self) -> list[Module]:
-        return sorted(
-            [
-                m
-                for m in set(self._modules.values())
-                if m is not None and m not in self.namespaces
-            ],
-            key=lambda m: m.name,
-        )
-
     def _add_module(
         self,
         name: str,
@@ -161,16 +153,20 @@ class ModuleFinder:
         return module
 
     @cached_property
-    def _builtin_modules(self) -> frozenset[str]:
-        """The built-in modules are determined based on the cx_Freeze build."""
-        builtin_modules: set[str] = set(sys.builtin_module_names)
+    def _builtin_modules(self) -> Mapping[str, str]:
+        """The built-in modules are based on the `freeze-core` build."""
+        builtin_modules: dict[str, str] = {}
+        for name in sys.builtin_module_names:
+            builtin_modules[name] = "built-in"
+        for name in _imp._frozen_module_names():  # ty: ignore # noqa: SLF001
+            builtin_modules[name] = "frozen"
         core_lib = resource_path("lib")
         if core_lib and core_lib.is_dir():
             # discard modules that exist in freeze-core 'lib'
             ext_suffix = get_config_var("EXT_SUFFIX")
             for file in core_lib.glob(f"*{ext_suffix}"):
-                builtin_modules.discard(file.name.removesuffix(ext_suffix))
-        return frozenset(builtin_modules)
+                builtin_modules.pop(file.name.removesuffix(ext_suffix), None)
+        return builtin_modules
 
     def _determine_parent(self, caller: Module | None) -> Module | None:
         """Determine the parent to use when searching packages."""
@@ -352,14 +348,6 @@ class ModuleFinder:
             # Check in module cache before trying to import it again.
             return self._modules[name]
 
-        if name in self._builtin_modules:
-            module = self._add_module(name)
-            logger.debug("Adding module [%s] [C_BUILTIN]", name)
-            if module.hook:
-                module.hook(self)
-            module.in_import = False
-            return module
-
         pos = name.rfind(".")
         if pos < 0:  # Top-level module
             path = self.path
@@ -382,11 +370,8 @@ class ModuleFinder:
             self._modules[name] = module
             return module
 
-        try:
-            module = self._load_module(
-                name, path, deferred_imports, parent_module
-            )
-        except ImportError:
+        module = self._load_module(name, path, deferred_imports, parent_module)
+        if module is None:
             logger.debug("Module [%s] cannot be imported", name)
             self._modules[name] = None
             return None
@@ -447,6 +432,12 @@ class ModuleFinder:
                 return module
 
         if not spec:
+            spec = BuiltinImporter.find_spec(name)
+
+        if not spec:
+            spec = FrozenImporter.find_spec(name)
+
+        if not spec:
             spec = self._find_editable_spec(name, path)
 
         if spec:
@@ -462,37 +453,31 @@ class ModuleFinder:
                 self.namespaces.append(module)
                 module.in_import = False
                 return module
-            if spec.submodule_search_locations:
-                logger.debug("Adding module [%s] [PACKAGE]", name)
-            else:
-                logger.debug("Adding module [%s] [MODULE]", name)
-            module.loader = spec.loader
 
-        if module is not None:
-            self._load_module_code(module, deferred_imports)
+            module.loader = spec.loader
+            if spec.origin in ("built-in", "frozen"):
+                logger.debug(
+                    "Adding module [%s] [%s]", name, spec.origin.upper()
+                )
+                self._load_module_code_builtins(module, deferred_imports)
+            else:
+                if spec.submodule_search_locations:
+                    logger.debug("Adding module [%s] [PACKAGE]", name)
+                else:
+                    logger.debug("Adding module [%s] [MODULE]", name)
+                if self._load_module_code(module, deferred_imports):
+                    self._load_module_code_libraries(module)
         return module
 
     def _load_module_code(
         self, module: Module, deferred_imports: DeferredList
-    ) -> Module | None:
+    ) -> bool:
         loader: Loader | None = module.loader
         name: str = module.name
-        if not isinstance(
-            loader,
-            (ExtensionFileLoader, SourceFileLoader, SourcelessFileLoader),
-        ):
-            if module.file:
-                filename = module.file.as_posix()
-                msg = f"Unknown module loader in {filename!r}"
-            else:
-                msg = f"Unknown module loader for {name!r}"
-            module.error_msg = msg
-            logger.debug("%s [%s]", msg, name)
-            return None
 
         if isinstance(loader, ExtensionFileLoader):
             logger.debug("Adding module [%s] [EXTENSION]", name)
-        else:
+        elif isinstance(loader, (SourceFileLoader, SourcelessFileLoader)):
             filename = loader.get_filename(name)
             try:
                 if (
@@ -515,19 +500,59 @@ class ModuleFinder:
                 msg = f"{exc.__class__.__name__}: {exc.msg}"
                 module.error_msg = msg
                 logger.debug("%s in '%s' [%s]", msg, filename, name)
-                return None
+                module.in_import = False
+                return False
             except SyntaxError as exc:
                 module.error_exc = exc
                 msg = f"{exc.__class__.__name__}: {exc.msg}"
                 module.error_msg = msg
                 logger.debug("%s in '%s' [%s]", msg, filename, name)
-                return None
+                module.in_import = False
+                return False
+        else:
+            if module.file:
+                filename = module.file.as_posix()
+                msg = f"Unknown module loader in {filename!r}"
+            else:
+                msg = f"Unknown module loader for {module.name!r}"
+            module.error_msg = msg
+            logger.debug("%s [%s]", msg, module.name)
+            module.in_import = False
+            return False
 
         # Run custom hook for the module
         if module.hook:
             module.hook(self)
 
-        # Add dynamic libraries (dependencies) of the package
+        # Make changes in code object
+        module.code = code_object_replace_package(module)
+        if self.replace_paths:
+            module.code = self._replace_paths_in_code(module)
+
+        # Scan the module code for import statements
+        self._scan_code(module, deferred_imports)
+        if module.code is None and module.stub_code is not None:
+            self._scan_code(module, deferred_imports, code=module.stub_code)
+        # using lazy loader
+        if module.root.lazy and module.stub_code:
+            self._scan_code(module, deferred_imports, code=module.stub_code)
+
+        module.in_import = False
+        return True
+
+    def _load_module_code_builtins(
+        self, module: Module, deferred_imports: DeferredList
+    ) -> Module | None:
+        # Run custom hook for the module
+        if module.hook:
+            module.hook(self)
+        # Scan the module code for import statements
+        self._scan_code(module, deferred_imports)
+        module.in_import = False
+        return module
+
+    def _load_module_code_libraries(self, module: Module) -> None:
+        """Add dynamic libraries (dependencies) of the package."""
         if module is module.root:
             for source, target in module.libs():
                 self.lib_files.setdefault(source, target)
@@ -543,25 +568,6 @@ class ModuleFinder:
                     libs = self.constants_module.values.get("__LIBS__")
                     libs_dirs = (libs.split(os.pathsep) if libs else []) + dirs
                     self.add_constant("__LIBS__", os.pathsep.join(libs_dirs))
-
-        if module.code is not None:
-            if self.replace_paths:
-                module.code = self._replace_paths_in_code(module)
-
-            # Scan the module code for import statements
-            self._scan_code(module, deferred_imports)
-
-            # Verify __package__ in use
-            module.code = code_object_replace_package(module)
-        elif module.stub_code is not None:
-            self._scan_code(module, deferred_imports, module.stub_code)
-
-        # using lazy loader
-        if module.root.lazy and module.stub_code:
-            self._scan_code(module, deferred_imports, module.stub_code)
-
-        module.in_import = False
-        return module
 
     def _load_module_from_file(
         self, name: str, filename: Path, deferred_imports: DeferredList
@@ -580,7 +586,7 @@ class ModuleFinder:
 
         module = self._add_module(name, filename=filename)
         module.loader = loader
-        if self._load_module_code(module, deferred_imports) is None:
+        if not self._load_module_code(module, deferred_imports):
             exc: BaseException | None = module.error_exc
             msg = f"ImportError: Cannot import {path!r}"
             msg += " due to the previous error."
@@ -622,13 +628,14 @@ class ModuleFinder:
 
         Returns a new code object with the modified paths in place.
         """
-        top_level_module: Module = module.root
         if code is None:
             code = module.code
         if code is None:
             return None
+
         # Prepare the new filename.
         original_filename = Path(code.co_filename)
+        top_level_module: Module = module.root
         for search_value, replace_value in self.replace_paths:
             if search_value == "*":
                 if top_level_module.file is None:
@@ -867,15 +874,17 @@ class ModuleFinder:
         self._import_deferred_imports(deferred_imports, skip_in_import=True)
         return module
 
-    def report_missing_modules(self) -> None:
-        """Display a list of modules that weren't found."""
-        if self._bad_modules:
-            print("Missing modules:")
-            for name in sorted(self._bad_modules.keys()):
-                callers = sorted(self._bad_modules[name].keys())
-                print(f"? {name} imported from", ", ".join(callers))
-            print("This is not necessarily a problem - the modules ", end="")
-            print("may not be needed on this platform.\n")
+    @cached_property
+    def modules(self) -> list[Module]:
+        """Sorted list of modules expected in the frozen executable."""
+        valid_modules = [
+            module
+            for name, module in self._modules.items()
+            if module is not None
+            and module not in self.namespaces
+            and name not in self._builtin_modules
+        ]
+        return sorted(set(valid_modules), key=lambda module: module.name)
 
     @property
     def optimize(self) -> int:
@@ -886,6 +895,16 @@ class ModuleFinder:
     def optimize(self, value: int) -> None:
         # The value of optimize is checked in '.command.build_exe' or '.cli'.
         self._optimize_flag = value if 0 <= value <= 2 else sys.flags.optimize
+
+    def report_missing_modules(self) -> None:
+        """Display a list of modules that weren't found."""
+        if self._bad_modules:
+            print("Missing modules:")
+            for name in sorted(self._bad_modules.keys()):
+                callers = sorted(self._bad_modules[name].keys())
+                print(f"? {name} imported from", ", ".join(callers))
+            print("This is not necessarily a problem - the modules ", end="")
+            print("may not be needed on this platform.\n")
 
     def zip_include_files(
         self,

--- a/cx_Freeze/freezer.py
+++ b/cx_Freeze/freezer.py
@@ -639,8 +639,8 @@ class Freezer:
         cache_path = finder.cache_path
 
         for module in reversed(finder.namespaces):
-            # if namespace package should be written to zip file, convert it
-            # to regular package, since then zipimport doesn't support PEP420
+            # A namespace package must be converted into regular package
+            # when written to zip file because zipimport doesn't support PEP420
             if module.in_file_system == 0:
                 module.code = compile(
                     "", "__init__.py", "exec", dont_inherit=True

--- a/tests/datatest.py
+++ b/tests/datatest.py
@@ -34,17 +34,17 @@ a.py
 
 ABSOLUTE_IMPORT_TEST: SourceList = (
     "a.module",
-    ["a", "a.module", "b", "b.x", "b.y", "b.z", "__future__", "sys", "gc"],
+    ["a", "a.module", "b", "b.x", "b.y", "b.z", "__future__"],
     ["blahblah", "z"],
-    [],
+    ["sys", "gc"],  # builtins
     """\
 mymodule.py
 a/__init__.py
 a/module.py
     from __future__ import absolute_import
-    import sys # sys
+    import sys
     import blahblah # fails
-    import gc # gc
+    import gc
     import b.x # b.x
     from b import y # b.y
     from b.z import * # b.z.*
@@ -225,9 +225,9 @@ testpkg1/submod.py
 
 MAYBE_TEST: SourceList = (
     "a.module",
-    ["a", "a.module", "sys", "b"],
+    ["a", "a.module", "b"],
     ["c"],
-    ["b.something"],
+    ["sys"],
     """\
 a/__init__.py
 a/module.py
@@ -241,9 +241,9 @@ b/__init__.py
 
 MAYBE_TEST_NEW: SourceList = (
     "a.module",
-    ["a", "a.module", "sys", "b", "__future__"],
+    ["a", "a.module", "b", "__future__"],
     ["c"],
-    ["b.something"],
+    ["sys"],
     """\
 a/__init__.py
 a/module.py
@@ -321,9 +321,9 @@ OPTIMIZE_2_TEST: SourceList = (
 
 PACKAGE_TEST: SourceList = (
     "a.module",
-    ["a", "a.b", "a.c", "a.module", "mymodule", "sys"],
+    ["a", "a.b", "a.c", "a.module", "mymodule"],
     ["blahblah", "c"],
-    [],
+    ["sys"],  # builtin
     """\
 mymodule.py
 a/__init__.py
@@ -357,10 +357,9 @@ RELATIVE_IMPORT_TEST: SourceList = (
         "a.b.c.d",
         "a.b.c.e",
         "a.b.x",
-        "gc",
     ],
     [],
-    [],
+    ["gc"],
     """\
 mymodule.py
 a/__init__.py

--- a/tests/test_modulefinder.py
+++ b/tests/test_modulefinder.py
@@ -77,7 +77,7 @@ def _do_test(
     import_this: str,
     modules: list[str],
     missing: list[str],
-    maybe_missing: list[str],  # noqa: ARG001
+    maybe_missing: list[str],
     source: str,
     report: bool = False,
     debug: bool = False,  # noqa: ARG001
@@ -105,9 +105,10 @@ def _do_test(
     if report:
         finder.report_missing_modules()
     modules = sorted(set(modules))
+    modules_plus_maybe_missing = sorted(set(modules) | set(maybe_missing))
     found = sorted([m.name for m in finder.modules])
     # check if we found what we expected, not more, not less
-    assert found == modules
+    assert found in (modules, modules_plus_maybe_missing)
     assert module is not None
     if module.error_msg:
         assert module.name in missing


### PR DESCRIPTION
Built-in modules as defined in `sys.builtin_module_names` and frozen modules (like '_frozen_importlib', '_frozen_importlib_external', 'zipimport', among others depending on the Python version), do not need to be copied.