### PR TITLE
fix: prevents additional modules from being copied (related to #3375)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,7 +53,7 @@ repos:
         args: ["-l", "79"]
 
   - repo: https://github.com/codespell-project/codespell
-    rev: 2ccb47ff45ad361a21071a7eedda4c37e6ae8c5a # frozen: v2.4.2
+    rev: 57b21406f092110c18776e39b0bda50d37c945c8 # frozen: v2.4.3
     hooks:
       - id: codespell
         additional_dependencies:

--- a/cx_Freeze/finder.py
+++ b/cx_Freeze/finder.py
@@ -729,10 +729,15 @@ class ModuleFinder:
     def add_alias(self, name: str, alias_for: str) -> None:
         """Add an alias for a particular module.
 
-        When an attempt is made to import a module using the alias name,
-        import the actual name instead.
+        When an attempt is made to import that module, the alias is used to
+        import the actual name.
         """
         self.aliases[name] = alias_for
+        # Import the module — if it was previously imported under its original
+        # name — using the alias defined at this point.
+        if name in self._modules:
+            self._modules.pop(name)
+            self.include_module(name)
 
     def add_base_modules(self) -> None:
         """Add the base modules to the finder.

--- a/cx_Freeze/hooks/__init__.py
+++ b/cx_Freeze/hooks/__init__.py
@@ -114,7 +114,6 @@ def load_collections(finder: ModuleFinder, module: Module) -> None:
         # collections.abc module does not exist in Python 3.13+
         # >>> _sys.modules['collections.abc'] = _collections_abc
         finder.add_alias("collections.abc", "_collections_abc")
-        finder.include_module("collections.abc")
 
 
 def load_concurrent_futures(finder: ModuleFinder, module: Module) -> None:

--- a/cx_Freeze/hooks/_importlib_.py
+++ b/cx_Freeze/hooks/_importlib_.py
@@ -14,17 +14,10 @@ __all__ = ["Hook"]
 
 
 class Hook(ModuleHook):
-    """The Hook class for importlib."""
+    """The Hook class for importlib package."""
 
     def importlib(self, finder: ModuleFinder, module: Module) -> None:
         """Hooks for importlib package."""
-        if module.in_file_system == 1:
-            # Use optimized mode
-            module.in_file_system = 2
-        # include module used by importlib._bootstrap_external
-        # (internally mapped to _frozen_importlib_external)
-        finder.include_module("importlib.metadata")
-        finder.include_module("importlib.readers")
 
     def importlib__bootstrap(
         self, finder: ModuleFinder, module: Module
@@ -38,8 +31,11 @@ class Hook(ModuleHook):
         """Set importlib._bootstrap_external as an alias."""
         finder.add_alias(module.name, "_frozen_importlib_external")
 
-    def importlib_metadata(self, finder: ModuleFinder, module: Module) -> None:
+    def importlib_metadata(
+        self,
+        finder: ModuleFinder,  # noqa: ARG002
+        module: Module,
+    ) -> None:
         """Ignore optional modules."""
         if module.name == "importlib.metadata":
-            module.ignore_names.add("pep517")
-            finder.include_module("email")
+            module.ignore_names.add("pep517")  # Python 3.10

--- a/tests/test_freezer.py
+++ b/tests/test_freezer.py
@@ -277,42 +277,42 @@ def test_freezer_options(
         pytest.param(
             {"zip_filename": None},
             {"zip_filename": "library.zip"},  # default compress is True
-            id="zip_filename=none",
+            id="zip_filename_none",
         ),
         pytest.param(
             {"zip_filename": "test"},
             {"zip_filename": "test.zip"},
-            id="zip_filename=test",
+            id="zip_filename_test",
         ),
         pytest.param(
             {"zip_filename": "test.zip"},
             {"zip_filename": "test.zip"},
-            id="zip_filename=test.zip",
+            id="zip_filename_test_zip",
         ),
         pytest.param(
             {"zip_filename": "test.zip", "target_dir": "ação"},
             {"zip_filename": "test.zip"},
-            id="zip_filename=test.zip/target_dir=utf_8/portuguese",
+            id="zip_filename_test_zip_target_dir_utf_8_portuguese",
         ),
         pytest.param(
             {"zip_filename": "test.zip", "target_dir": "行動"},
             {"zip_filename": "test.zip"},
-            id="zip_filename=test.zip/target_dir=utf_8/chinese",
+            id="zip_filename_test_zip_target_dir_utf_8_chinese",
         ),
         pytest.param(
             {"compress": True},
             {"compress": True, "zip_filename": "library.zip"},
-            id="zip_filename=none/compress=true",
+            id="zip_filename_none_compress_true",
         ),
         pytest.param(
             {"compress": False},
             {"compress": False, "zip_filename": None},
-            id="zip_filename=none/compress=false",
+            id="zip_filename_none_compress_false",
         ),
         pytest.param(
             {"compress": False, "zip_filename": "library.zip"},
             {"compress": False, "zip_filename": "library.zip"},
-            id="zip_filename=name/compress=false",
+            id="zip_filename_name_compress_false",
         ),
     ],
 )


### PR DESCRIPTION
During the optimization performed in #3372 and subsequently in #3375, a bug in `add_alias` was revealed: when an alias is added (for example, in a hook) but the module has already been imported, the alias has no effect. This allowed for the copying of `importlib._bootstrap` and `importlib._bootstrap_external` (which are aliases for `_frozen_importlib` and `_frozen_importlib_external`, respectively). A similar issue also occurred with `collections.abc` (which exists only up to Python 3.12).