### PR TITLE
chore: add support for frozen modules included w/ freeze-core 0.7+

### DIFF
--- a/cx_Freeze/executable.py
+++ b/cx_Freeze/executable.py
@@ -24,11 +24,6 @@ if TYPE_CHECKING:
 
     from cx_Freeze._typing import StrPath
 
-
-STRINGREPLACE = list(
-    string.whitespace + string.punctuation.replace(".", "").replace("_", "")
-)
-
 __all__ = ["Executable", "validate_executables"]
 
 
@@ -261,8 +256,9 @@ class Executable:
         self._name = name
         name = name.partition(".")[0]
         if not name.isidentifier():
-            for invalid in STRINGREPLACE:
-                name = name.replace(invalid, "_")
+            invalid = string.whitespace + string.punctuation
+            idtable = str.maketrans(invalid, "_" * len(invalid))
+            name = name.translate(idtable)
         name = os.path.normcase(name)
         self._internal_name = name
 

--- a/cx_Freeze/finder.py
+++ b/cx_Freeze/finder.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import _imp
 import inspect
+import json
 import linecache
 import logging
 import os
@@ -41,7 +42,7 @@ from cx_Freeze._bytecode import (
     code_object_replace_package,
     scan_code,
 )
-from cx_Freeze._compat import IS_WINDOWS
+from cx_Freeze._compat import IS_WINDOWS, SOABI
 from cx_Freeze.common import process_path_specs, resource_path
 from cx_Freeze.hooks.unused_modules import (
     DEFAULT_EXCLUDES,
@@ -146,28 +147,11 @@ class ModuleFinder:
             module.finder = self
             root_name = name.split(".", maxsplit=1)[0]
             if (
-                name not in self._builtin_modules
+                name not in self.builtin_modules
                 and root_name not in sys.stdlib_module_names
             ):
                 module.update_distribution()
         return module
-
-    @cached_property
-    def _builtin_modules(self) -> Mapping[str, str]:
-        """The built-in modules are based on the `freeze-core` build."""
-        builtin_modules: dict[str, str] = {}
-        for name in sys.builtin_module_names:
-            builtin_modules[name] = "built-in"
-        if sys.version_info[:2] >= (3, 11):
-            for name in _imp._frozen_module_names():  # noqa: SLF001
-                builtin_modules[name] = "frozen"
-        core_lib = resource_path("lib")
-        if core_lib and core_lib.is_dir():
-            # discard modules that exist in freeze-core 'lib'
-            ext_suffix = get_config_var("EXT_SUFFIX")
-            for file in core_lib.glob(f"*{ext_suffix}"):
-                builtin_modules.pop(file.name.removesuffix(ext_suffix), None)
-        return builtin_modules
 
     def _determine_parent(self, caller: Module | None) -> Module | None:
         """Determine the parent to use when searching packages."""
@@ -739,24 +723,35 @@ class ModuleFinder:
             self._modules.pop(name)
             self.include_module(name)
 
-    def add_base_modules(self) -> None:
-        """Add the base modules to the finder.
-
-        These are the modules that Python imports itself during initialization
-        and, if not found, can result in behavior that differs from running
-        from source; also include modules used within the bootstrap code.
-
-        When cx_Freeze is built, these modules (and modules they load) are
-        included in the startup zip file.
-        """
-        self.include_package("encodings")
-
     def add_constant(self, name: str, value: str) -> None:
         """Make available a constant in the module BUILD_CONSTANTS.
 
         BUILD_CONSTANTS is used in the initscripts.
         """
         self.constants_module.values[name] = value
+
+    @cached_property
+    def builtin_modules(self) -> Mapping[str, str]:
+        """The built-in modules are based on the `freeze-core` build."""
+        builtin_modules: dict[str, str] = {}
+        frozen_file = resource_path(f"frozen/frozen-{SOABI}.json")
+        if frozen_file:
+            # using freeze-core 0.7.0+
+            builtin_modules.update(json.loads(frozen_file.read_bytes()))
+            builtin_modules.pop("__version__", None)
+            return builtin_modules
+        for name in sys.builtin_module_names:
+            builtin_modules[name] = "built-in"
+        if sys.version_info[:2] >= (3, 11):
+            for name in _imp._frozen_module_names():  # noqa: SLF001
+                builtin_modules[name] = "frozen"
+        core_lib = resource_path("lib")
+        if core_lib and core_lib.is_dir():
+            # discard modules that exist in freeze-core 'lib'
+            ext_suffix = get_config_var("EXT_SUFFIX")
+            for file in core_lib.glob(f"*{ext_suffix}"):
+                builtin_modules.pop(file.name.removesuffix(ext_suffix), None)
+        return builtin_modules
 
     def exclude_dependent_files(self, filename: StrPath) -> None:
         """Exclude the dependent files of the named file.
@@ -881,7 +876,7 @@ class ModuleFinder:
         builtin = {
             module
             for module in valid_modules
-            if module.name in self._builtin_modules
+            if module.name in self.builtin_modules
         }
         if sys.version_info[:2] < (3, 11):
             builtin |= {

--- a/cx_Freeze/freezer.py
+++ b/cx_Freeze/freezer.py
@@ -363,9 +363,6 @@ class Freezer:
         finder: ModuleFinder = self.finder
         finder.include_file_as_module(exe.main_script, exe.main_module_name)
         finder.include_file_as_module(exe.init_script, exe.init_module_name)
-        startup = resource_path("initscripts/__startup__.py")
-        if startup:
-            finder.include_file_as_module(startup)
 
         # copy the executable and its dependencies
         target_path = self.target_dir / exe.target_name
@@ -450,7 +447,14 @@ class Freezer:
             finder.include_module(name)
         for name in self.packages:
             finder.include_package(name)
-        finder.add_base_modules()
+        # Include modules required during initialization;
+        # (using freeze-core 0.7.0+ it is frozen in the executable).
+        if "encodings" not in finder.builtin_modules:
+            finder.include_package("encodings")
+        if "__startup__" not in finder.builtin_modules:
+            startup = resource_path("initscripts/__startup__.py")
+            if startup:
+                finder.include_file_as_module(startup)
         return finder
 
     def _post_freeze_hook(self) -> None:

--- a/tests/datatest.py
+++ b/tests/datatest.py
@@ -34,14 +34,13 @@ a.py
 
 ABSOLUTE_IMPORT_TEST: SourceList = (
     "a.module",
-    ["a", "a.module", "b", "b.x", "b.y", "b.z", "__future__"],
+    ["a", "a.module", "b", "b.x", "b.y", "b.z"],
     ["blahblah", "z"],
     ["sys", "gc"],  # builtins
     """\
 mymodule.py
 a/__init__.py
 a/module.py
-    from __future__ import absolute_import
     import sys
     import blahblah # fails
     import gc
@@ -241,7 +240,7 @@ b/__init__.py
 
 MAYBE_TEST_NEW: SourceList = (
     "a.module",
-    ["a", "a.module", "b", "__future__"],
+    ["a", "a.module", "b"],
     ["c"],
     ["sys"],
     """\
@@ -250,7 +249,6 @@ a/module.py
     from b import something
     from c import something
 b/__init__.py
-    from __future__ import absolute_import
     from sys import *
 """,
     {},
@@ -346,7 +344,6 @@ a/c.py
 RELATIVE_IMPORT_TEST: SourceList = (
     "a.module",
     [
-        "__future__",
         "a",
         "a.module",
         "a.b",
@@ -365,7 +362,6 @@ mymodule.py
 a/__init__.py
     from .b import y, z # a.b.y, a.b.z
 a/module.py
-    from __future__ import absolute_import # __future__
     import gc # gc
 a/gc.py
 a/sys.py


### PR DESCRIPTION
Python includes some frozen modules (`_frozen_importlib`, `_frozen_importlib_external`, `zipimport`, among others, depending on the Python version).
freeze-core 0.7+ introduces—based on the approach used in Python—additional modules and packages to the PyImport_FrozenModules table.
Modules required for startup, such as `__startup__` and `encoding`, are now frozen and, of course, provide faster startup times. Also, with these modules frozen into the executable, they will not be copied.
https://github.com/marcelotduarte/freeze-core/pull/171
https://github.com/marcelotduarte/freeze-core/pull/173
https://github.com/marcelotduarte/freeze-core/pull/179