### PR TITLE
finder: search for alias of package (previously limited to modules)

### DIFF
--- a/cx_Freeze/finder.py
+++ b/cx_Freeze/finder.py
@@ -355,8 +355,15 @@ class ModuleFinder:
                         if os.path.isdir(pathtoadd) and pathtoadd not in path:
                             path.append(pathtoadd)
 
-        if name in self.aliases:
-            actual_name = self.aliases[name]
+        # Search for an alias of a module or package.
+        pos = len(name)
+        while pos >= 0:
+            actual_name = self.aliases.get(name[:pos])
+            if actual_name is not None:
+                break
+            pos = name.rfind(".", 0, pos)
+        if actual_name:
+            actual_name += name[pos:]
             module = self._internal_import_module(
                 actual_name, deferred_imports
             )

--- a/cx_Freeze/hooks/_pkg_resources_.py
+++ b/cx_Freeze/hooks/_pkg_resources_.py
@@ -21,7 +21,7 @@ class Hook(ModuleHook):
     """
 
     def pkg_resources(self, finder: ModuleFinder, module: Module) -> None:
-        """Import modules from setuptools."""
+        """Import modules from setuptools._vendor."""
         finder.exclude_module("pkg_resources.tests")
         failed = [
             name
@@ -36,5 +36,9 @@ class Hook(ModuleHook):
         if vendor_dir.is_dir():
             finder.path.append(os.path.normpath(vendor_dir))
             for name in failed:
+                pos = name.rfind(".")
+                if pos > 0:
+                    parent_name = name[:pos]
+                    finder.include_module(parent_name)
                 finder.include_module(name, module)
             finder.path.pop()

--- a/cx_Freeze/hooks/_setuptools_.py
+++ b/cx_Freeze/hooks/_setuptools_.py
@@ -31,8 +31,11 @@ class Hook(ModuleHook):
         """Include _distutils and _vendor subpackage of setuptools."""
         finder.exclude_module("setuptools.tests")
         finder.exclude_module("setuptools._distutils.tests")
+        finder.exclude_module("setuptools._distutils.compilers.C.tests")
         finder.exclude_module("setuptools._vendor")
-        finder.include_package("setuptools._distutils")
+        finder.add_alias("distutils", "setuptools._distutils")
+        if module.in_file_system == 1:
+            module.in_file_system = 2
 
         try:
             requires = metadata.requires(module.name)


### PR DESCRIPTION
This change allows creating an alias for `distutils`, which is internal to `setuptools` (since its removal in Python 3.12).
As a result, the list of missing modules is reduced when depending on `setuptools`.