### PR TITLE
build(deps): bump setuptools and patchelf dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
     hooks:
       - id: validate-pyproject
         additional_dependencies:
-          - validate-pyproject-schema-store[all]==2026.07.28
+          - validate-pyproject-schema-store[all]==2026.08.08
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: 7c55798a78262d14b2074abf623d8a992ebb70d4 # frozen: v0.16.2

--- a/cx_Freeze/dep_parser.py
+++ b/cx_Freeze/dep_parser.py
@@ -463,8 +463,11 @@ class ELFParser(Parser):
 
         mobj = re.match(r"patchelf\s+(\d+(.\d+)?)", version)
         if mobj:
-            version = mobj.group(1)
-            if tuple(map(int, version.split("."))) >= (0, 14):
+            version = tuple(map(int, mobj.group(1).split(".")))
+            if version >= (0, 14) and version[:2] != (0, 18):
                 return
-        msg = f"patchelf {version} found. cx_Freeze requires patchelf >= 0.14."
+        msg = (
+            f"patchelf {version} found. "
+            "cx_Freeze requires 'patchelf>=0.14,!=0.18'."
+        )
         raise ValueError(msg)

--- a/cx_Freeze/dep_parser.py
+++ b/cx_Freeze/dep_parser.py
@@ -463,8 +463,9 @@ class ELFParser(Parser):
 
         mobj = re.match(r"patchelf\s+(\d+(.\d+)?)", version)
         if mobj:
-            version = tuple(map(int, mobj.group(1).split(".")))
-            if version >= (0, 14) and version[:2] != (0, 18):
+            version = mobj.group(1)
+            version_tuple = tuple(map(int, version.split(".")))
+            if version_tuple[:2] >= (0, 14) and version_tuple[:2] != (0, 18):
                 return
         msg = (
             f"patchelf {version} found. "

--- a/doc/src/installation.rst
+++ b/doc/src/installation.rst
@@ -61,16 +61,17 @@ Python requirements are installed automatically by pip, uv, conda or pacman.
 
    freeze-core >=0.6.1
    packaging >=25.0
-   setuptools >=78.1.1,<84.0
+   setuptools >=78.1.1,<85.0
    filelock >=3.20.3           #  Linux
-   patchelf >=0.14,<0.18       #  Linux
+   patchelf >=0.16.1           #  Linux
    dmgbuild >=1.6.1            #  macOS
-   lief >=0.16,<=1.0           #  Windows
+   lief >=0.16.0,<1.1.0        #  Windows
    python-msilib >=0.4.1       #  Python 3.13+ on Windows
 
 .. note::
 
-   #. If you have trouble with patchelf, check :ref:`patchelf`.
+   #. When using the system package manager, you can use "patchelf>=0.14".
+      If you have trouble with patchelf, check :ref:`patchelf`.
    #. ``lief`` in conda-forge is named ``py-lief``.
 
 Download the source code

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools~=83.0",
+    "setuptools~=84.0",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -30,19 +30,19 @@ classifiers = [
 dependencies = [
     "freeze-core>=0.6.1",
     "packaging>=25.0",
-    "setuptools>=78.1.1,<84.0",
+    "setuptools>=78.1.1,<85.0",
     # Linux
     "filelock>=3.20.3 ;sys_platform == 'linux'",
-    "patchelf>=0.16.1,<0.18 ;sys_platform == 'linux' and platform_machine == 'x86_64'",
-    "patchelf>=0.16.1,<0.18 ;sys_platform == 'linux' and platform_machine == 'i686'",
-    "patchelf>=0.16.1,<0.18 ;sys_platform == 'linux' and platform_machine == 'aarch64'",
-    "patchelf>=0.16.1,<0.18 ;sys_platform == 'linux' and platform_machine == 'armv7l'",
-    "patchelf>=0.16.1,<0.18 ;sys_platform == 'linux' and platform_machine == 'ppc64le'",
-    "patchelf>=0.16.1,<0.18 ;sys_platform == 'linux' and platform_machine == 's390x'",
+    "patchelf>=0.16.1 ;sys_platform == 'linux' and platform_machine == 'x86_64'",
+    "patchelf>=0.16.1 ;sys_platform == 'linux' and platform_machine == 'i686'",
+    "patchelf>=0.16.1 ;sys_platform == 'linux' and platform_machine == 'aarch64'",
+    "patchelf>=0.16.1 ;sys_platform == 'linux' and platform_machine == 'armv7l'",
+    "patchelf>=0.16.1 ;sys_platform == 'linux' and platform_machine == 'ppc64le'",
+    "patchelf>=0.16.1 ;sys_platform == 'linux' and platform_machine == 's390x'",
     # macOS
     "dmgbuild>=1.6.1 ;sys_platform == 'darwin'",
     # Windows
-    "lief>=0.16.0,<=1.0.0 ;sys_platform == 'win32'",
+    "lief>=0.16.0,<1.1.0 ;sys_platform == 'win32'",
     "python-msilib>=0.4.1 ;sys_platform == 'win32' and python_version >= '3.13'",
 ]
 keywords = ["cx-freeze cxfreeze cx_Freeze freeze python"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,13 @@
 freeze-core>=0.6.1
 packaging>=25.0
-setuptools>=78.1.1,<84.0
+setuptools>=78.1.1,<85.0
 filelock>=3.20.3 ;sys_platform == 'linux'
-patchelf>=0.16.1,<0.18 ;sys_platform == 'linux' and platform_machine == 'x86_64'
-patchelf>=0.16.1,<0.18 ;sys_platform == 'linux' and platform_machine == 'i686'
-patchelf>=0.16.1,<0.18 ;sys_platform == 'linux' and platform_machine == 'aarch64'
-patchelf>=0.16.1,<0.18 ;sys_platform == 'linux' and platform_machine == 'armv7l'
-patchelf>=0.16.1,<0.18 ;sys_platform == 'linux' and platform_machine == 'ppc64le'
-patchelf>=0.16.1,<0.18 ;sys_platform == 'linux' and platform_machine == 's390x'
+patchelf>=0.16.1 ;sys_platform == 'linux' and platform_machine == 'x86_64'
+patchelf>=0.16.1 ;sys_platform == 'linux' and platform_machine == 'i686'
+patchelf>=0.16.1 ;sys_platform == 'linux' and platform_machine == 'aarch64'
+patchelf>=0.16.1 ;sys_platform == 'linux' and platform_machine == 'armv7l'
+patchelf>=0.16.1 ;sys_platform == 'linux' and platform_machine == 'ppc64le'
+patchelf>=0.16.1 ;sys_platform == 'linux' and platform_machine == 's390x'
 dmgbuild>=1.6.1 ;sys_platform == 'darwin'
-lief>=0.16.0,<=1.0.0 ;sys_platform == 'win32'
+lief>=0.16.0,<1.1.0 ;sys_platform == 'win32'
 python-msilib>=0.4.1 ;sys_platform == 'win32' and python_version >= '3.13'


### PR DESCRIPTION
Build with setuptools 84.0.
Dependencies to run:
- setuptools >=78.1.1,<85.0
- patchelf >=0.16.1 on Linux, including new version 0.19.1.